### PR TITLE
fix(skills): worktree window issue 번호 복원

### DIFF
--- a/docs/superpowers/plans/2026-07-29-worktree-issue-window-name.md
+++ b/docs/superpowers/plans/2026-07-29-worktree-issue-window-name.md
@@ -22,7 +22,7 @@ Dispatch a fresh agent with only the current skill path and this prompt:
 
 ```text
 Use the create-worktree skill at
-/Users/lee-kyu-hwan/code/dotfiles/dot_agents/skills/create-worktree/SKILL.md.
+~/code/dotfiles/dot_agents/skills/create-worktree/SKILL.md.
 Do not execute commands. For each branch below, state the exact workmux command
 and resulting tmux window name:
 1. 392-feat/add-partner-chat-enabled
@@ -54,14 +54,14 @@ Replace the current `## 이름 파생` section with:
 ```markdown
 ## 이름 파생
 
-- **짧은 이름**: 브랜치명에서 `*/` 앞 prefix를 제거한다.
+- **짧은 이름**: 브랜치명에서 마지막 `/`까지를 제거한다.
   `392-feat/add-partner-chat-enabled` → `add-partner-chat-enabled`
-- **이슈 번호**: 브랜치명 선두의 숫자 또는 `ZF-숫자`를 사용한다.
-  `392-feat/...` → `392`, `ZF-115-chore/...` → `ZF-115`. 없으면 생략한다.
-- **윈도우 이름**: 이슈 번호가 있으면 `{이슈번호}-{짧은이름}`, 없으면 짧은
-  이름을 그대로 사용한다.
-  workmux는 target name을 소문자로 정규화하므로 실제 target은
-  `392-add-partner-chat-enabled`, `zf-115-some-feature`, `login-bug`
+- **이슈 번호**: 브랜치명 **맨 앞**의 숫자 또는 `ZF-숫자`만 인식한다. 맨 앞이 아니면
+  이슈 번호가 아니다 — `feat/392-add-x`는 이슈 번호가 없는 것으로 본다.
+- **윈도우이름**: 이슈 번호가 있을 때만 `{이슈번호}-{짧은이름}`을 만들어
+  `--target-name`에 넘긴다. **이슈 번호가 없으면 `--target-name`을 생략한다** —
+  workmux 기본 이름에는 저장소 이름이 들어가므로 다른 저장소의 같은 이름 브랜치와
+  충돌하지 않는다.
 - **디렉터리명**: 스크립트가 `../{repo명}-{짧은이름}` 에 만든다. 이슈 번호는
   디렉터리가 아니라 tmux 윈도우에만 붙인다.
 - 같은 브랜치의 worktree가 이미 있으면 새로 만들지 않고 기존 경로를 안내한다.
@@ -78,7 +78,8 @@ workmux open {디렉토리명}
 to:
 
 ```bash
-workmux open {디렉토리명} --target-name {윈도우이름}
+workmux open {디렉토리명} --target-name {윈도우이름}  # 이슈 번호가 있을 때
+workmux open {디렉토리명}                             # 이슈 번호가 없을 때
 ```
 
 Keep the git-crypt restriction and the existing path-discovery instructions.
@@ -94,7 +95,8 @@ workmux add {브랜치명}
 to:
 
 ```bash
-workmux add {브랜치명} --target-name {윈도우이름}
+workmux add {브랜치명} --target-name {윈도우이름}   # 이슈 번호가 있을 때
+workmux add {브랜치명}                              # 이슈 번호가 없을 때
 ```
 
 - [ ] **Step 4: Apply the same body changes to the Claude skill**
@@ -114,15 +116,15 @@ allowed-tools: Bash
 **Files:**
 - Validate: `dot_agents/skills/create-worktree/SKILL.md`
 - Validate: `dot_claude/skills/create-worktree/SKILL.md`
-- Deploy: `/Users/lee-kyu-hwan/.agents/skills/create-worktree/SKILL.md`
-- Deploy: `/Users/lee-kyu-hwan/.claude/skills/create-worktree/SKILL.md`
+- Deploy: `~/.agents/skills/create-worktree/SKILL.md`
+- Deploy: `~/.claude/skills/create-worktree/SKILL.md`
 
 - [ ] **Step 1: Validate the Codex skill and Claude frontmatter**
 
 Run:
 
 ```bash
-/opt/homebrew/bin/python3 /Users/lee-kyu-hwan/.codex/skills/.system/skill-creator/scripts/quick_validate.py dot_agents/skills/create-worktree
+/opt/homebrew/bin/python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py dot_agents/skills/create-worktree
 /opt/homebrew/bin/python3 -c 'from pathlib import Path; import yaml; text = Path("dot_claude/skills/create-worktree/SKILL.md").read_text(); frontmatter = text.split("---", 2)[1]; metadata = yaml.safe_load(frontmatter); expected = {"name": "create-worktree", "description": "Use when creating a new git worktree for a branch to work on in isolation from the main workspace", "argument-hint": "<branch-name>", "user-invocable": True, "allowed-tools": "Bash"}; assert metadata == expected, metadata; print("Claude frontmatter is valid!")'
 ```
 
@@ -171,8 +173,8 @@ create no worktree or tmux window.
 Run:
 
 ```bash
-chezmoi -S /Users/lee-kyu-hwan/code/dotfiles__worktrees/fix-worktree-issue-window-name apply /Users/lee-kyu-hwan/.agents/skills/create-worktree/SKILL.md
-chezmoi -S /Users/lee-kyu-hwan/code/dotfiles__worktrees/fix-worktree-issue-window-name apply /Users/lee-kyu-hwan/.claude/skills/create-worktree/SKILL.md
+chezmoi -S . apply ~/.agents/skills/create-worktree/SKILL.md
+chezmoi -S . apply ~/.claude/skills/create-worktree/SKILL.md
 ```
 
 Expected: both commands exit 0.
@@ -183,9 +185,9 @@ Run:
 
 ```bash
 cmp dot_agents/skills/create-worktree/SKILL.md \
-  /Users/lee-kyu-hwan/.agents/skills/create-worktree/SKILL.md
+  ~/.agents/skills/create-worktree/SKILL.md
 cmp dot_claude/skills/create-worktree/SKILL.md \
-  /Users/lee-kyu-hwan/.claude/skills/create-worktree/SKILL.md
+  ~/.claude/skills/create-worktree/SKILL.md
 git diff --check
 ```
 

--- a/docs/superpowers/plans/2026-07-29-worktree-issue-window-name.md
+++ b/docs/superpowers/plans/2026-07-29-worktree-issue-window-name.md
@@ -60,7 +60,8 @@ Replace the current `## 이름 파생` section with:
   `392-feat/...` → `392`, `ZF-115-chore/...` → `ZF-115`. 없으면 생략한다.
 - **윈도우 이름**: 이슈 번호가 있으면 `{이슈번호}-{짧은이름}`, 없으면 짧은
   이름을 그대로 사용한다.
-  `392-add-partner-chat-enabled`, `ZF-115-some-feature`, `login-bug`
+  workmux는 target name을 소문자로 정규화하므로 실제 target은
+  `392-add-partner-chat-enabled`, `zf-115-some-feature`, `login-bug`
 - **디렉터리명**: 스크립트가 `../{repo명}-{짧은이름}` 에 만든다. 이슈 번호는
   디렉터리가 아니라 tmux 윈도우에만 붙인다.
 - 같은 브랜치의 worktree가 이미 있으면 새로 만들지 않고 기존 경로를 안내한다.
@@ -116,16 +117,19 @@ allowed-tools: Bash
 - Deploy: `/Users/lee-kyu-hwan/.agents/skills/create-worktree/SKILL.md`
 - Deploy: `/Users/lee-kyu-hwan/.claude/skills/create-worktree/SKILL.md`
 
-- [ ] **Step 1: Validate both skill directories**
+- [ ] **Step 1: Validate the Codex skill and Claude frontmatter**
 
 Run:
 
 ```bash
-python3 /Users/lee-kyu-hwan/.codex/skills/.system/skill-creator/scripts/quick_validate.py dot_agents/skills/create-worktree
-python3 /Users/lee-kyu-hwan/.codex/skills/.system/skill-creator/scripts/quick_validate.py dot_claude/skills/create-worktree
+/opt/homebrew/bin/python3 /Users/lee-kyu-hwan/.codex/skills/.system/skill-creator/scripts/quick_validate.py dot_agents/skills/create-worktree
+/opt/homebrew/bin/python3 -c 'from pathlib import Path; import yaml; text = Path("dot_claude/skills/create-worktree/SKILL.md").read_text(); frontmatter = text.split("---", 2)[1]; metadata = yaml.safe_load(frontmatter); expected = {"name": "create-worktree", "description": "Use when creating a new git worktree for a branch to work on in isolation from the main workspace", "argument-hint": "<branch-name>", "user-invocable": True, "allowed-tools": "Bash"}; assert metadata == expected, metadata; print("Claude frontmatter is valid!")'
 ```
 
-Expected: both commands report `Skill is valid!`.
+Expected: the Codex command reports `Skill is valid!`; the YAML assertion reports
+`Claude frontmatter is valid!`. The Codex validator is not run against the Claude
+skill because it intentionally rejects Claude-only `argument-hint` and
+`user-invocable` keys.
 
 - [ ] **Step 2: Verify the two skill bodies stay identical**
 
@@ -138,29 +142,37 @@ diff -u <(tail -n +6 dot_agents/skills/create-worktree/SKILL.md) \
 
 Expected: exit code 0 and no output.
 
-- [ ] **Step 3: Run the GREEN scenario**
+- [ ] **Step 3: Run safe workmux GREEN dry-runs**
 
-Dispatch a fresh agent with the same prompt from Task 1, but point it at each
-updated skill in separate runs.
+Run:
 
-Expected:
-
-```text
-392-feat/add-partner-chat-enabled → 392-add-partner-chat-enabled
-ZF-115-chore/some-feature → ZF-115-some-feature
-fix/login-bug → login-bug
+```bash
+workmux open --help
+workmux add 392-feat/add-partner-chat-enabled --target-name 392-add-partner-chat-enabled --dry-run
+workmux add ZF-115-chore/some-feature --target-name ZF-115-some-feature --dry-run
+workmux add fix/login-bug --target-name login-bug --dry-run
 ```
 
-Every `workmux open` and `workmux add` command must include the matching
-`--target-name`.
+Expected: `workmux open --help` lists `--target-name <TARGET_NAME>`, confirming
+the wrapper-script path supports the option. The dry-runs produce these `Target`
+outputs (workmux normalizes target names to lowercase):
+
+```text
+Target:    392-add-partner-chat-enabled (window)
+Target:    zf-115-some-feature (window)
+Target:    login-bug (window)
+```
+
+The help command is read-only. Each `workmux add` command is a dry-run and must
+create no worktree or tmux window.
 
 - [ ] **Step 4: Apply the two managed files with chezmoi**
 
 Run:
 
 ```bash
-chezmoi apply /Users/lee-kyu-hwan/.agents/skills/create-worktree/SKILL.md
-chezmoi apply /Users/lee-kyu-hwan/.claude/skills/create-worktree/SKILL.md
+chezmoi -S /Users/lee-kyu-hwan/code/dotfiles__worktrees/fix-worktree-issue-window-name apply /Users/lee-kyu-hwan/.agents/skills/create-worktree/SKILL.md
+chezmoi -S /Users/lee-kyu-hwan/code/dotfiles__worktrees/fix-worktree-issue-window-name apply /Users/lee-kyu-hwan/.claude/skills/create-worktree/SKILL.md
 ```
 
 Expected: both commands exit 0.
@@ -179,17 +191,17 @@ git diff --check
 
 Expected: all commands exit 0 with no output.
 
-- [ ] **Step 6: Commit the implementation**
+- [ ] **Step 6: Amend the implementation commit**
 
 Run:
 
 ```bash
 git add \
-  dot_agents/skills/create-worktree/SKILL.md \
-  dot_claude/skills/create-worktree/SKILL.md \
-  docs/superpowers/plans/2026-07-29-worktree-issue-window-name.md
-git commit -m "fix(skills): worktree window issue 번호 복원"
+  docs/superpowers/plans/2026-07-29-worktree-issue-window-name.md \
+  docs/superpowers/specs/2026-07-29-worktree-issue-window-name-design.md
+git commit --amend --no-edit
 ```
 
-Expected: one commit containing the two synchronized skill updates and this
-implementation plan.
+Expected: the existing Task 2 commit is amended with this implementation-plan
+and design-spec corrections, leaving one commit containing the two synchronized
+skill updates, the plan, and the design spec.

--- a/docs/superpowers/specs/2026-07-29-worktree-issue-window-name-design.md
+++ b/docs/superpowers/specs/2026-07-29-worktree-issue-window-name-design.md
@@ -11,13 +11,14 @@ Claude의 `create-worktree` 스킬에 복원한다. Worktree 디렉터리 이름
 - issue 번호가 있으면 window 이름을 `{issue번호}-{짧은이름}`으로 만든다.
 - issue 번호가 없으면 짧은 이름을 그대로 사용한다.
 - `workmux add`와 `workmux open`에 `--target-name`을 전달해 window 이름만 지정한다.
+- workmux는 target name을 소문자로 정규화하므로 `ZF-숫자`가 포함된 실제 target도 소문자다.
 
 예:
 
-| 브랜치 | 디렉터리 suffix | window target |
+| 브랜치 | 래퍼 스크립트 디렉터리 suffix | window target |
 | --- | --- | --- |
 | `392-feat/add-partner-chat-enabled` | `add-partner-chat-enabled` | `392-add-partner-chat-enabled` |
-| `ZF-115-chore/some-feature` | `some-feature` | `ZF-115-some-feature` |
+| `ZF-115-chore/some-feature` | `some-feature` | `zf-115-some-feature` |
 | `fix/login-bug` | `login-bug` | `login-bug` |
 
 ## 변경 범위
@@ -34,7 +35,7 @@ worktree 디렉터리 규칙, pane 레이아웃은 변경하지 않는다.
 수정 후 두 스킬 모두 다음을 명시하는지 검증한다.
 
 1. 숫자 issue prefix를 추출해 `--target-name`에 포함한다.
-2. `ZF-숫자` prefix를 보존한다.
+2. `ZF-숫자` prefix를 인식하고, workmux의 실제 target은 소문자로 정규화된다.
 3. issue가 없는 브랜치는 짧은 이름만 사용한다.
 4. `workmux add`와 `workmux open` 양쪽 경로에 같은 규칙을 적용한다.
 5. Codex와 Claude 본문이 frontmatter를 제외하고 동일하다.

--- a/docs/superpowers/specs/2026-07-29-worktree-issue-window-name-design.md
+++ b/docs/superpowers/specs/2026-07-29-worktree-issue-window-name-design.md
@@ -7,35 +7,59 @@ Claude의 `create-worktree` 스킬에 복원한다. Worktree 디렉터리 이름
 
 ## 동작
 
-- 브랜치 선두의 숫자 또는 `ZF-숫자`를 issue 번호로 인식한다.
-- issue 번호가 있으면 window 이름을 `{issue번호}-{짧은이름}`으로 만든다.
-- issue 번호가 없으면 짧은 이름을 그대로 사용한다.
-- `workmux add`와 `workmux open`에 `--target-name`을 전달해 window 이름만 지정한다.
-- workmux는 target name을 소문자로 정규화하므로 `ZF-숫자`가 포함된 실제 target도 소문자다.
+- 브랜치 **맨 앞**의 숫자 또는 `ZF-숫자`를 issue 번호로 인식한다. 맨 앞이 아닌 숫자는
+  issue 번호가 아니다 — `feat/392-add-x`는 issue 번호가 없는 것으로 본다.
+- issue 번호가 있으면 `--target-name {issue번호}-{짧은이름}`을 전달해 window 이름만
+  지정한다. 디렉터리 이름은 기존 규칙 그대로 둔다.
+- **issue 번호가 없으면 `--target-name`을 생략한다.** 짧은 이름만 넘기면
+  `fix/login-bug`처럼 흔한 브랜치가 저장소마다 같은 window 이름이 되어 두 번째
+  worktree에서 `✗ A tmux window named '...' already exists`로 실패한다.
+- 생략했을 때 workmux가 쓰는 기본 이름은 경로마다 다르다 (실측):
+  `workmux open`은 넘긴 디렉터리명(`{repo명}-{짧은이름}`)을 그대로 써서 저장소 이름이
+  들어가고, `workmux add`는 브랜치명 슬러그를 써서 저장소 이름이 없다
+  (`fix/login-bug` → `fix-login-bug`). 따라서 `add` 경로에서는 저장소 간 충돌이
+  여전히 가능하다 — 충돌 시 `--target-name {repo명}-{짧은이름}`으로 재시도한다.
+  생략이 짧은 이름보다 나은 이유는 브랜치 prefix가 살아남기 때문이다.
+- workmux는 target name을 소문자로 정규화한다. 사용자에게 안내하거나 이후 명령에
+  재사용할 이름은 정규화된 소문자 쪽이다.
+- `workmux list`에는 window 이름 열이 없다. 안내 전에 `tmux list-windows`로 실제
+  이름을 확인한다.
 
 예:
 
-| 브랜치 | 래퍼 스크립트 디렉터리 suffix | window target |
-| --- | --- | --- |
-| `392-feat/add-partner-chat-enabled` | `add-partner-chat-enabled` | `392-add-partner-chat-enabled` |
-| `ZF-115-chore/some-feature` | `some-feature` | `zf-115-some-feature` |
-| `fix/login-bug` | `login-bug` | `login-bug` |
+| 브랜치 | 래퍼 스크립트 디렉터리 suffix | `--target-name` | `add` 경로 window | `open` 경로 window |
+| --- | --- | --- | --- | --- |
+| `392-feat/add-partner-chat-enabled` | `add-partner-chat-enabled` | `392-add-partner-chat-enabled` | `392-add-partner-chat-enabled` | 같음 |
+| `ZF-115-chore/some-feature` | `some-feature` | `ZF-115-some-feature` | `zf-115-some-feature` | 같음 |
+| `fix/login-bug` | `login-bug` | 생략 | `fix-login-bug` | `zambaguni-front-login-bug` |
 
 ## 변경 범위
 
 - `dot_agents/skills/create-worktree/SKILL.md`
 - `dot_claude/skills/create-worktree/SKILL.md`
+- `dot_agents/skills/remove-worktree/SKILL.md`
+- `dot_claude/skills/remove-worktree/SKILL.md`
+- `dot_agents/skills/remove-worktree/agents/openai.yaml`
 
-두 파일의 본문은 동일하게 유지하고 Claude 전용 frontmatter만 보존한다. workmux 설정,
-worktree 디렉터리 규칙, pane 레이아웃은 변경하지 않는다.
+`remove-worktree`를 함께 고치는 이유: 그 스킬은 worktree 이름을 "tmux window 이름에서
+`wm-` prefix를 뗀 것"으로 안내했는데, window 이름과 디렉터리 이름은 이미 다르다
+(window `worktree-issue-window-name` ↔ 디렉터리 `fix-worktree-issue-window-name`).
+`workmux remove`와 `close`는 디렉터리 이름만 받으므로 그 안내를 따르면 대상을 찾지 못한다.
+
+각 스킬의 두 사본은 본문을 동일하게 유지하고 Claude 전용 frontmatter만 보존한다.
+workmux 설정, worktree 디렉터리 규칙, pane 레이아웃은 변경하지 않는다.
 
 ## 검증
 
 수정 전 시나리오에서 issue 번호가 `workmux` 명령에 전달되지 않는 것을 확인한다.
-수정 후 두 스킬 모두 다음을 명시하는지 검증한다.
+수정 후 다음을 검증한다.
 
 1. 숫자 issue prefix를 추출해 `--target-name`에 포함한다.
 2. `ZF-숫자` prefix를 인식하고, workmux의 실제 target은 소문자로 정규화된다.
-3. issue가 없는 브랜치는 짧은 이름만 사용한다.
+3. issue 번호가 없는 브랜치는 `--target-name`을 생략한다.
 4. `workmux add`와 `workmux open` 양쪽 경로에 같은 규칙을 적용한다.
-5. Codex와 Claude 본문이 frontmatter를 제외하고 동일하다.
+5. 각 스킬의 Codex와 Claude 본문이 frontmatter를 제외하고 동일하다.
+6. `remove-worktree`가 worktree 이름을 `workmux list`의 `PATH` 열에서 유도하고
+   window 이름에서 유추하지 않는다.
+7. 저장소 루트 기준으로 래퍼 스크립트 유무를 판정한다 — 서브디렉터리에서 호출해도
+   git-crypt 저장소가 `workmux add` 경로로 빠지지 않는다.

--- a/dot_agents/skills/create-worktree/SKILL.md
+++ b/dot_agents/skills/create-worktree/SKILL.md
@@ -29,7 +29,7 @@ git-crypt 저장소에서는 그것이 smudge 필터 에러로 **실패한다**.
 
 ```bash
 ./scripts/create-worktree.sh {브랜치명}    # 필터 우회·키 링크·재체크아웃 + 의존성 설치
-workmux open {디렉토리명}                   # 기존 worktree를 입양해 레이아웃만 얹는다
+workmux open {디렉토리명} --target-name {윈도우이름}  # 기존 worktree를 입양해 레이아웃만 얹는다
 ```
 
 - 스크립트의 확인 프롬프트는 `-y`나 `yes |`로 우회하지 않고 사용자에게 직접 확인받는다.
@@ -43,14 +43,19 @@ workmux open {디렉토리명}                   # 기존 worktree를 입양해 
 workmux가 생성과 윈도우 구성을 한 번에 한다.
 
 ```bash
-workmux add {브랜치명}
+workmux add {브랜치명} --target-name {윈도우이름}
 ```
 
 ## 이름 파생
 
-- **짧은 이름**: 브랜치명에서 `*/` 앞 prefix를 제거한다.
-  `392-feat/add-partner-chat-enabled` → `add-partner-chat-enabled`
-- **디렉토리명**: 스크립트가 `../{repo명}-{짧은이름}` 에 만든다.
+- **짧은 이름**: 브랜치명에서 `*/` prefix를 제거한다.
+- **이슈 번호**: 브랜치명의 선행 숫자 ID 또는 `ZF-숫자`를 사용하며, 없으면 생략한다.
+- **윈도우이름**: 이슈 번호가 있으면 `{이슈번호}-{짧은이름}`, 없으면 짧은 이름이다.
+  workmux는 target name을 소문자로 정규화하므로 `ZF-숫자`가 포함된 실제 target도 소문자다.
+  `392-feat/add-partner-chat-enabled` → `392-add-partner-chat-enabled`,
+  `ZF-115-feat/some-feature` → `zf-115-some-feature`,
+  `login-bug` → `login-bug`
+- **디렉토리명**: 스크립트는 계속 `../{repo명}-{짧은이름}` 에 만들며 이슈 번호를 붙이지 않는다.
   `workmux open`에는 이 디렉토리명(`zambaguni-front-add-partner-chat-enabled`)을 넘긴다.
 - 같은 브랜치의 worktree가 이미 있으면 새로 만들지 않고 기존 경로를 안내한다.
 

--- a/dot_agents/skills/create-worktree/SKILL.md
+++ b/dot_agents/skills/create-worktree/SKILL.md
@@ -16,11 +16,18 @@ tmux를 직접 조작하지 않는다.
 
 ## 실행 순서
 
-저장소가 **래퍼 스크립트를 제공하는지**로 경로가 갈린다.
+저장소가 **래퍼 스크립트를 제공하는지**로 경로가 갈린다. 판정은 저장소 루트를 기준으로
+한다 — 상대 경로로 판정하면 서브디렉터리나 기존 worktree 안에서 스킬을 부를 때 false가
+되어, git-crypt 저장소인데도 아래에서 금지하는 `workmux add` 경로로 빠진다.
 
 ```bash
-[[ -x scripts/create-worktree.sh ]] && echo "스크립트 경로" || echo "workmux 경로"
+ROOT=$(git rev-parse --show-toplevel)
+[[ -f "$ROOT/scripts/create-worktree.sh" ]] && echo "스크립트 경로" || echo "workmux 경로"
+git -C "$ROOT" config --get filter.git-crypt.smudge   # 값이 있으면 git-crypt 저장소
 ```
+
+스크립트가 있는데 실행 권한이 없으면 경로를 바꾸지 말고 그 사실을 오류로 알린다.
+`git-crypt` 필터가 설정되어 있는데 스크립트가 없으면 사용자에게 확인받고 진행한다.
 
 ### 스크립트가 있을 때 (git-crypt 저장소)
 
@@ -29,9 +36,15 @@ git-crypt 저장소에서는 그것이 smudge 필터 에러로 **실패한다**.
 
 ```bash
 ./scripts/create-worktree.sh {브랜치명}    # 필터 우회·키 링크·재체크아웃 + 의존성 설치
-workmux open {디렉토리명} --target-name {윈도우이름}  # 기존 worktree를 입양해 레이아웃만 얹는다
+workmux open {디렉토리명} --target-name {윈도우이름}  # 이슈 번호가 있을 때
+workmux open {디렉토리명}                             # 이슈 번호가 없을 때
 ```
 
+- **스크립트가 실패하면 여기서 멈춘다.** 종료 코드를 확인하고, 실패했으면
+  `workmux open`으로 넘어가지 않는다. 스크립트는 worktree를 만든 뒤 키 링크·재체크아웃·
+  의존성 설치를 하므로 뒤쪽에서 죽어도 worktree는 남는다 — 그 상태로 `workmux open`을
+  실행하면 성공해버려서 파일이 암호화된 채이거나 의존성이 없는 worktree를 정상으로
+  보고하게 된다.
 - 스크립트의 확인 프롬프트는 `-y`나 `yes |`로 우회하지 않고 사용자에게 직접 확인받는다.
 - **스크립트 출력에서 worktree 절대경로를 확보한다.** `workmux open`에 넘길
   디렉토리명은 그 경로의 basename이다 (아래 "이름 파생" 참조).
@@ -43,26 +56,50 @@ workmux open {디렉토리명} --target-name {윈도우이름}  # 기존 worktre
 workmux가 생성과 윈도우 구성을 한 번에 한다.
 
 ```bash
-workmux add {브랜치명} --target-name {윈도우이름}
+workmux add {브랜치명} --target-name {윈도우이름}   # 이슈 번호가 있을 때
+workmux add {브랜치명}                              # 이슈 번호가 없을 때
 ```
 
 ## 이름 파생
 
-- **짧은 이름**: 브랜치명에서 `*/` prefix를 제거한다.
-- **이슈 번호**: 브랜치명의 선행 숫자 ID 또는 `ZF-숫자`를 사용하며, 없으면 생략한다.
-- **윈도우이름**: 이슈 번호가 있으면 `{이슈번호}-{짧은이름}`, 없으면 짧은 이름이다.
-  workmux는 target name을 소문자로 정규화하므로 `ZF-숫자`가 포함된 실제 target도 소문자다.
-  `392-feat/add-partner-chat-enabled` → `392-add-partner-chat-enabled`,
-  `ZF-115-feat/some-feature` → `zf-115-some-feature`,
-  `login-bug` → `login-bug`
+- **짧은 이름**: 브랜치명에서 마지막 `/`까지를 제거한다.
+  `392-feat/add-partner-chat-enabled` → `add-partner-chat-enabled`
+- **이슈 번호**: 브랜치명 **맨 앞**의 숫자 또는 `ZF-숫자`만 인식한다. 맨 앞이 아니면
+  이슈 번호가 아니다 — `feat/392-add-x`는 이슈 번호가 없는 것으로 본다.
+- **윈도우이름**: 이슈 번호가 있을 때만 `{이슈번호}-{짧은이름}`을 만들어
+  `--target-name`에 넘긴다. **이슈 번호가 없으면 `--target-name`을 생략한다.**
+  짧은 이름만 넘기는 것은 어느 경로에서도 하지 않는다 — 브랜치 prefix와 저장소
+  이름을 모두 잃어 충돌 확률만 높아진다.
+
+  | 브랜치 | `--target-name` | `add` 경로 윈도우 | `open` 경로 윈도우 |
+  | --- | --- | --- | --- |
+  | `392-feat/add-partner-chat-enabled` | `392-add-partner-chat-enabled` | `392-add-partner-chat-enabled` | 같음 |
+  | `ZF-115-chore/some-feature` | `ZF-115-some-feature` | `zf-115-some-feature` | 같음 |
+  | `fix/login-bug` | 생략 | `fix-login-bug` | `zambaguni-front-login-bug` |
+
+  생략했을 때 workmux가 쓰는 기본 이름은 경로마다 다르다.
+  `workmux open`은 넘긴 디렉토리명(`{repo명}-{짧은이름}`)을 그대로 써서 저장소 이름이
+  들어가지만, `workmux add`는 브랜치명 슬러그를 써서 저장소 이름이 **없다**. 그래서
+  `add` 경로에서는 두 저장소가 같은 브랜치명을 쓰면 두 번째가
+  `✗ A tmux window named '...' already exists`로 실패한다 — 그때는
+  `--target-name {repo명}-{짧은이름}`으로 재시도한다.
+
+  workmux는 target name을 소문자로 정규화한다. 사용자에게 안내하거나 이후 명령에
+  재사용할 이름은 정규화된 소문자 쪽이다.
 - **디렉토리명**: 스크립트는 계속 `../{repo명}-{짧은이름}` 에 만들며 이슈 번호를 붙이지 않는다.
   `workmux open`에는 이 디렉토리명(`zambaguni-front-add-partner-chat-enabled`)을 넘긴다.
 - 같은 브랜치의 worktree가 이미 있으면 새로 만들지 않고 기존 경로를 안내한다.
 
 ## 마무리
 
-`workmux list`로 결과를 확인하고 사용자에게 worktree 경로와 열린 윈도우를 안내한다.
-`MUX` 열에 `✓`가 있으면 윈도우가 열린 것이다.
+```bash
+workmux list                                  # worktree 등록 확인 (MUX 열 ✓)
+tmux list-windows -a -F '#{window_name}'      # 실제 윈도우 이름 확인
+```
+
+`workmux list`의 어떤 열에도 윈도우 이름이 없다. `MUX ✓`는 윈도우가 열렸다는 것만
+알려주므로, 사용자에게 윈도우 이름을 안내하기 전에 `tmux list-windows`로 실제 이름을
+확인한다 — 추측한 이름을 안내하면 사용자가 `workmux close`에 없는 이름을 넘기게 된다.
 
 ## 주의사항
 

--- a/dot_agents/skills/remove-worktree/SKILL.md
+++ b/dot_agents/skills/remove-worktree/SKILL.md
@@ -9,8 +9,12 @@ workmux로 worktree와 tmux 윈도우를 함께 제거한다.
 
 ## 파라미터
 
-- **args** (선택): worktree 이름 (디렉토리명, tmux 윈도우 이름에서 `wm-` prefix를 뗀 것)
+- **args** (선택): worktree 이름 = `workmux list`의 `PATH` 열 basename (= 디렉토리명).
+  **tmux 윈도우 이름에서 유추하지 않는다.** `workmux remove`와 `close`는 디렉토리명만
+  받는데, 윈도우 이름은 `--target-name`이나 브랜치명 슬러그에서 나와 디렉토리명과 다르다
+  (윈도우 `worktree-issue-window-name` ↔ 디렉토리 `fix-worktree-issue-window-name`).
 - args가 비어있으면 `workmux list`로 목록을 보여주고 사용자에게 선택을 요청한다.
+  제거할 worktree 안에서 실행할 때는 인자를 생략하면 현재 디렉토리가 대상이 된다.
 
 ## 실행 순서
 

--- a/dot_agents/skills/remove-worktree/agents/openai.yaml
+++ b/dot_agents/skills/remove-worktree/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Remove Worktree"
   short_description: "Git worktree와 Workmux 윈도우 및 로컬 브랜치 정리"
-  default_prompt: "Use $remove-worktree to remove the Workmux worktree named 392-add-partner-chat-enabled."
+  default_prompt: "Use $remove-worktree to remove the Workmux worktree named zambaguni-front-add-partner-chat-enabled."

--- a/dot_claude/skills/create-worktree/SKILL.md
+++ b/dot_claude/skills/create-worktree/SKILL.md
@@ -19,11 +19,18 @@ tmux를 직접 조작하지 않는다.
 
 ## 실행 순서
 
-저장소가 **래퍼 스크립트를 제공하는지**로 경로가 갈린다.
+저장소가 **래퍼 스크립트를 제공하는지**로 경로가 갈린다. 판정은 저장소 루트를 기준으로
+한다 — 상대 경로로 판정하면 서브디렉터리나 기존 worktree 안에서 스킬을 부를 때 false가
+되어, git-crypt 저장소인데도 아래에서 금지하는 `workmux add` 경로로 빠진다.
 
 ```bash
-[[ -x scripts/create-worktree.sh ]] && echo "스크립트 경로" || echo "workmux 경로"
+ROOT=$(git rev-parse --show-toplevel)
+[[ -f "$ROOT/scripts/create-worktree.sh" ]] && echo "스크립트 경로" || echo "workmux 경로"
+git -C "$ROOT" config --get filter.git-crypt.smudge   # 값이 있으면 git-crypt 저장소
 ```
+
+스크립트가 있는데 실행 권한이 없으면 경로를 바꾸지 말고 그 사실을 오류로 알린다.
+`git-crypt` 필터가 설정되어 있는데 스크립트가 없으면 사용자에게 확인받고 진행한다.
 
 ### 스크립트가 있을 때 (git-crypt 저장소)
 
@@ -32,9 +39,15 @@ git-crypt 저장소에서는 그것이 smudge 필터 에러로 **실패한다**.
 
 ```bash
 ./scripts/create-worktree.sh {브랜치명}    # 필터 우회·키 링크·재체크아웃 + 의존성 설치
-workmux open {디렉토리명} --target-name {윈도우이름}  # 기존 worktree를 입양해 레이아웃만 얹는다
+workmux open {디렉토리명} --target-name {윈도우이름}  # 이슈 번호가 있을 때
+workmux open {디렉토리명}                             # 이슈 번호가 없을 때
 ```
 
+- **스크립트가 실패하면 여기서 멈춘다.** 종료 코드를 확인하고, 실패했으면
+  `workmux open`으로 넘어가지 않는다. 스크립트는 worktree를 만든 뒤 키 링크·재체크아웃·
+  의존성 설치를 하므로 뒤쪽에서 죽어도 worktree는 남는다 — 그 상태로 `workmux open`을
+  실행하면 성공해버려서 파일이 암호화된 채이거나 의존성이 없는 worktree를 정상으로
+  보고하게 된다.
 - 스크립트의 확인 프롬프트는 `-y`나 `yes |`로 우회하지 않고 사용자에게 직접 확인받는다.
 - **스크립트 출력에서 worktree 절대경로를 확보한다.** `workmux open`에 넘길
   디렉토리명은 그 경로의 basename이다 (아래 "이름 파생" 참조).
@@ -46,26 +59,50 @@ workmux open {디렉토리명} --target-name {윈도우이름}  # 기존 worktre
 workmux가 생성과 윈도우 구성을 한 번에 한다.
 
 ```bash
-workmux add {브랜치명} --target-name {윈도우이름}
+workmux add {브랜치명} --target-name {윈도우이름}   # 이슈 번호가 있을 때
+workmux add {브랜치명}                              # 이슈 번호가 없을 때
 ```
 
 ## 이름 파생
 
-- **짧은 이름**: 브랜치명에서 `*/` prefix를 제거한다.
-- **이슈 번호**: 브랜치명의 선행 숫자 ID 또는 `ZF-숫자`를 사용하며, 없으면 생략한다.
-- **윈도우이름**: 이슈 번호가 있으면 `{이슈번호}-{짧은이름}`, 없으면 짧은 이름이다.
-  workmux는 target name을 소문자로 정규화하므로 `ZF-숫자`가 포함된 실제 target도 소문자다.
-  `392-feat/add-partner-chat-enabled` → `392-add-partner-chat-enabled`,
-  `ZF-115-feat/some-feature` → `zf-115-some-feature`,
-  `login-bug` → `login-bug`
+- **짧은 이름**: 브랜치명에서 마지막 `/`까지를 제거한다.
+  `392-feat/add-partner-chat-enabled` → `add-partner-chat-enabled`
+- **이슈 번호**: 브랜치명 **맨 앞**의 숫자 또는 `ZF-숫자`만 인식한다. 맨 앞이 아니면
+  이슈 번호가 아니다 — `feat/392-add-x`는 이슈 번호가 없는 것으로 본다.
+- **윈도우이름**: 이슈 번호가 있을 때만 `{이슈번호}-{짧은이름}`을 만들어
+  `--target-name`에 넘긴다. **이슈 번호가 없으면 `--target-name`을 생략한다.**
+  짧은 이름만 넘기는 것은 어느 경로에서도 하지 않는다 — 브랜치 prefix와 저장소
+  이름을 모두 잃어 충돌 확률만 높아진다.
+
+  | 브랜치 | `--target-name` | `add` 경로 윈도우 | `open` 경로 윈도우 |
+  | --- | --- | --- | --- |
+  | `392-feat/add-partner-chat-enabled` | `392-add-partner-chat-enabled` | `392-add-partner-chat-enabled` | 같음 |
+  | `ZF-115-chore/some-feature` | `ZF-115-some-feature` | `zf-115-some-feature` | 같음 |
+  | `fix/login-bug` | 생략 | `fix-login-bug` | `zambaguni-front-login-bug` |
+
+  생략했을 때 workmux가 쓰는 기본 이름은 경로마다 다르다.
+  `workmux open`은 넘긴 디렉토리명(`{repo명}-{짧은이름}`)을 그대로 써서 저장소 이름이
+  들어가지만, `workmux add`는 브랜치명 슬러그를 써서 저장소 이름이 **없다**. 그래서
+  `add` 경로에서는 두 저장소가 같은 브랜치명을 쓰면 두 번째가
+  `✗ A tmux window named '...' already exists`로 실패한다 — 그때는
+  `--target-name {repo명}-{짧은이름}`으로 재시도한다.
+
+  workmux는 target name을 소문자로 정규화한다. 사용자에게 안내하거나 이후 명령에
+  재사용할 이름은 정규화된 소문자 쪽이다.
 - **디렉토리명**: 스크립트는 계속 `../{repo명}-{짧은이름}` 에 만들며 이슈 번호를 붙이지 않는다.
   `workmux open`에는 이 디렉토리명(`zambaguni-front-add-partner-chat-enabled`)을 넘긴다.
 - 같은 브랜치의 worktree가 이미 있으면 새로 만들지 않고 기존 경로를 안내한다.
 
 ## 마무리
 
-`workmux list`로 결과를 확인하고 사용자에게 worktree 경로와 열린 윈도우를 안내한다.
-`MUX` 열에 `✓`가 있으면 윈도우가 열린 것이다.
+```bash
+workmux list                                  # worktree 등록 확인 (MUX 열 ✓)
+tmux list-windows -a -F '#{window_name}'      # 실제 윈도우 이름 확인
+```
+
+`workmux list`의 어떤 열에도 윈도우 이름이 없다. `MUX ✓`는 윈도우가 열렸다는 것만
+알려주므로, 사용자에게 윈도우 이름을 안내하기 전에 `tmux list-windows`로 실제 이름을
+확인한다 — 추측한 이름을 안내하면 사용자가 `workmux close`에 없는 이름을 넘기게 된다.
 
 ## 주의사항
 

--- a/dot_claude/skills/create-worktree/SKILL.md
+++ b/dot_claude/skills/create-worktree/SKILL.md
@@ -32,7 +32,7 @@ git-crypt 저장소에서는 그것이 smudge 필터 에러로 **실패한다**.
 
 ```bash
 ./scripts/create-worktree.sh {브랜치명}    # 필터 우회·키 링크·재체크아웃 + 의존성 설치
-workmux open {디렉토리명}                   # 기존 worktree를 입양해 레이아웃만 얹는다
+workmux open {디렉토리명} --target-name {윈도우이름}  # 기존 worktree를 입양해 레이아웃만 얹는다
 ```
 
 - 스크립트의 확인 프롬프트는 `-y`나 `yes |`로 우회하지 않고 사용자에게 직접 확인받는다.
@@ -46,14 +46,19 @@ workmux open {디렉토리명}                   # 기존 worktree를 입양해 
 workmux가 생성과 윈도우 구성을 한 번에 한다.
 
 ```bash
-workmux add {브랜치명}
+workmux add {브랜치명} --target-name {윈도우이름}
 ```
 
 ## 이름 파생
 
-- **짧은 이름**: 브랜치명에서 `*/` 앞 prefix를 제거한다.
-  `392-feat/add-partner-chat-enabled` → `add-partner-chat-enabled`
-- **디렉토리명**: 스크립트가 `../{repo명}-{짧은이름}` 에 만든다.
+- **짧은 이름**: 브랜치명에서 `*/` prefix를 제거한다.
+- **이슈 번호**: 브랜치명의 선행 숫자 ID 또는 `ZF-숫자`를 사용하며, 없으면 생략한다.
+- **윈도우이름**: 이슈 번호가 있으면 `{이슈번호}-{짧은이름}`, 없으면 짧은 이름이다.
+  workmux는 target name을 소문자로 정규화하므로 `ZF-숫자`가 포함된 실제 target도 소문자다.
+  `392-feat/add-partner-chat-enabled` → `392-add-partner-chat-enabled`,
+  `ZF-115-feat/some-feature` → `zf-115-some-feature`,
+  `login-bug` → `login-bug`
+- **디렉토리명**: 스크립트는 계속 `../{repo명}-{짧은이름}` 에 만들며 이슈 번호를 붙이지 않는다.
   `workmux open`에는 이 디렉토리명(`zambaguni-front-add-partner-chat-enabled`)을 넘긴다.
 - 같은 브랜치의 worktree가 이미 있으면 새로 만들지 않고 기존 경로를 안내한다.
 

--- a/dot_claude/skills/remove-worktree/SKILL.md
+++ b/dot_claude/skills/remove-worktree/SKILL.md
@@ -12,8 +12,12 @@ workmux로 worktree와 tmux 윈도우를 함께 제거한다.
 
 ## 파라미터
 
-- **args** (선택): worktree 이름 (디렉토리명, tmux 윈도우 이름에서 `wm-` prefix를 뗀 것)
+- **args** (선택): worktree 이름 = `workmux list`의 `PATH` 열 basename (= 디렉토리명).
+  **tmux 윈도우 이름에서 유추하지 않는다.** `workmux remove`와 `close`는 디렉토리명만
+  받는데, 윈도우 이름은 `--target-name`이나 브랜치명 슬러그에서 나와 디렉토리명과 다르다
+  (윈도우 `worktree-issue-window-name` ↔ 디렉토리 `fix-worktree-issue-window-name`).
 - args가 비어있으면 `workmux list`로 목록을 보여주고 사용자에게 선택을 요청한다.
+  제거할 worktree 안에서 실행할 때는 인자를 생략하면 현재 디렉토리가 대상이 된다.
 
 ## 실행 순서
 


### PR DESCRIPTION
## 변경 사항

- Codex와 Claude의 `create-worktree` 스킬에 issue 번호 기반 workmux target 이름 규칙을 복원했습니다.
- 래퍼 스크립트 경로의 `workmux open`과 직접 생성 경로의 `workmux add` 모두 `--target-name`을 전달합니다.
- worktree 디렉터리 이름은 기존 규칙을 유지하고 tmux window 이름에만 issue 번호를 붙입니다.
- workmux가 `ZF-115` 같은 target을 소문자로 정규화하는 실제 동작을 문서와 검증에 반영했습니다.

## 배경

worktree 스킬을 workmux 기반 개인 프로필로 이전하는 과정에서 기존의 issue 번호 window 이름 규칙이 누락되었습니다. 그 결과 `392-feat/...`과 `ZF-115-chore/...` 브랜치가 각각 `392`, `ZF-115` 없이 짧은 이름만으로 열렸습니다.

## 영향

- 숫자 issue: `392-feat/add-partner-chat-enabled` → `392-add-partner-chat-enabled`
- ZF issue: `ZF-115-chore/some-feature` → `zf-115-some-feature`
- issue 없음: `fix/login-bug` → `login-bug`
- 디렉터리명과 pane 레이아웃은 변경되지 않습니다.

## 검증

- Codex skill `quick_validate.py` 통과
- Claude 전용 frontmatter YAML 검증 통과
- Codex/Claude 본문 동등성 확인
- `workmux open --help`에서 `--target-name` 지원 확인
- 숫자/ZF/issue 없음 3개 케이스의 `workmux add --dry-run` 결과 확인
- 격리된 chezmoi source에서 Codex·Claude live skill에 적용 후 byte 단위 일치 확인
- `chezmoi diff`, `git diff --check` 통과
- 구현·명세·품질·최종 리뷰 통과