### PR TITLE
feat: tmux 안에서도 Ghostty 셸 통합이 동작하게 한다

### DIFF
--- a/dot_tmux.conf.tmpl
+++ b/dot_tmux.conf.tmpl
@@ -5,6 +5,16 @@ set -g mouse on
 # (after-select-pane/window는 tmux 내부 이벤트라 이 옵션과 무관하게 동작한다)
 set -g focus-events on
 
+# tmux 서버는 데몬이라 오래 살아남는다. Ghostty를 재시작하면 새 환경변수가
+# 생기는데, update-environment에 없으면 서버가 옛 값을 계속 물려준다.
+# 기본값에는 Ghostty 관련 항목이 하나도 없어 직접 추가한다.
+set -ga update-environment GHOSTTY_RESOURCES_DIR
+set -ga update-environment GHOSTTY_BIN_DIR
+set -ga update-environment GHOSTTY_SHELL_FEATURES
+set -ga update-environment TERM_PROGRAM
+set -ga update-environment TERM_PROGRAM_VERSION
+set -ga update-environment TERMINFO
+
 # ============================================================
 # 클립보드 및 복사 설정 (OSC 52 지원)
 # ============================================================

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -120,6 +120,21 @@ if command -v bat &>/dev/null; then
 fi
 
 # ============================================================
+# Ghostty 셸 통합
+#
+# Ghostty는 자기가 직접 띄운 셸에만 통합을 자동 주입한다. 아래 tmux 블록이
+# exec tmux를 하므로 tmux가 다시 띄우는 셸에는 주입되지 않는다 —
+# ghostty-integration 파일 상단 주석이 tmux를 그 사례로 명시하고 이 코드를
+# 권장한다. 반드시 exec tmux **앞**에 두어야 한다(exec 이후는 실행 안 됨).
+#
+# 멱등하다: 비대화형 셸과 이미 초기화된 셸에서는 즉시 return 0 한다.
+# 켜지는 기능은 GHOSTTY_SHELL_FEATURES가 결정한다 (현재 cursor:blink,path,title).
+# ============================================================
+if [[ -n "$GHOSTTY_RESOURCES_DIR" ]]; then
+    source "$GHOSTTY_RESOURCES_DIR"/shell-integration/zsh/ghostty-integration
+fi
+
+# ============================================================
 # tmux 자동 연결 (재부팅 후에도 세션 복원)
 #
 # 주의: 이 로직을 바꾼 뒤에는 Ghostty를 Cmd+Q로 "완전 종료 후 재실행"


### PR DESCRIPTION
draft PR #10 분리 4/6. 스택 전체 목록은 #14 참조.

## 문제

Ghostty는 자기가 직접 띄운 셸에만 셸 통합을 주입합니다. `.zshrc`가 `exec tmux`를 하므로 tmux가 다시 띄우는 pane 셸에는 주입되지 않아, cursor blink·path·title 기능이 pane 안에서 죽어 있었습니다.

## 내용

- `dot_zshrc.tmpl`에서 `$GHOSTTY_RESOURCES_DIR`이 있을 때 `ghostty-integration`을 직접 source. **반드시 `exec tmux` 앞**에 둡니다 (`exec` 이후는 실행되지 않음). 멱등하므로 비대화형·중복 초기화 셸에서는 즉시 return 합니다
- `dot_tmux.conf.tmpl`에 `update-environment` 추가 — tmux 서버는 데몬이라 오래 살아남고, 기본값에 Ghostty 관련 항목이 하나도 없어 Ghostty를 재시작해도 서버가 옛 `GHOSTTY_*` 값을 계속 물려줍니다

## 검증

- `chezmoi execute-template`으로 두 템플릿 렌더 통과
- 현재 pane에서 `GHOSTTY_SHELL_FEATURES=cursor:blink,path,title`이 전달되는 것을 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)