### PR TITLE
refactor(terminal): Quick Terminal 제거

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -21,19 +21,3 @@ scrollback-limit = 1000000
 
 # 알림
 desktop-notifications = true
-
-# Quick Terminal
-#
-# Option+F10/F11/F12 3연속 체계로 통일한다.
-#   M-F10 = Quick Terminal (여기, Ghostty 전역)
-#   M-F11 = workmux dashboard popup (.tmux.conf, root 바인딩)
-#   M-F12 = tmux prefix (.tmux.conf)
-#
-# F10~F12는 macOS 기본이 미디어키(음소거/볼륨)이므로 fn을 함께 눌러야 한다
-# (fn+Option+F10). 음량 조절을 그대로 쓰기 위해 fnState는 바꾸지 않는다.
-keybind = global:alt+f10=toggle_quick_terminal
-quick-terminal-position = center
-quick-terminal-animation-duration = 0.15
-quick-terminal-screen = mouse
-quick-terminal-autohide = true
-quick-terminal-size = 60%, 80%

--- a/dot_tmux.conf.tmpl
+++ b/dot_tmux.conf.tmpl
@@ -152,9 +152,11 @@ bind = run-shell "$HOME/.local/bin/tmux-stack-layout"
 # ============================================================
 bind W display-popup -h 85% -w 90% -E "workmux dashboard"
 
-# prefix 없이 단일 조작으로도 띄운다. Option+F10/F11/F12 3연속 체계의 가운데다.
-#   M-F10 = Quick Terminal (Ghostty 전역), M-F12 = prefix
-# F10~F12는 macOS 기본이 미디어키라 fn을 함께 눌러야 한다 (fn+Option+F11).
+# prefix 없이 단일 조작으로도 띄운다. M-F11은 dashboard, M-F12는 prefix다
+# (prefix가 M-F12인 것은 macOS 분기뿐이다 — Linux는 C-b).
+# F11/F12는 macOS 기본이 미디어키(음소거/볼륨)라 fn을 함께 눌러야 한다
+# (fn+Option+F11). 번거롭지만 음량 키를 그대로 쓰기 위해 fnState는 의도적으로
+# 바꾸지 않는다.
 # root 테이블이므로 이 키는 pane 안 앱에 전달되지 않는다 —
 # nvim(F키·Alt 매핑 0개)·readline·Ghostty 어느 쪽과도 충돌하지 않음을 확인했다.
 bind -n M-F11 display-popup -h 85% -w 90% -E "workmux dashboard"

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -137,11 +137,14 @@ fi
 # ============================================================
 # tmux 자동 연결 (재부팅 후에도 세션 복원)
 #
-# 주의: 이 로직을 바꾼 뒤에는 Ghostty를 Cmd+Q로 "완전 종료 후 재실행"
-# 해야 적용된다. Ghostty quick terminal은 surface를 재사용하므로
-# (Ctrl+` 토글은 보이기/숨기기만 하고 .zshrc를 다시 읽지 않음),
-# 이미 열려 있던 quick 창은 옛 로직대로 main 세션에 계속 붙어 있는다.
-# GHOSTTY_QUICK_TERMINAL 환경변수는 Ghostty 1.3.0+ 에서 quick terminal에 설정됨.
+# 이 로직은 tmux 밖의 새 대화형 셸에서만 실행된다 — pane 안은 $TMUX 가드에
+# 걸려 애초에 대상이 아니다. `-A`라서 main 세션이 살아 있으면 그대로 붙고,
+# Ghostty를 완전히 종료해도 tmux 서버는 데몬으로 남아 세션이 유지된다. 세션
+# 자체를 새로 만들려면 `tmux kill-session -t main`이 필요하다.
+#
+# quick 세션 마이그레이션: 예전 Quick Terminal이 만든 `quick` 세션이 남아 있으면
+# resurrect가 스냅샷에 담아 재부팅마다 되살린다. `tmux kill-session -t quick`
+# 으로 지운 뒤 `prefix + C-s`로 다시 저장해야 사라진다.
 #
 # ORCA_PANE_KEY 가드: Orca(ADE)는 pane마다 ORCA_WORKTREE_ID,
 # ORCA_AGENT_HOOK_{PORT,TOKEN} 등을 주입하고 탭·split·스크롤백·세션 복원을
@@ -154,13 +157,8 @@ fi
 # ============================================================
 if command -v tmux &>/dev/null && [[ -z "$TMUX" ]] && [[ $- == *i* ]] \
     && [[ -z "$ORCA_PANE_KEY" ]]; then
-    if [[ -n "$GHOSTTY_QUICK_TERMINAL" ]]; then
-        # Quick Terminal → quick 세션
-        exec tmux new-session -A -s quick -c ~/code
-    else
-        # 일반 터미널 → main 세션 (continuum이 자동 복원)
-        exec tmux new-session -A -s main
-    fi
+    # 모든 대화형 터미널 → main 세션 (continuum이 자동 복원)
+    exec tmux new-session -A -s main
 fi
 
 # ============================================================


### PR DESCRIPTION
`feat/tmux-memory-monitoring`에 쌓여 있던 미머지 작업을 `origin/main` 기준으로 다시 계산해 3개로 분리한 것 중 **1/3**입니다.

## 스택

```
main
 └─ (1) refactor/remove-quick-terminal      ← 이 PR
     └─ (2) feat/tmux-resource-monitor
         └─ (3) feat/skill-move-window-to-session
```

위에서부터 순서대로 머지합니다.

## 내용

- `ghostty/config`: `global:alt+f10=toggle_quick_terminal`과 `quick-terminal-*` 옵션 5개 삭제
- `.zshrc`: `GHOSTTY_QUICK_TERMINAL` 분기 제거 → 모든 대화형 셸이 `tmux new-session -A -s main`
- `.tmux.conf`: M-F10(Quick Terminal) 언급이 사라진 만큼 M-F11 주석 정리

## 왜

Quick Terminal은 surface를 재사용해 토글로는 `.zshrc`를 다시 읽지 않습니다. 그래서 tmux 연결 로직을 바꿔도 이미 열려 있던 창은 옛 동작을 유지하는 함정이 있었습니다.

세션이 `main`/`quick` 둘로 갈리면서 resurrect 복원 대상과 workmux 부모 세션 판정도 갈라졌습니다 — `create-worktree` 스킬이 `--parent-session main`을 명시해야 했던 이유가 이것입니다.

## 검증

- `chezmoi execute-template`으로 `dot_tmux.conf.tmpl`, `dot_zshrc.tmpl` 렌더 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)