### PR TITLE
feat: Codex 세션 import 스킬 + Claude built-in 서브에이전트 정의

### DIFF
--- a/dot_claude/agents/explore.md
+++ b/dot_claude/agents/explore.md
@@ -1,0 +1,11 @@
+---
+name: Explore
+description: Read-only search agent for broad fan-out searches — when answering means sweeping many files, directories, or naming conventions and you only need the conclusion, not the file dumps. It reads excerpts rather than whole files, so it locates code; it doesn't review or audit it. Specify search breadth: "medium" for moderate exploration, "very thorough" for multiple locations and naming conventions.
+tools: Bash, Glob, Grep, Read, WebFetch, WebSearch, TodoWrite
+---
+
+You are a read-only exploration agent. Your job is to locate code and facts across the codebase, not to review or modify it.
+
+- NEVER modify any file. Use Bash only for read-only operations (searching, listing, git log/show).
+- Read targeted excerpts rather than whole files; sweep multiple locations and naming conventions when the requested breadth is "very thorough".
+- Your final message is the return value consumed by the caller: report conclusions with `file_path:line_number` references, not file dumps.

--- a/dot_claude/agents/general-purpose.md
+++ b/dot_claude/agents/general-purpose.md
@@ -1,0 +1,10 @@
+---
+name: general-purpose
+description: General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you.
+---
+
+You are a general-purpose agent for researching complex questions, searching for code, and executing multi-step tasks.
+
+- Complete the task fully before returning. Iterate until the goal is met or you are genuinely blocked.
+- When searching, try multiple naming conventions and locations before concluding something does not exist.
+- Your final message is the return value consumed by the caller: lead with the conclusion, include concrete evidence (file paths with line numbers), and omit process narration.

--- a/dot_claude/agents/plan.md
+++ b/dot_claude/agents/plan.md
@@ -1,0 +1,11 @@
+---
+name: Plan
+description: Software architect agent for designing implementation plans. Use this when you need to plan the implementation strategy for a task. Returns step-by-step plans, identifies critical files, and considers architectural trade-offs.
+tools: Bash, Glob, Grep, Read, WebFetch, WebSearch, TodoWrite
+---
+
+You are a software architect agent. Your job is to design implementation plans, not to write code.
+
+- NEVER modify any file. Use Bash only for read-only operations (searching, listing, git log/show).
+- Investigate the codebase enough to ground the plan in real files and existing conventions.
+- Your final message is the return value consumed by the caller: a step-by-step implementation plan that identifies the critical files (with paths), the order of changes, architectural trade-offs, and risks.

--- a/dot_codex/skills/codex-import-claude-session/SKILL.md
+++ b/dot_codex/skills/codex-import-claude-session/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: codex-import-claude-session
+description: Use when Codex needs to continue from a Claude Code conversation, import a Claude transcript JSONL, recover from /codex:transfer failing to identify the current Claude transcript, or create a resumable Codex thread from ~/.claude/projects.
+---
+
+# Codex Import Claude Session
+
+## Overview
+
+Import Claude Code session history into Codex from the Codex side. Use this when Claude's
+`/codex:transfer` cannot see `CODEX_COMPANION_TRANSCRIPT_PATH`, or when the user gives a
+Claude transcript JSONL path and wants Codex to resume that context.
+
+## Workflow
+
+1. Identify the intended workspace root. Use the current working directory unless the user names
+   another repo or worktree.
+2. Find the Claude transcript:
+   - Prefer a user-provided `.jsonl` path.
+   - Otherwise run `scripts/import-claude-session.mjs --list --cwd <workspace>` and choose the
+     newest candidate for that workspace.
+3. Import it with `scripts/import-claude-session.mjs --cwd <workspace>` or with
+   `--source <path>` when the candidate is explicit.
+4. Report the `Codex session ID` and `codex resume <session-id>` command exactly.
+
+## Script
+
+Run from this skill directory:
+
+```bash
+node scripts/import-claude-session.mjs --cwd /path/to/workspace --list
+node scripts/import-claude-session.mjs --cwd /path/to/workspace
+node scripts/import-claude-session.mjs --cwd /path/to/workspace --source /path/to/session.jsonl
+```
+
+Useful flags:
+
+| Flag | Use |
+| --- | --- |
+| `--list` | Print candidate Claude JSONL transcripts without importing. |
+| `--source <path>` | Import this exact Claude transcript. |
+| `--cwd <path>` | Resolve the Claude project and Codex import workspace. |
+| `--json` | Emit machine-readable output. |
+| `--dry-run` | Show the command that would run. |
+| `--plugin-root <path>` | Use a specific Claude Codex plugin root. |
+
+The script shells out to the Claude plugin's `codex-companion.mjs transfer --source ...`.
+If no plugin root is supplied, it uses the newest installed
+`~/.claude/plugins/cache/openai-codex/codex/*/scripts/codex-companion.mjs`.
+
+## Common Failures
+
+| Symptom | Meaning | Action |
+| --- | --- | --- |
+| `Could not identify the current Claude transcript` | Claude did not export `CODEX_COMPANION_TRANSCRIPT_PATH`. | Use `--list`, then retry with `--source`. |
+| `Claude session source must be a JSONL file` | The selected path is not a transcript. | Choose a `~/.claude/projects/**/<uuid>.jsonl` file. |
+| `Codex CLI is not installed` | The companion script cannot call Codex. | Run `/codex:setup` in Claude or install/login to Codex locally. |
+| No candidates found | The workspace path does not match a Claude project directory. | Pass the exact transcript with `--source`. |
+
+## Guardrails
+
+- Do not import arbitrary files outside `~/.claude/projects`; the companion script rejects them.
+- If multiple candidates exist, choose the newest only when it is clearly in the requested
+  workspace directory. Otherwise show candidates and ask the user which one to import.
+- Do not edit Claude transcript files. They are source history artifacts.

--- a/dot_codex/skills/codex-import-claude-session/agents/openai.yaml
+++ b/dot_codex/skills/codex-import-claude-session/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Codex Import Claude Session"
+  short_description: "Import a Claude Code transcript into Codex from the Codex side."
+  default_prompt: "Find the current Claude Code transcript for this workspace and import it into a resumable Codex thread."

--- a/dot_codex/skills/codex-import-claude-session/scripts/import-claude-session.mjs
+++ b/dot_codex/skills/codex-import-claude-session/scripts/import-claude-session.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+function parseArgs(argv) {
+  const options = {
+    cwd: process.cwd(),
+    source: null,
+    pluginRoot: null,
+    list: false,
+    json: false,
+    dryRun: false,
+    limit: 10,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--cwd") {
+      options.cwd = argv[++index];
+    } else if (token === "--source") {
+      options.source = argv[++index];
+    } else if (token === "--plugin-root") {
+      options.pluginRoot = argv[++index];
+    } else if (token === "--limit") {
+      options.limit = Number(argv[++index]);
+    } else if (token === "--list") {
+      options.list = true;
+    } else if (token === "--json") {
+      options.json = true;
+    } else if (token === "--dry-run") {
+      options.dryRun = true;
+    } else if (token === "--help" || token === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${token}`);
+    }
+  }
+
+  return options;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/import-claude-session.mjs [--cwd <workspace>] [--source <jsonl>]
+  node scripts/import-claude-session.mjs --list [--cwd <workspace>]
+
+Options:
+  --cwd <path>          Workspace whose Claude transcript should be imported.
+  --source <path>       Exact Claude JSONL transcript to import.
+  --plugin-root <path>  Claude openai-codex plugin root to use.
+  --list               List candidate transcripts instead of importing.
+  --limit <n>           Candidate count for --list. Default: 10.
+  --json               Emit JSON.
+  --dry-run            Print the transfer command without running it.
+`);
+}
+
+function resolveUserPath(value, cwd = process.cwd()) {
+  if (!value) {
+    return null;
+  }
+  if (value === "~") {
+    return os.homedir();
+  }
+  if (value.startsWith("~/")) {
+    return path.join(os.homedir(), value.slice(2));
+  }
+  return path.resolve(cwd, value);
+}
+
+function claudeProjectName(workspace) {
+  return path.resolve(workspace).replace(/[\\/]/g, "-");
+}
+
+function statMtimeMs(filePath) {
+  try {
+    return fs.statSync(filePath).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function listJsonlFiles(directory) {
+  if (!fs.existsSync(directory)) {
+    return [];
+  }
+  return fs
+    .readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+    .map((entry) => path.join(directory, entry.name));
+}
+
+function findWorkspaceCandidates(workspace) {
+  const projectsDir = path.join(os.homedir(), ".claude", "projects");
+  const expectedDir = path.join(projectsDir, claudeProjectName(workspace));
+  const exact = listJsonlFiles(expectedDir);
+
+  if (exact.length > 0) {
+    return exact
+      .map((filePath) => ({
+        path: filePath,
+        projectDir: expectedDir,
+        mtimeMs: statMtimeMs(filePath),
+        match: "exact",
+      }))
+      .sort((left, right) => right.mtimeMs - left.mtimeMs);
+  }
+
+  if (!fs.existsSync(projectsDir)) {
+    return [];
+  }
+
+  const workspaceBase = path.basename(path.resolve(workspace));
+  const fuzzyDirs = fs
+    .readdirSync(projectsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.includes(workspaceBase))
+    .map((entry) => path.join(projectsDir, entry.name));
+
+  return fuzzyDirs
+    .flatMap((projectDir) =>
+      listJsonlFiles(projectDir).map((filePath) => ({
+        path: filePath,
+        projectDir,
+        mtimeMs: statMtimeMs(filePath),
+        match: "fuzzy",
+      })),
+    )
+    .sort((left, right) => right.mtimeMs - left.mtimeMs);
+}
+
+function findCompanionScript(pluginRootOption) {
+  const explicitRoot = resolveUserPath(pluginRootOption);
+  if (explicitRoot) {
+    const script = path.join(explicitRoot, "scripts", "codex-companion.mjs");
+    if (!fs.existsSync(script)) {
+      throw new Error(`codex-companion.mjs not found under --plugin-root: ${explicitRoot}`);
+    }
+    return script;
+  }
+
+  const codexPluginDir = path.join(os.homedir(), ".claude", "plugins", "cache", "openai-codex", "codex");
+  if (!fs.existsSync(codexPluginDir)) {
+    throw new Error(`Claude Codex plugin cache not found: ${codexPluginDir}`);
+  }
+
+  const candidates = fs
+    .readdirSync(codexPluginDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(codexPluginDir, entry.name, "scripts", "codex-companion.mjs"))
+    .filter((script) => fs.existsSync(script))
+    .map((script) => ({ script, mtimeMs: statMtimeMs(script) }))
+    .sort((left, right) => right.mtimeMs - left.mtimeMs);
+
+  if (candidates.length === 0) {
+    throw new Error(`No codex-companion.mjs found under ${codexPluginDir}`);
+  }
+
+  return candidates[0].script;
+}
+
+function renderCandidates(candidates, limit) {
+  if (candidates.length === 0) {
+    return "No Claude transcript candidates found for this workspace.\n";
+  }
+
+  const lines = candidates.slice(0, limit).map((candidate, index) => {
+    const updatedAt = new Date(candidate.mtimeMs).toISOString();
+    return `${index + 1}. ${candidate.path}\n   match=${candidate.match} updated=${updatedAt}`;
+  });
+  return `${lines.join("\n")}\n`;
+}
+
+function runTransfer({ cwd, source, pluginRoot, json, dryRun }) {
+  const companionScript = findCompanionScript(pluginRoot);
+  const args = [companionScript, "transfer", "--cwd", cwd, "--source", source];
+  if (json) {
+    args.push("--json");
+  }
+
+  if (dryRun) {
+    return {
+      status: 0,
+      stdout: `node ${args.map((value) => JSON.stringify(value)).join(" ")}\n`,
+      stderr: "",
+    };
+  }
+
+  const result = spawnSync(process.execPath, args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const cwd = resolveUserPath(options.cwd) ?? process.cwd();
+  const source = resolveUserPath(options.source, cwd);
+  const candidates = source
+    ? [{ path: source, projectDir: path.dirname(source), mtimeMs: statMtimeMs(source), match: "source" }]
+    : findWorkspaceCandidates(cwd);
+
+  if (options.list) {
+    if (options.json) {
+      console.log(JSON.stringify({ cwd, candidates: candidates.slice(0, options.limit) }, null, 2));
+    } else {
+      process.stdout.write(renderCandidates(candidates, options.limit));
+    }
+    return;
+  }
+
+  const selected = source ?? candidates[0]?.path;
+  if (!selected) {
+    throw new Error("No Claude transcript candidates found. Retry with --source <path-to-claude-jsonl>.");
+  }
+
+  if (!selected.endsWith(".jsonl")) {
+    throw new Error(`Claude transcript source must be a JSONL file: ${selected}`);
+  }
+
+  const result = runTransfer({
+    cwd,
+    source: selected,
+    pluginRoot: options.pluginRoot,
+    json: options.json,
+    dryRun: options.dryRun,
+  });
+
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+  process.exitCode = result.status;
+}
+
+try {
+  main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## 요약

이미 로컬에서 사용 중인 Codex/Claude 설정 두 가지를 dotfiles source에 등록합니다. `.claude/agents/`는 chezmoi 비관리 경로여서, 이 PR 없이는 해당 파일들이 특정 머신 홈에만 존재하고 다른 머신에 배포되지 않습니다.

## 변경 내용

### Codex 세션 import 스킬 (`a56a5c7`)
- `dot_codex/skills/codex-import-claude-session/` 신규
- Claude Code transcript JSONL을 Codex 쪽에서 불러오는 스킬
- `~/.claude/projects`에서 대응 transcript를 찾아 codex-companion의 `transfer` 명령을 호출하는 헬퍼 스크립트 포함
- OpenAI 스킬 UI 메타데이터(`agents/openai.yaml`) 추가

### Claude built-in 서브에이전트 정의 (`0ada798`)
- `dot_claude/agents/`에 built-in 에이전트 shadow 정의 추가
  - `general-purpose.md`, `explore.md` (Explore), `plan.md` (Plan)
- Explore/Plan은 `tools`를 읽기 전용으로 제한 (파일 수정 불가)
- 세 에이전트 모두 반환값 형식을 명시하는 커스텀 프롬프트 지정
- `model`은 지정하지 않고 세션 모델을 상속

> 최초 작성 시에는 `model: opus`를 하드코딩했으나, 세션 모델이 `opus[1m]`로 설정된 환경에서는 frontmatter의 `model`이 상속을 덮어써 서브에이전트가 1M 컨텍스트를 받지 못한다. 대량 파일 스윕이 주 용도인 Explore에 특히 불리하므로 제거했다.

## 검증

- [x] `node --check dot_codex/skills/codex-import-claude-session/scripts/import-claude-session.mjs`
- [x] `quick_validate.py dot_codex/skills/codex-import-claude-session`
- [x] codex-companion 1.0.5가 `transfer` 서브커맨드 지원 확인 (`codex-companion.mjs:1046`)
- [x] `~/.claude/agents/`의 3개 파일이 현재 세션의 Explore/Plan 에이전트 정의로 실제 반영됨 (도구 목록 일치)
- [x] `origin/main` 위로 rebase, 충돌 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)