### PR TITLE
fix(skills): remove-worktree에 고아 workmux agent state 정리 추가

### DIFF
--- a/dot_agents/skills/remove-worktree/SKILL.md
+++ b/dot_agents/skills/remove-worktree/SKILL.md
@@ -29,8 +29,9 @@ workmux remove {이름}             # worktree + tmux 윈도우 + 로컬 브랜�
 
 ## 고아 agent state 정리 (workmux 0.1.233 버그 우회)
 
-**`workmux remove`·`close` 후에는 반드시 아래를 실행한다.** 안 하면 dashboard·sidebar·
-`workmux status`가 **전부** 빈 화면이 된다.
+**`workmux remove`·`close`·`merge` 후에는 반드시 아래를 실행한다.** 안 하면 dashboard·
+sidebar·`workmux status`가 **전부** 빈 화면이 된다. `remove --gone`·`--all`처럼 여러 개를
+한 번에 지웠으면 고아도 여러 개 생기지만, 아래 스니펫이 한 번에 다 정리한다.
 
 ```bash
 d="$HOME/.local/state/workmux/agents"
@@ -49,12 +50,13 @@ if [ -d "$d" ] && [ -n "$live" ]; then
 fi
 ```
 
-**왜 필요한가:** `remove`·`close`는 tmux 윈도우만 kill하고 agent state 파일은 지우지
-않는다. 원래는 reconcile이 나중에 수거하지만, v0.1.233의 `51bd57c6`(#209 수정)이 그
-수거 경로를 깨뜨렸다 — 없는 pane을 조회하면 tmux는 exit 0으로 빈 필드를 돌려주는데
-workmux가 이를 "판단 불가"로 보고 열거 **전체**를 에러로 중단한다. 그래서 **에이전트가
-돌던 worktree를 제거할 때마다 고아 파일이 하나씩 쌓이고 그 즉시 모든 뷰가 빈다.**
-`reap-agents`도 같은 에러로 죽어서 탈출구가 못 된다.
+**왜 필요한가:** `remove`·`close`·`merge`는 tmux 윈도우만 kill하고 agent state 파일은
+지우지 않는다(`remove`와 `merge`는 같은 `cleanup.rs`를 쓴다). 원래는 reconcile이 나중에
+수거하지만, v0.1.233의 `51bd57c6`(#209 수정)이 그 수거 경로를 깨뜨렸다 — 없는 pane을
+조회하면 tmux는 exit 0으로 빈 필드를 돌려주는데 workmux가 이를 "판단 불가"로 보고 열거
+**전체**를 에러로 중단한다. 그래서 **에이전트가 돌던 worktree를 제거할 때마다 고아
+파일이 하나씩 쌓이고 그 즉시 모든 뷰가 빈다.** `reap-agents`도 같은 에러로 죽어서
+탈출구가 못 된다.
 
 두 가드는 workmux의 reconcile 로직을 그대로 따른 것이므로 **지우지 말 것**:
 - `instance` 비교 — 다른 tmux 서버의 state를 건드리지 않는다

--- a/dot_agents/skills/remove-worktree/SKILL.md
+++ b/dot_agents/skills/remove-worktree/SKILL.md
@@ -21,10 +21,48 @@ workmux로 worktree와 tmux 윈도우를 함께 제거한다.
 ```bash
 workmux list                      # 대상 확인
 workmux remove {이름}             # worktree + tmux 윈도우 + 로컬 브랜치
+# 그리고 아래 "고아 agent state 정리"를 반드시 실행한다
 ```
 
 `workmux remove`는 기본적으로 **확인 프롬프트를 띄우고 미커밋 변경이 있으면 경고**한다.
 그 프롬프트를 `-f`로 우회하지 않고 사용자에게 직접 확인받는다.
+
+## 고아 agent state 정리 (workmux 0.1.233 버그 우회)
+
+**`workmux remove`·`close` 후에는 반드시 아래를 실행한다.** 안 하면 dashboard·sidebar·
+`workmux status`가 **전부** 빈 화면이 된다.
+
+```bash
+d="$HOME/.local/state/workmux/agents"
+live=$(tmux list-panes -a -F '#{pane_id}') || live=""
+if [ -d "$d" ] && [ -n "$live" ]; then
+  sock=$(tmux display-message -p '#{socket_path}')
+  boot=$(tmux display-message -p '#{start_time}')
+  for f in "$d"/tmux__*.json; do
+    [ -e "$f" ] || continue
+    [ "$(jq -r '.pane_key.instance // ""' "$f")" = "$sock" ] || continue  # 다른 tmux 서버
+    [ "$(jq -r '.boot_id // ""' "$f")" = "$boot" ] || continue            # 이전 부팅 = resurrect 입력
+    p=$(jq -r '.pane_key.pane_id // ""' "$f")
+    printf '%s\n' "$live" | grep -qxF -- "$p" && continue                 # 살아있는 pane
+    rm -f -- "$f" && echo "pruned stale workmux agent state: $p"
+  done
+fi
+```
+
+**왜 필요한가:** `remove`·`close`는 tmux 윈도우만 kill하고 agent state 파일은 지우지
+않는다. 원래는 reconcile이 나중에 수거하지만, v0.1.233의 `51bd57c6`(#209 수정)이 그
+수거 경로를 깨뜨렸다 — 없는 pane을 조회하면 tmux는 exit 0으로 빈 필드를 돌려주는데
+workmux가 이를 "판단 불가"로 보고 열거 **전체**를 에러로 중단한다. 그래서 **에이전트가
+돌던 worktree를 제거할 때마다 고아 파일이 하나씩 쌓이고 그 즉시 모든 뷰가 빈다.**
+`reap-agents`도 같은 에러로 죽어서 탈출구가 못 된다.
+
+두 가드는 workmux의 reconcile 로직을 그대로 따른 것이므로 **지우지 말 것**:
+- `instance` 비교 — 다른 tmux 서버의 state를 건드리지 않는다
+- `boot_id` 비교 — tmux/컴퓨터 크래시 후 남은 이전 부팅의 state는 `workmux resurrect`의
+  입력이다. 지우면 복구가 불가능해진다
+
+upstream 이슈 [raine/workmux#213](https://github.com/raine/workmux/issues/213)이 수정되면
+이 섹션 전체를 삭제한다.
 
 ### 자주 쓰는 변형
 

--- a/dot_claude/skills/remove-worktree/SKILL.md
+++ b/dot_claude/skills/remove-worktree/SKILL.md
@@ -24,10 +24,48 @@ workmux로 worktree와 tmux 윈도우를 함께 제거한다.
 ```bash
 workmux list                      # 대상 확인
 workmux remove {이름}             # worktree + tmux 윈도우 + 로컬 브랜치
+# 그리고 아래 "고아 agent state 정리"를 반드시 실행한다
 ```
 
 `workmux remove`는 기본적으로 **확인 프롬프트를 띄우고 미커밋 변경이 있으면 경고**한다.
 그 프롬프트를 `-f`로 우회하지 않고 사용자에게 직접 확인받는다.
+
+## 고아 agent state 정리 (workmux 0.1.233 버그 우회)
+
+**`workmux remove`·`close` 후에는 반드시 아래를 실행한다.** 안 하면 dashboard·sidebar·
+`workmux status`가 **전부** 빈 화면이 된다.
+
+```bash
+d="$HOME/.local/state/workmux/agents"
+live=$(tmux list-panes -a -F '#{pane_id}') || live=""
+if [ -d "$d" ] && [ -n "$live" ]; then
+  sock=$(tmux display-message -p '#{socket_path}')
+  boot=$(tmux display-message -p '#{start_time}')
+  for f in "$d"/tmux__*.json; do
+    [ -e "$f" ] || continue
+    [ "$(jq -r '.pane_key.instance // ""' "$f")" = "$sock" ] || continue  # 다른 tmux 서버
+    [ "$(jq -r '.boot_id // ""' "$f")" = "$boot" ] || continue            # 이전 부팅 = resurrect 입력
+    p=$(jq -r '.pane_key.pane_id // ""' "$f")
+    printf '%s\n' "$live" | grep -qxF -- "$p" && continue                 # 살아있는 pane
+    rm -f -- "$f" && echo "pruned stale workmux agent state: $p"
+  done
+fi
+```
+
+**왜 필요한가:** `remove`·`close`는 tmux 윈도우만 kill하고 agent state 파일은 지우지
+않는다. 원래는 reconcile이 나중에 수거하지만, v0.1.233의 `51bd57c6`(#209 수정)이 그
+수거 경로를 깨뜨렸다 — 없는 pane을 조회하면 tmux는 exit 0으로 빈 필드를 돌려주는데
+workmux가 이를 "판단 불가"로 보고 열거 **전체**를 에러로 중단한다. 그래서 **에이전트가
+돌던 worktree를 제거할 때마다 고아 파일이 하나씩 쌓이고 그 즉시 모든 뷰가 빈다.**
+`reap-agents`도 같은 에러로 죽어서 탈출구가 못 된다.
+
+두 가드는 workmux의 reconcile 로직을 그대로 따른 것이므로 **지우지 말 것**:
+- `instance` 비교 — 다른 tmux 서버의 state를 건드리지 않는다
+- `boot_id` 비교 — tmux/컴퓨터 크래시 후 남은 이전 부팅의 state는 `workmux resurrect`의
+  입력이다. 지우면 복구가 불가능해진다
+
+upstream 이슈 [raine/workmux#213](https://github.com/raine/workmux/issues/213)이 수정되면
+이 섹션 전체를 삭제한다.
 
 ### 자주 쓰는 변형
 

--- a/dot_claude/skills/remove-worktree/SKILL.md
+++ b/dot_claude/skills/remove-worktree/SKILL.md
@@ -32,8 +32,9 @@ workmux remove {이름}             # worktree + tmux 윈도우 + 로컬 브랜�
 
 ## 고아 agent state 정리 (workmux 0.1.233 버그 우회)
 
-**`workmux remove`·`close` 후에는 반드시 아래를 실행한다.** 안 하면 dashboard·sidebar·
-`workmux status`가 **전부** 빈 화면이 된다.
+**`workmux remove`·`close`·`merge` 후에는 반드시 아래를 실행한다.** 안 하면 dashboard·
+sidebar·`workmux status`가 **전부** 빈 화면이 된다. `remove --gone`·`--all`처럼 여러 개를
+한 번에 지웠으면 고아도 여러 개 생기지만, 아래 스니펫이 한 번에 다 정리한다.
 
 ```bash
 d="$HOME/.local/state/workmux/agents"
@@ -52,12 +53,13 @@ if [ -d "$d" ] && [ -n "$live" ]; then
 fi
 ```
 
-**왜 필요한가:** `remove`·`close`는 tmux 윈도우만 kill하고 agent state 파일은 지우지
-않는다. 원래는 reconcile이 나중에 수거하지만, v0.1.233의 `51bd57c6`(#209 수정)이 그
-수거 경로를 깨뜨렸다 — 없는 pane을 조회하면 tmux는 exit 0으로 빈 필드를 돌려주는데
-workmux가 이를 "판단 불가"로 보고 열거 **전체**를 에러로 중단한다. 그래서 **에이전트가
-돌던 worktree를 제거할 때마다 고아 파일이 하나씩 쌓이고 그 즉시 모든 뷰가 빈다.**
-`reap-agents`도 같은 에러로 죽어서 탈출구가 못 된다.
+**왜 필요한가:** `remove`·`close`·`merge`는 tmux 윈도우만 kill하고 agent state 파일은
+지우지 않는다(`remove`와 `merge`는 같은 `cleanup.rs`를 쓴다). 원래는 reconcile이 나중에
+수거하지만, v0.1.233의 `51bd57c6`(#209 수정)이 그 수거 경로를 깨뜨렸다 — 없는 pane을
+조회하면 tmux는 exit 0으로 빈 필드를 돌려주는데 workmux가 이를 "판단 불가"로 보고 열거
+**전체**를 에러로 중단한다. 그래서 **에이전트가 돌던 worktree를 제거할 때마다 고아
+파일이 하나씩 쌓이고 그 즉시 모든 뷰가 빈다.** `reap-agents`도 같은 에러로 죽어서
+탈출구가 못 된다.
 
 두 가드는 workmux의 reconcile 로직을 그대로 따른 것이므로 **지우지 말 것**:
 - `instance` 비교 — 다른 tmux 서버의 state를 건드리지 않는다


### PR DESCRIPTION
> **다른 세션에서 리뷰를 이어받는 경우를 위해 자체 완결적으로 작성했다.** 이 본문만 읽으면
> 배경 대화 없이 리뷰가 가능하다. 재현 명령은 전부 실제로 실행해본 것이다.

## TL;DR

workmux 0.1.233에서 **에이전트가 돌던 worktree를 제거하면 dashboard·sidebar·`workmux status`가 전부 빈 화면이 된다.** 고아가 된 agent state 파일 하나가 목록 열거 전체를 에러로 중단시키기 때문이다. upstream 버그이고 0.1.233이 최신이라 업데이트로는 안 고쳐진다.

이 PR은 `remove-worktree` 스킬에 제거 직후 고아 파일을 정리하는 단계를 추가한다. 삭제 조건은 workmux 자신의 reconcile 로직을 그대로 옮겼다.

- 변경: `dot_claude`·`dot_agents`의 `skills/remove-worktree/SKILL.md` 2개 파일, 문서만 (코드 없음)
- upstream 이슈: [raine/workmux#213](https://github.com/raine/workmux/issues/213) (내가 올림)
- 커밋 2개: `610deb5`(정리 단계 추가), `5977652`(`merge`까지 범위 확장)

---

## 1. 증상

`.tmux.conf`의 `bind W display-popup -h 85% -w 90% -E "workmux dashboard"`로 dashboard를 띄우면 **아무것도 안 보인다.** 팝업이 열렸다가 즉시 닫히거나, 열려도 표가 비어 있다.

에러 메시지가 안 보이는 게 진단을 어렵게 만든다 — `display-popup -E`는 명령이 죽으면 팝업을 그대로 닫아버린다. CLI로 직접 실행하면 정체가 드러난다:

```console
$ workmux status --json
Error: tmux returned malformed live pane information for %92
```

## 2. 근본 원인

### 2.1 tmux가 없는 pane에 대해 에러를 내지 않는다

이게 출발점이다. tmux 3.7b에서 `display-message -p -t <없는 pane>`은 **실패가 아니라 exit 0으로 모든 pane 필드를 빈 문자열로** 확장한다.

```console
$ tmux -V
tmux 3.7b

$ FMT=$'#{pane_id}\t#{pane_pid}\t#{pane_current_command}\t#{pane_current_path}\t#{pane_title}\t#{session_name}\t#{window_name}\t#{session_id}\t#{window_id}'

# 살아있는 pane
$ tmux display-message -p -t '%78' "$FMT"
%78	27941	node	/Users/me/code/dotfiles	✳ working	main	 my-window	$0	@28

# 없는 pane — 에러가 아니다
$ tmux display-message -p -t '%99999' "$FMT" | od -c
0000000   \t  \t  \t  \t  \t  \t  \t  \t  \n
$ tmux display-message -p -t '%99999' "$FMT" >/dev/null; echo $?
0
```

`%abc`(문법상 잘못된 타깃), `nosuch:9`(없는 세션)도 전부 exit 0 + 빈 확장이다. workmux는 stdout을 `trim()`하므로 최종적으로 빈 문자열 `""`을 받는다.

### 2.2 workmux가 그 빈 응답을 "판단 불가"로 분류한다

upstream `main`(`002a2dc`) 기준 경로:

| 단계 | 위치 | 일어나는 일 |
|------|------|------------|
| 1 | [`store.rs:370`](https://github.com/raine/workmux/blob/002a2dc/src/state/store.rs#L370) | 배치 `list-panes -a` 성공 → 살아있는 pane 맵 |
| 2 | [`store.rs:403-405`](https://github.com/raine/workmux/blob/002a2dc/src/state/store.rs#L403-L405) | 맵에 없는 state는 `validate_agent_alive(&state)?`로 개별 확인 |
| 3 | [`mod.rs:773`](https://github.com/raine/workmux/blob/002a2dc/src/multiplexer/mod.rs#L773) | `get_live_pane_info(pane_id)?` |
| 4 | [`tmux.rs:884-891`](https://github.com/raine/workmux/blob/002a2dc/src/multiplexer/tmux.rs#L884-L891) | `display-message`가 §2.1대로 `Ok("")` 반환 |
| 5 | [`tmux.rs:68-76`](https://github.com/raine/workmux/blob/002a2dc/src/multiplexer/tmux.rs#L68-L76) | `parse_live_pane_line("")` → 필드 1개, [7개 미만이라 `None`](https://github.com/raine/workmux/blob/002a2dc/src/multiplexer/tmux.rs#L30) → `anyhow!("tmux returned malformed live pane information for {pane_id}")` |
| 6 | 2·3의 `?` | `load_reconciled_agents` **전체**가 Err로 중단 |

핵심은 **부재를 확인하는 코드가 `Err` 분기에만 있다**는 것이다. [`tmux.rs:77-99`](https://github.com/raine/workmux/blob/002a2dc/src/multiplexer/tmux.rs#L77-L99)가 `list-panes -a -F '#{pane_id}'`로 "정말 없는 pane"을 확인해 `Ok(None)`을 돌려주는데, §2.1 때문에 **이 tmux에서는 없는 pane이 `Err`로 오지 않아 그 분기에 도달할 수 없다.**

### 2.3 이건 v0.1.233이 만든 regression이다

`51bd57c6`("preserve agent state on uncertain tmux pane queries", 2026-08-02T14:45:10Z, upstream #209 수정) 이전의 코드는:

```rust
let output = match output {
    Ok(o) => o,
    Err(_) => return Ok(None), // Pane doesn't exist or error querying
};
Ok(parse_live_pane_line(output.trim()).map(|(_, info)| info))
```

같은 빈 응답이 `Ok(None)` → "not alive" → **state 파일 자동 삭제**로 흘렀다. 즉 원래는 self-healing이었다. 수정 후에는 같은 입력이 hard error가 되고, 파일은 영구히 남아 매 실행마다 실패한다.

로컬 로그가 이 전환을 그대로 보여준다. 바이너리 설치 시각은 `2026-08-02 21:48 UTC`(`/opt/homebrew/bin/workmux` symlink mtime)다:

```
# 업그레이드 전 — 정상적으로 수거되고 있었다
2026-08-02T08:26:18.521354Z  INFO reconcile: removing agent, pane no longer exists pane_id="%1"

# 업그레이드 후 — 같은 상황이 치명적 에러
2026-08-03T01:01:02.315462Z ERROR workmux failed error=tmux returned malformed live pane information for %69
2026-08-03T03:16:07.268109Z ERROR workmux failed error=tmux returned malformed live pane information for %92
```

#209의 의도(불확실할 때 지우지 않는다)는 옳다. 문제는 **"진짜 없는 pane"이 이제 "불확실"로 분류된다**는 것뿐이다.

## 3. 왜 트리거가 흔한가 — `remove`·`close`·`merge`

reconcile이 agent state의 **유일한** garbage collector다. `002a2dc`에서 `delete_agent` 호출 지점 전부:

```
src/state/store.rs:413            reconcile — "pane no longer exists"   ← 51bd57c6이 깨뜨린 분기
src/state/store.rs:432            reconcile — pane PID 변경
src/state/store.rs:456            reconcile — foreground command 변경
src/command/reap_agents.rs:45     exit에 성공한 에이전트만
src/command/resurrect.rs:111
```

`remove`·`close`·`merge`는 store를 **전혀** 건드리지 않는다:

- `src/command/remove.rs`, `src/workflow/remove.rs`, `src/command/close.rs` → `delete_agent` 없음
- `remove`와 `merge`는 같은 `src/workflow/cleanup.rs`를 거치고, 거기서 [`kill_window_target`](https://github.com/raine/workmux/blob/002a2dc/src/workflow/cleanup.rs#L491)으로 윈도우만 죽인다. `cleanup.rs`에도 `delete_agent`가 없다
- `merge`는 `command/merge.rs:79`에서 `workflow::merge`를 호출하고 그것이 다시 `cleanup`으로 간다

즉 **에이전트가 돌던 worktree를 제거/머지할 때마다 고아가 하나씩 쌓이고, 그 즉시 모든 뷰가 빈다.** 예외적인 크래시 상황이 아니라 정상 워크플로다.

### 실측: 고아 개수가 에이전트 개수와 정확히 일치했다

2026-08-03 03:03에 `workmux remove <이름> -f`로 worktree 5개를 지웠다.

| 제거된 윈도우 | claude pane | 결과 |
|---|---|---|
| search-suggestion-grid-aria-structure | `%92` | 고아 발생 |
| expired-account-reauth-path | `%95` | 고아 발생 |
| mobile-sns-mypage-profile-activity | `%101` | 고아 발생 |
| user-home-carousel-loading-responsive-ui | 없음(빈 셸) | 고아 없음 |
| user-mobile-notification-routing | 없음(빈 셸) | 고아 없음 |

고아 3개, 그리고 다른 윈도우의 **정상 에이전트 9개가 전부 안 보였다.** 3개 파일을 지우자 9개가 즉시 복구됐다. 같은 날 아침에도 `%69` 하나 때문에 에이전트 8개가 전부 안 보였다.

### `reap-agents`는 탈출구가 못 된다

[`reap_agents.rs:13`](https://github.com/raine/workmux/blob/002a2dc/src/command/reap_agents.rs#L13)이 `load_reconciled_agents(mux.as_ref())?`를 먼저 호출하므로 **같은 에러로 죽는다.** 게다가 state를 지우는 건 `exit_agent`에 성공한 에이전트뿐인데, 이미 죽은 pane은 여기에 해당할 수 없다. 수동 `rm`이 현재 유일한 복구 수단이다.

## 4. 이 PR이 하는 일

`remove-worktree` 스킬에 "고아 agent state 정리" 섹션을 추가한다. `dot_claude`·`dot_agents` 본문은 동일하게 유지했다(frontmatter만 다름 — `dot_claude`에만 `user-invocable`·`allowed-tools: Bash`가 있다).

```bash
d="$HOME/.local/state/workmux/agents"
live=$(tmux list-panes -a -F '#{pane_id}') || live=""
if [ -d "$d" ] && [ -n "$live" ]; then
  sock=$(tmux display-message -p '#{socket_path}')
  boot=$(tmux display-message -p '#{start_time}')
  for f in "$d"/tmux__*.json; do
    [ -e "$f" ] || continue
    [ "$(jq -r '.pane_key.instance // ""' "$f")" = "$sock" ] || continue  # 다른 tmux 서버
    [ "$(jq -r '.boot_id // ""' "$f")" = "$boot" ] || continue            # 이전 부팅 = resurrect 입력
    p=$(jq -r '.pane_key.pane_id // ""' "$f")
    printf '%s\n' "$live" | grep -qxF -- "$p" && continue                 # 살아있는 pane
    rm -f -- "$f" && echo "pruned stale workmux agent state: $p"
  done
fi
```

### 각 줄의 의도

| 줄 | 이유 |
|---|---|
| `live=$(...) \|\| live=""` + `[ -n "$live" ]` | `list-panes -a`가 실패하면 **아무것도 하지 않는다.** 부재 판정을 신뢰할 수 없는 상태에서 지우면 #209와 같은 데이터 손실이 된다 |
| `[ -d "$d" ]` | state 디렉토리가 없는 머신(설치 직후, server 타입)에서 no-op |
| `[ -e "$f" ] \|\| continue` | glob이 하나도 안 맞을 때 리터럴 패턴이 들어오는 것 방어 |
| `instance == #{socket_path}` | state 파일은 tmux 소켓별로 키가 잡힌다. 다른 tmux 서버의 state를 현재 서버의 pane 목록으로 판정하면 안 된다 |
| `boot_id == #{start_time}` | **가장 중요.** 아래 별도 설명 |
| `grep -qxF -- "$p"` | `-x` 완전 일치 (`%9`가 `%92`에 매칭되는 것 방지), `-F` 고정 문자열, `--` 로 `%`로 시작하는 인자 보호 |
| `jq -r '... // ""'` | 필드가 없는 파일에서 `null` 문자열이 나오지 않게 |

### `boot_id` 가드가 왜 필수인가

state 파일의 `boot_id`는 tmux `#{start_time}`(서버 시작 Unix timestamp)이다. **tmux 서버가 죽고 새로 뜨면 이전 부팅의 pane은 전부 "없는 pane"으로 보인다.** 이 가드가 없으면 그 상황에서 state 파일을 **전부** 지워버리고, `workmux resurrect`의 입력이 사라져 크래시 복구가 불가능해진다.

upstream도 정확히 같은 가드를 갖고 있다 — [`store.rs:397-402`](https://github.com/raine/workmux/blob/002a2dc/src/state/store.rs#L397-L402):

```rust
None if previous_server => {
    trace!(pane_id, "reconcile: preserving agent from previous server lifecycle for resurrect");
}
```

이 스니펫의 세 조건은 upstream reconcile이 `delete_agent`에 도달하는 조건과 같다: 같은 instance + 같은 서버 lifecycle + 배치 pane 목록에 없음. **의도적으로 workmux보다 더 공격적이지 않게 만들었다.**

## 5. 설계 결정과 기각한 대안

| 대안 | 기각 이유 |
|---|---|
| workmux 업데이트 | 0.1.233이 최신 릴리스다. 수정본이 아직 없다 |
| upstream PR을 보내고 기다린다 | 이슈는 올렸다([#213](https://github.com/raine/workmux/issues/213)). 그동안 제거할 때마다 깨지는 걸 방치할 수 없다 |
| `.workmux.yaml`의 `pre_remove` 훅 | **불가능.** workmux 훅은 `post_create`와 `pre_remove` **둘뿐**이다(`src/config.rs:408,416`). `pre_remove`는 윈도우를 죽이기 **전에** 돌아서 고아를 볼 수 없다. post-remove 훅이 없다 |
| `bind W`를 "정리 후 dashboard"로 래핑 | dashboard는 고쳐지지만 `sidebar`·`status`·`list`·`wait`·셸 completion은 여전히 깨진 상태로 남는다. 원인 지점에서 막는 쪽이 낫다 |
| `reap-agents`를 주기적으로 | §3 마지막 — 같은 에러로 죽는다 |
| 별도 스크립트 파일로 분리 | 임시 우회 코드라 upstream 수정 시 통째로 삭제하는 게 목표다. 스킬 안에 인라인이면 삭제가 한 번에 끝난다. chezmoi `executable_` 접두사·배포 경로 관리도 불필요 |

## 6. 검증

### 6.1 분기별 fixture 테스트

합성 state 파일 4개로 각 분기를 확인했다:

| fixture | 조건 | 기대 | 결과 |
|---|---|---|---|
| 살아있는 pane, 현재 부팅 | 정상 에이전트 | 보존 | `keep(live) %68` ✅ |
| 없는 pane, 현재 부팅 | 고아 | **삭제** | `pruned %99991` ✅ |
| 없는 pane, 이전 부팅 | resurrect 입력 | 보존 | `keep(resurrect) %99992` ✅ |
| 없는 pane, 다른 소켓 | 타 서버 state | 보존 | `keep(instance) %99993` ✅ |

4개 중 삭제된 건 1개뿐이다.

### 6.2 실제 환경 no-op 확인

커밋된 `SKILL.md`에서 스니펫을 **다시 추출**해서 검사했다 (문서와 실행 코드가 어긋나는 것 방지):

```console
$ awk '/^## 고아 agent state 정리/,0' dot_claude/skills/remove-worktree/SKILL.md \
  | awk '/^```bash$/{f=1;next} /^```$/{f=0} f' > extracted.sh
$ bash -n extracted.sh && echo "문법 OK"
문법 OK
$ bash extracted.sh; echo "rc=$?"
rc=0                              # 출력 없음 = 고아 없음
$ ls ~/.local/state/workmux/agents | wc -l
13                                # 실행 전후 동일
```

두 번째 커밋(`5977652`) 후에도 추출본을 `diff`해서 **스니펫 코드가 변하지 않았음**을 확인했다 — 그 커밋은 문구만 바꿨다.

### 6.3 배포 확인

```console
$ chezmoi apply -v ~/.claude/skills/remove-worktree ~/.agents/skills/remove-worktree
$ chezmoi diff ~/.claude/skills/remove-worktree ~/.agents/skills/remove-worktree
                                  # 출력 없음 = 동기화 완료
```

전체 `chezmoi apply`는 **의도적으로 피했다** — `~/.config/workmux/config.yaml`의 `nerdfont` 항목은 workmux가 런타임에 직접 써넣어서, 전체 apply를 돌리면 매번 drift가 생긴다.

### 6.4 두 파일 본문 동일성

```console
$ diff <(tail -n +8 dot_claude/skills/remove-worktree/SKILL.md) \
       <(tail -n +5 dot_agents/skills/remove-worktree/SKILL.md)
                                  # 출력 없음
```

### 6.5 의존성

`jq`는 `dot_Brewfile:21`(`brew "jq"`)에 이미 있다. 새 의존성 없음.

## 7. 리뷰어가 봐줄 것

1. **`boot_id`·`instance` 가드를 지우지 말 것.** §4의 이유. 스킬 본문에도 "지우지 말 것"이라고 적어뒀다
2. **적용 범위가 맞나** — `remove`·`close`·`merge`로 잡았다. `rename`은 pane을 죽이지 않고, `resurrect`는 자체적으로 state를 관리하므로 제외했다. 빠진 명령이 있는지 봐주면 좋겠다
3. **`grep -qxF -- "$p"`의 `--`** — pane id가 `%`로 시작해서 옵션으로 오해될 여지는 없지만 방어적으로 넣었다. 불필요하다고 보면 빼도 된다
4. **문구 길이** — 우회 이유 설명이 길다. "왜 필요한가" 블록을 줄이고 이 PR 링크만 남기는 것도 방법이다. 다만 upstream 수정까지 이 코드가 왜 있는지 모르면 누군가 무심코 지울 위험이 있어 남겼다

## 8. 한계 (알려진 미커버)

- **강제되지 않는다.** 스킬 프롬프트의 한 단계이므로 에이전트가 건너뛸 수 있다. §5대로 workmux에 post-remove 훅이 없어 강제할 지점이 없다
- **스킬 밖에서 `workmux remove`를 직접 실행하면 커버되지 않는다.** 그때는 dashboard가 빈 걸 보고 수동으로 정리해야 한다
- **다른 스킬 경로.** `superpowers:finishing-a-development-branch`처럼 머지·정리를 유도하는 스킬이 `workmux merge`를 직접 호출하면 이 단계를 안 거친다
- **에이전트가 죽어서 생긴 고아**(제거와 무관)는 여전히 다음 `remove` 때까지 남는다. 아침의 `%69`가 그 경우였다

이 한계들이 신경 쓰이면 `bind W` 래핑(§5의 4번째 대안)을 **추가로** 넣는 게 최종 방어선이 된다. 이번엔 원인 지점만 막았다.

## 9. 브랜치를 `origin/main`에서 뗀 이유

**중요.** 작업 시점에 chezmoi source worktree(`~/code/dotfiles`)는 `feat/tmux-memory-monitoring`에 있었고, **그 브랜치는 이 파일에서 `origin/main`보다 뒤처져 있었다.** `origin/main`에는 #8로 개선된 `파라미터` 섹션(윈도우 이름 ≠ 디렉토리명 경고)이 있는데 그 브랜치에는 구버전이 남아 있다.

그래서 워킹트리 파일을 복사하지 않고 `origin/main`에서 worktree를 새로 떼어 섹션만 다시 얹었다. 첫 커밋이 `+76 -0`(삭제 0줄)인 게 그 증거다 — 워킹트리를 복사했으면 `-10`이 섞여 #8을 되돌렸을 것이다.

여담: 이 조사 중에 발견한 `2026-08-03T03:02:19Z ERROR Worktree not found: 1096-expired-account-reauth-path` 로그가 정확히 #8이 경고하는 함정(윈도우 이름으로 `remove`를 시도)이었다.

## 10. 로컬 상태 (핸드오프)

리뷰를 이어받는 세션이 알아야 할 것:

- **작업 worktree**: `/Users/lee-kyu-hwan/code/dotfiles__worktrees/workmux-stale-agent-cleanup` — 브랜치 `chore/workmux-stale-agent-state-cleanup`, 클린 상태. `git worktree add`로만 만들었고 tmux 윈도우는 없다
- **`~/code/dotfiles`(chezmoi source)에 같은 변경이 커밋되지 않은 채 남아 있다.** 일부러 되돌리지 않았다 — 여기가 chezmoi source라서 되돌리면 다음 `chezmoi apply` 때 배포된 스킬에서 우회 코드가 조용히 사라진다. **이 PR 머지 후** `git checkout -- dot_claude/skills/remove-worktree/SKILL.md dot_agents/skills/remove-worktree/SKILL.md`로 정리하면 된다
- **배포본은 이 PR과 완전히 같지 않다.** 우회 섹션은 동일하지만 `파라미터` 섹션이 §9의 구버전이다 (chezmoi source가 뒤처진 브랜치를 가리키기 때문). 머지 후 그 브랜치에 main을 반영하거나 source worktree를 main으로 옮기면 해결된다
- **현재 고아 없음.** 이 PR 작업 중 두 차례(`%69`, 그리고 `%92 %95 %101`) 정리했고 백업은 세션 scratchpad에 있다

## 11. upstream 수정 후 할 일

[raine/workmux#213](https://github.com/raine/workmux/issues/213)이 릴리스에 반영되면:

1. `workmux update`
2. 두 `SKILL.md`에서 "고아 agent state 정리" 섹션 **전체** 삭제 + 실행 순서의 주석 한 줄 삭제
3. `chezmoi apply`

스킬 본문 마지막 줄에 이 지시를 적어뒀다.

## 12. 환경

```
workmux 0.1.233 (Homebrew, 2026-08-02 21:48 UTC 설치)
tmux 3.7b
macOS 26.4.1 arm64
jq (dot_Brewfile:21)
upstream main: 002a2dc / 문제 커밋: 51bd57c6
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
