### PR TITLE
feat(tmux): 상태바 둘째 줄에 리소스 모니터 추가

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -21,4 +21,8 @@ setup.sh
 .hammerspoon/init.lua
 run_once_configure-keycastr.sh
 run_onchange_brew-bundle.sh
+# vm_stat·vm.swapusage·hw.memsize·kern.memorystatus_vm_pressure_level 가 전부
+# Darwin 전용이다. .tmux.conf 쪽도 darwin 분기로 막았고 스크립트 자체도 uname 을
+# 확인하지만, 애초에 배포하지 않는 것이 가장 확실하다.
+.local/bin/tmux-mem-status
 {{ end }}

--- a/dot_local/bin/executable_tmux-mem-status
+++ b/dot_local/bin/executable_tmux-mem-status
@@ -1,0 +1,465 @@
+#!/usr/bin/env bash
+# 시스템/에이전트 리소스 요약.
+#
+#   (인자 없음)  status-right 용 짧은 한 줄
+#   --wide       status-format[1] 용 전체 폭 한 줄
+#   --detail     popup 용 상세 (prefix + Option+m)
+#
+# ============================================================
+# 지표 선택 근거
+# ============================================================
+# tmux 생태계의 고전 플러그인들(tmux-mem-cpu-load, tmux-cpu-mem-monitor)이
+# 공통으로 쓰는 조합은 "메모리 used/total + CPU + load average 3개"다. 그 관례를
+# 따르되 두 가지를 바꿨다.
+#
+# 1. 즉시성 CPU% 대신 load average를 쓴다.
+#    macOS에서 즉시 CPU%를 얻으려면 top -l 1 이 필요한데 실측 675ms다.
+#    status-interval 5초마다 이걸 돌리는 건 과하다. sysctl -n vm.loadavg 는
+#    37ms이고, 고전 플러그인들도 load average를 함께 보여준다. 코어 수로
+#    나눈 포화도가 CPU%보다 오히려 해석하기 쉽다.
+#
+# 2. Ghostty RSS의 시간 변화량(Δ)을 추가했다. 어떤 플러그인도 안 하지만
+#    이 환경에서는 가장 중요한 값이다. ghostty#10258 reflow 누수를 겪어
+#    74GB까지 간 적이 있고, 절대값 "153M"만 보면 누수 중인지 알 수 없다.
+#    "153M ▲+2M/10m" 이어야 판단이 된다.
+#
+# 에이전트별 내역(claude/codex/MCP/nvim)은 이 환경 고유의 필요다. worktree
+# 윈도우마다 에이전트를 띄우면 claude 인스턴스당 약 490MB가 쌓인다. AI 에이전트
+# 모니터링 도구들(marmonitor, tmux-agent-sidebar, Termdock)도 같은 문제를 다루지만
+# 세션 상태·토큰·비용 중심이고 메모리는 부차적이라, 메모리는 직접 계산한다.
+#
+# ============================================================
+# 성능
+# ============================================================
+# status-interval(5초)마다 실행된다. ps 한 번 + sysctl 두 번 + vm_stat 한 번 +
+# 히스토리 파일 I/O. 실측 --wide 약 90ms. top(675ms)과
+# memory_pressure(23ms, 게다가 아래 이유로 부정확)는 쓰지 않는다.
+set -uo pipefail
+
+# ============================================================
+# macOS 전용
+# ============================================================
+# vm_stat, vm.swapusage, hw.memsize, kern.memorystatus_vm_pressure_level 가 모두
+# Darwin 전용이다. 다른 OS에서는 측정할 수 있는 것이 하나도 없는데, 실패를 0으로
+# 그리면 "완전히 유휴한 건강한 기계"로 보인다. 그래서 그렇게 말하고 끝낸다.
+# .chezmoiignore 와 .tmux.conf 의 darwin 분기가 1차 방어선이고 여기가 2차다.
+if [ "$(uname -s)" != Darwin ]; then
+  if [ "${1:-}" = "--detail" ]; then
+    printf 'tmux-mem-status 는 macOS 전용입니다 (현재 %s).\n' "$(uname -s)"
+    printf '\n아무 키나 누르면 닫힙니다.'
+    read -rsn1
+  else
+    printf ' #[fg=colour240]리소스 모니터: macOS 전용#[fg=colour248]'
+  fi
+  exit 0
+fi
+
+GHOSTTY_WARN_MB=1000     # 평소 150~250MB. 1GB를 넘으면 reflow 누수 의심
+GHOSTTY_DELTA_WARN_MB=50 # 10분에 이만큼 늘면 누수 진행 중으로 본다
+SWAP_WARN_MB=4096
+SWAP_CAUTION_MB=2048
+MEM_WARN_PCT=85
+MEM_CAUTION_PCT=70
+
+HIST_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/tmux-mem-status"
+HIST_FILE="$HIST_DIR/ghostty.log"
+HIST_WINDOW=600          # Δ 계산 구간 (초). 10분.
+
+# ============================================================
+# 수집
+# ============================================================
+
+# ps 의 comm 은 실행 파일 경로 전체다. Ghostty는
+# /Applications/Ghostty.app/Contents/MacOS/ghostty 로 나오므로 $2=="ghostty" 로
+# 비교하면 0이 된다. 또 공백이 든 경로가 91개 있어(Google Chrome 등) $2 만
+# 보면 "Google" 로 잘린다. 첫 필드 이후 전체를 경로로 취하고 basename 을 쓴다.
+#
+# MCP 판정(path ~ /mcp/)은 else-if 체인 밖에 있다 — 의도적이다. MCP 서버는
+# claude/codex와 별개 프로세스이므로 겹치지 않지만, 만약 에이전트 경로에 mcp가
+# 들어가면 그 값은 양쪽에 계상된다. 또 여러 프로세스의 RSS 단순 합산은 공유
+# 메모리를 중복 계산하므로 Activity Monitor 값과 정확히 일치하지 않는다.
+# 추세를 보는 용도이고 절대값 정확도를 주장하지 않는다.
+#
+# ps 가 실패하면 "-"를 내보낸다. 0으로 덮으면 에이전트가 9개 돌고 있는데도
+# 유휴 기계와 픽셀 단위로 같은 화면이 나온다.
+collect_procs() {
+  local raw
+  raw=$(ps -Ao rss=,comm= 2>/dev/null) || { echo "- - - - - -"; return 0; }
+  [ -n "$raw" ] || { echo "- - - - - -"; return 0; }
+  printf '%s\n' "$raw" | awk '
+    {
+      rss  = $1
+      path = substr($0, index($0, $2))
+      n = split(path, seg, "/")
+      name = seg[n]
+
+      if      (name == "ghostty") g += rss
+      else if (name == "claude")  { c += rss; cn++ }
+      else if (name == "codex")   x += rss
+      else if (name == "nvim")    v += rss
+      # MCP 서버는 이름이 제각각(mcp@latest, context7-mcp, ...)이라 경로로
+      # 식별한다. 합치면 GB 단위가 되므로 따로 보여줄 값어치가 있다.
+      if (path ~ /mcp/) m += rss
+    }
+    END { printf "%d %d %d %d %d %d\n", g+0, c+0, cn+0, x+0, v+0, m+0 }
+  '
+}
+
+# vm_stat 에는 compressor 가 든 줄이 둘이다:
+#   "Pages stored in compressor"   = 압축 전 원본 크기 (오해 유발)
+#   "Pages occupied by compressor" = 실제 점유 물리 메모리 (이게 맞다)
+# 앞을 앵커로 고정한다.
+#
+# 사용량은 active + wired + compressor 로 본다. Activity Monitor의 "사용된
+# 메모리"에 대응한다. "여유율"은 쓰지 않는다 — memory_pressure는 압축 메모리를
+# 분모에서 제외해 실제보다 낙관적으로 나온다(같은 시점 54% vs 35%).
+#
+# 페이지 크기는 상수로 박지 않는다. vm_stat 첫 줄이 알려주므로 추가 비용이 0이고,
+# 박아두면 Intel Mac(4096)에서 값이 4배로 틀린다.
+#   Mach Virtual Memory Statistics: (page size of 16384 bytes)
+collect_vm() {
+  local raw
+  raw=$(vm_stat 2>/dev/null) || { echo "- -"; return 0; }
+  [ -n "$raw" ] || { echo "- -"; return 0; }
+  printf '%s\n' "$raw" | awk '
+    NR == 1 { for (i = 1; i <= NF; i++) if ($i == "of") page = $(i+1) }
+    /^Pages active/                 { gsub(/\./,"",$3); act=$3 }
+    /^Pages wired down/             { gsub(/\./,"",$4); wired=$4 }
+    /^Pages occupied by compressor/ { gsub(/\./,"",$5); comp=$5 }
+    END {
+      if (page+0 == 0) { print "- -"; exit }
+      printf "%d %d\n", (act+wired+comp)*page/1024, comp*page/1024
+    }
+  '
+}
+
+# total = 4096.00M  used = 3305.88M  free = 790.12M  (encrypted)
+#
+# END 블록이 필수다. 없으면 입력이 빈 경우 출력이 한 줄도 없어서 호출부의
+# read 가 변수를 빈 문자열로 만들고, 뒤쪽 [ "$sw_used_mb" -ge ... ] 가
+# "integer expression expected" 로 터진다 (stderr는 tmux가 버려서 안 보인다).
+collect_swap() {
+  sysctl -n vm.swapusage 2>/dev/null | awk '
+    {
+      for (i = 1; i <= NF; i++) {
+        if ($i == "used")  { v = $(i+2); sub(/M$/, "", v); u = v; seen = 1 }
+        if ($i == "total") { v = $(i+2); sub(/M$/, "", v); t = v; seen = 1 }
+      }
+    }
+    END {
+      if (!seen) { print "- -"; exit }
+      printf "%d %d\n", u, t
+    }
+  '
+}
+
+# Ghostty RSS 히스토리를 남겨 Δ를 계산한다. 이 파일이 누수 판단의 근거다.
+# 형식: "<epoch> <rss_kb>" 한 줄씩. HIST_WINDOW 밖은 버린다.
+# 출력: 구간 내 최고(最古) 샘플과의 차이(KB)와 경과 분.
+#   히스토리가 아직 없으면 빈 값, 캐시에 쓸 수 없으면 "ERR".
+#
+# ── 손상 줄을 반드시 걸러야 하는 이유 ──
+# awk 의 `$1 >= now - w` 는 $1 이 숫자로 안 보이면 문자열 비교가 되어 항상 참이다.
+# 그 값이 셸 산술 $(( now - oldest_t )) 로 들어가면 set -u 가 이를 변수명으로 보고
+# unbound variable 로 서브셸을 죽인다. 죽는 곳이 프로세스 치환 안이라 본체는
+# 태연히 살아서 나머지 지표를 완벽하게 출력한다 — 즉 Δ 하나만 조용히 사라지고,
+# 정리 awk 도 같은 문자열 비교를 쓰므로 손상 줄이 영구히 살아남아 카나리아가
+# 영원히 죽는다. 그래서 두 awk 모두 NF·숫자 게이트를 통과한 줄만 취급하고,
+# 손상 줄은 보존하지 않고 폐기한다. rss 필드가 없는 부분 기록 줄도 같이 걸러진다
+# (빈 값은 셸 산술에서 0으로 승격되어 "현재 RSS 전체가 증가분"인 거짓 경보가 된다).
+ghostty_delta() {
+  local now="$1" rss="$2"
+  local oldest_t oldest_rss tmp
+  # $2 > 0 도 게이트에 넣는다. rss 0 은 "Ghostty 미실행"이라 기준선이 될 수 없다.
+  # 아래에서 0 을 기록하지 않게 막았지만, 그 이전에 쌓인 파일에는 0 샘플이 남아
+  # 있어 Ghostty 를 다시 붙일 때 "▲+59M" 거짓 누수 경보가 뜬다(재현됨).
+  local gate='NF == 2 && $1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ && $2 > 0'
+
+  mkdir -p "$HIST_DIR" 2>/dev/null || { echo ERR; return 0; }
+
+  if [ -f "$HIST_FILE" ]; then
+    read -r oldest_t oldest_rss < <(
+      awk -v now="$now" -v w="$HIST_WINDOW" \
+        "$gate && \$1 >= now - w { print \$1, \$2; exit }" "$HIST_FILE"
+    )
+  fi
+
+  # append 후 구간 밖 잘라내기. 파일이 무한정 자라지 않게 한다.
+  # tmp 이름에 $$ 를 붙이는 이유: 고정 이름이면 동시 실행 시 여러 awk 가 같은
+  # 파일을 O_TRUNC 로 열어 히스토리가 통째로 비워진다 (7개 동시 실행에서 재현됨).
+  # 하필 74GB 사고 당시가 클라이언트 7개였다 — 잡아야 할 상황에서 눈을 감는다.
+  printf '%s %s\n' "$now" "$rss" >> "$HIST_FILE" 2>/dev/null || { echo ERR; return 0; }
+  tmp="$HIST_FILE.$$"
+  awk -v now="$now" -v w="$HIST_WINDOW" "$gate && \$1 >= now - w" "$HIST_FILE" \
+    > "$tmp" 2>/dev/null && mv "$tmp" "$HIST_FILE" 2>/dev/null || rm -f "$tmp"
+
+  [ -z "${oldest_t:-}" ] && return 0
+  local span=$(( now - oldest_t ))
+  [ "$span" -lt 60 ] && return 0   # 1분 미만이면 노이즈다
+  printf '%d %d\n' "$(( rss - oldest_rss ))" "$(( span / 60 ))"
+}
+
+# ============================================================
+# 표시 보조
+# ============================================================
+
+human() {
+  awk -v kb="$1" 'BEGIN {
+    if (kb >= 1048576) printf "%.1fG", kb / 1048576
+    else               printf "%dM",   kb / 1024
+  }'
+}
+
+# 10칸 막대. tmux-mem-cpu-load 관례를 따른다.
+bar() {
+  awk -v pct="$1" 'BEGIN {
+    n = int(pct / 10 + 0.5); if (n > 10) n = 10; if (n < 0) n = 0
+    s = ""
+    for (i = 0; i < n; i++)  s = s "█"
+    for (i = n; i < 10; i++) s = s "░"
+    print s
+  }'
+}
+
+# 같은 세션에 폭이 다른 클라이언트가 붙어 있으면 reflow 누수 조건이 성립한다.
+# window-size latest 라서 포커스가 옮겨갈 때마다 그 세션의 모든 윈도우가 새 폭으로
+# 리사이즈되고, ghostty#10258 이 그 경로에서 메모리를 해제하지 않는다. 74GB 사고
+# 때가 정확히 이 상태였다(main 세션에 Orca 클라이언트 7개, 폭 134~319).
+# 세션이 다르면 윈도우가 독립적이라 진동하지 않으므로 경고하지 않는다.
+reflow_risk() {
+  tmux list-clients -F '#{client_session} #{client_width}' 2>/dev/null | awk '
+    { if (!(($1) in seen)) seen[$1] = $2
+      else if ($2 != seen[$1]) bad[$1] = seen[$1] "/" $2 }
+    END { for (s in bad) printf "%s %s ", s, bad[s] }
+  '
+}
+
+# ============================================================
+# 공통 수집 실행
+#
+# 수집 실패를 0으로 덮지 않는다. 덮으면 77% 쓰는 기계가 "MEM 0M 0%" 빈 막대로,
+# 11G 스왑을 쓰는 기계가 "스왑 0M/0M" 으로 보인다 — 응급 상황이 전면 정상으로
+# 표시되는 것이 이 도구에서 가장 나쁜 실패다. 실패한 값은 센티널("-")로 받아
+# *_ok 플래그로 옮기고, 표시 단계에서 "?" 와 경고색으로 그린다.
+# ============================================================
+is_num() { case "${1:-}" in ''|*[!0-9]*) return 1 ;; *) return 0 ;; esac; }
+
+read -r g_kb c_kb c_n x_kb v_kb m_kb < <(collect_procs)
+read -r used_kb comp_kb < <(collect_vm)
+read -r sw_used_mb sw_tot_mb < <(collect_swap)
+memsize=$(sysctl -n hw.memsize 2>/dev/null || echo -)
+ncpu=$(sysctl -n hw.ncpu 2>/dev/null || echo -)
+read -r l1 l5 l15 < <(sysctl -n vm.loadavg 2>/dev/null | tr -d '{}' | awk '{print $1, $2, $3}'; echo)
+plevel=$(sysctl -n kern.memorystatus_vm_pressure_level 2>/dev/null || echo -)
+
+proc_ok=1; is_num "$g_kb"       || { proc_ok=0; g_kb=0; c_kb=0; c_n=0; x_kb=0; v_kb=0; m_kb=0; }
+vm_ok=1;   is_num "$used_kb"    || { vm_ok=0;   used_kb=0; comp_kb=0; }
+swap_ok=1; is_num "$sw_used_mb" || { swap_ok=0; sw_used_mb=0; sw_tot_mb=0; }
+tot_ok=1;  is_num "$memsize"    || { tot_ok=0;  memsize=0; }
+tot_kb=$(( memsize / 1024 ))
+cpu_ok=1;  is_num "$ncpu"       || { cpu_ok=0;  ncpu=1; }
+load_ok=1; is_num "${l1%%.*}"   || { load_ok=0; l1=0; l5=0; l15=0; }
+
+mem_pct=0; mem_pct_ok=0
+if [ "$vm_ok" = 1 ] && [ "$tot_ok" = 1 ] && [ "$tot_kb" -gt 0 ]; then
+  mem_pct=$(( used_kb * 100 / tot_kb )); mem_pct_ok=1
+fi
+
+# SECONDS/date 없이 epoch 획득 (date 호출 1회)
+now=$(date +%s 2>/dev/null || echo -)
+
+# Δ는 Ghostty 가 실제로 돌고 있을 때만 계산한다. 미실행(0)을 정상 샘플로 기록하면
+# ssh/iTerm 으로 10분 작업한 뒤 Ghostty 를 붙일 때 "▲+59M/9m" 빨간 누수 경보가
+# 뜬다(재현됨). 종료하면 반대로 큰 음수가 뜬다. 거짓 경보는 진짜 경보를 무시하게
+# 만들므로, 0은 측정값이 아니라 "Ghostty 없음"이라는 별개 상태로 다룬다.
+g_delta_kb=""; g_delta_min=""
+if is_num "$now" && [ "$proc_ok" = 1 ] && [ "$g_kb" -gt 0 ]; then
+  read -r g_delta_kb g_delta_min < <(ghostty_delta "$now" "$g_kb"; echo)
+fi
+
+# ============================================================
+# --detail : popup
+# ============================================================
+if [ "${1:-}" = "--detail" ]; then
+  printf '리소스 상세 — %s\n\n' "$(date '+%Y-%m-%d %H:%M:%S')"
+
+  if [ "$mem_pct_ok" = 1 ]; then
+    printf '메모리       %8s / %-8s %3d%%  %s\n' \
+      "$(human "$used_kb")" "$(human "$tot_kb")" "$mem_pct" "$(bar "$mem_pct")"
+  else
+    printf '메모리       %8s   ← 측정 실패 (vm_stat / hw.memsize)\n' '?'
+  fi
+  printf '  압축       %8s\n' "$([ "$vm_ok" = 1 ] && human "$comp_kb" || echo '?')"
+  if [ "$swap_ok" = 1 ]; then
+    printf '  스왑       %8s / %-8s\n' \
+      "$(human $((sw_used_mb * 1024)))" "$(human $((sw_tot_mb * 1024)))"
+  else
+    printf '  스왑       %8s   ← 측정 실패 (vm.swapusage)\n' '?'
+  fi
+  printf '  커널 압박  %8s   (1=정상 2=경고 4=위험)\n' "$plevel"
+  if [ "$load_ok" = 1 ]; then
+    printf 'load        %8s %s %s   (%s코어 → 1분 포화도 %s%%)\n' \
+      "$l1" "$l5" "$l15" "$ncpu" "$(awk -v a="$l1" -v n="$ncpu" 'BEGIN{printf "%.0f", a*100/n}')"
+  else
+    printf 'load        %8s   ← 측정 실패 (vm.loadavg)\n' '?'
+  fi
+
+  printf '\nGhostty      %8s' "$([ "$proc_ok" = 1 ] && human "$g_kb" || echo '?')"
+  if [ "$proc_ok" != 1 ]; then
+    printf '   ← 측정 실패 (ps)'
+  elif [ "${g_delta_kb:-}" = ERR ]; then
+    printf '   (Δ 불가 — 캐시 쓰기 실패: %s)' "$HIST_DIR"
+  elif [ "$g_kb" = 0 ]; then
+    printf '   (Ghostty 미실행 — Δ 계산 안 함)'
+  elif [ -n "${g_delta_kb:-}" ]; then
+    printf '   최근 %s분 변화 %+dM' "$g_delta_min" "$(( g_delta_kb / 1024 ))"
+    [ "$(( g_delta_kb / 1024 ))" -ge "$GHOSTTY_DELTA_WARN_MB" ] && printf '  ← 누수 의심'
+  else
+    printf '   (Δ 측정 중 — 히스토리 축적 대기)'
+  fi
+  printf '\n             평소 150~250M. %dM 초과 또는 10분 %dM 증가면 reflow 누수 의심\n' \
+    "$GHOSTTY_WARN_MB" "$GHOSTTY_DELTA_WARN_MB"
+
+  if [ "$proc_ok" = 1 ]; then
+    printf '\nclaude       %8s   × %d개 (평균 %s)\n' \
+      "$(human "$c_kb")" "$c_n" "$([ "$c_n" -gt 0 ] && human $((c_kb / c_n)) || echo -)"
+    printf 'codex        %8s\n' "$(human "$x_kb")"
+    printf 'MCP 서버     %8s\n' "$(human "$m_kb")"
+    printf 'nvim         %8s\n' "$(human "$v_kb")"
+  else
+    printf '\n에이전트 내역 측정 실패 — ps 를 실행할 수 없다 (PATH 확인)\n'
+  fi
+
+  printf '\n--- 프로세스 그룹 상위 10 ---\n'
+  ps -Ao rss=,comm= 2>/dev/null | awk '
+    { path = substr($0, index($0, $2)); n = split(path, seg, "/"); s[seg[n]] += $1 }
+    END { for (k in s) printf "%d\t%s\n", s[k], k }
+  ' | sort -rn | head -10 | awk -F'\t' '{ printf "%9.1f MB  %s\n", $1/1024, $2 }'
+
+  printf '\n--- tmux 클라이언트 ---\n'
+  tmux list-clients -F '#{client_name}  세션=#{client_session}  #{client_width}x#{client_height}' 2>/dev/null \
+    || echo '(tmux 밖)'
+  risk=$(reflow_risk)
+  if [ -n "$risk" ]; then
+    printf '⚠ 같은 세션에 폭이 다른 클라이언트: %s\n' "$risk"
+    printf '  window-size latest 라서 포커스 전환마다 reflow가 일어난다 (ghostty#10258).\n'
+  else
+    printf '✓ 세션마다 클라이언트 폭이 일정 — reflow 누수 조건 아님\n'
+  fi
+
+  printf '\n아무 키나 누르면 닫힙니다.'
+  read -rsn1
+  exit 0
+fi
+
+# ============================================================
+# --wide : status-format[1] (전체 폭)
+# ============================================================
+if [ "${1:-}" = "--wide" ]; then
+  DIM='#[fg=colour240]'; FG='#[fg=colour248]'
+  RED='#[fg=colour196,bold]'; ORANGE='#[fg=colour214]'
+  out=""
+  add() { out="${out}${out:+ ${DIM}│${FG} }$1"; }
+
+  # --- 메모리 ---
+  if [ "$mem_pct_ok" = 1 ]; then
+    if   [ "$mem_pct" -ge "$MEM_WARN_PCT" ];    then mc="$RED"
+    elif [ "$mem_pct" -ge "$MEM_CAUTION_PCT" ]; then mc="$ORANGE"
+    else mc=""; fi
+    add "MEM ${mc}$(human "$used_kb")/$(human "$tot_kb") ${mem_pct}%${FG} ${DIM}$(bar "$mem_pct")${FG}"
+  else
+    add "${RED}MEM ?${FG}"
+  fi
+
+  add "압축 $([ "$vm_ok" = 1 ] && human "$comp_kb" || echo "${RED}?${FG}")"
+
+  if [ "$swap_ok" = 1 ]; then
+    if   [ "$sw_used_mb" -ge "$SWAP_WARN_MB" ];    then sc="$RED"
+    elif [ "$sw_used_mb" -ge "$SWAP_CAUTION_MB" ]; then sc="$ORANGE"
+    else sc=""; fi
+    add "스왑 ${sc}$(human $((sw_used_mb * 1024)))/$(human $((sw_tot_mb * 1024)))${FG}"
+  else
+    add "${RED}스왑 ?${FG}"
+  fi
+
+  case "$plevel" in
+    1) add "압박 정상" ;;
+    2) add "${ORANGE}압박 경고${FG}" ;;
+    4) add "${RED}압박 위험${FG}" ;;
+    *) add "${ORANGE}압박 ?${FG}" ;;
+  esac
+
+  # --- load: 코어 수로 나눈 포화도가 해석하기 쉽다 ---
+  if [ "$load_ok" = 1 ]; then
+    sat=$(awk -v a="$l1" -v n="$ncpu" 'BEGIN{printf "%.0f", a*100/n}')
+    if   [ "$sat" -ge 200 ]; then lc="$RED"
+    elif [ "$sat" -ge 100 ]; then lc="$ORANGE"
+    else lc=""; fi
+    # 1분 > 5분이면 상승 중
+    trend=$(awk -v a="$l1" -v b="$l5" 'BEGIN{ if (a > b*1.1) print "▲"; else if (a < b*0.9) print "▼"; else print "=" }')
+    add "LOAD ${lc}${l1}${FG} ${l5} ${l15} ${lc}${sat}%/$([ "$cpu_ok" = 1 ] && echo "${ncpu}코어" || echo '?코어') ${trend}${FG}"
+  else
+    add "${RED}LOAD ?${FG}"
+  fi
+
+  # --- Ghostty: 절대값 + Δ (누수 카나리아) ---
+  if [ "$proc_ok" != 1 ]; then
+    add "${RED}에이전트·Ghostty 측정실패(ps)${FG}"
+  else
+    if [ "$((g_kb / 1024))" -ge "$GHOSTTY_WARN_MB" ]; then gc="$RED"; else gc=""; fi
+    gtxt="Ghostty ${gc}$(human "$g_kb")${FG}"
+    if [ "${g_delta_kb:-}" = ERR ]; then
+      # 캐시에 쓸 수 없으면 Δ는 영구히 안 나온다. "측정 중"으로 위장하지 않는다.
+      gtxt="${gtxt} ${RED}Δ:err${FG}"
+    elif [ -n "${g_delta_kb:-}" ]; then
+      dmb=$(( g_delta_kb / 1024 ))
+      if [ "$dmb" -ge "$GHOSTTY_DELTA_WARN_MB" ]; then
+        gtxt="${gtxt} ${RED}▲+${dmb}M/${g_delta_min}m${FG}"
+      else
+        gtxt="${gtxt} ${DIM}$(printf '%+d' "$dmb")M/${g_delta_min}m${FG}"
+      fi
+    fi
+    add "$gtxt"
+
+    # --- 에이전트 내역 ---
+    agents=""
+    [ "$c_n" -gt 0 ]  && agents="claude $(human "$c_kb")×${c_n}"
+    [ "$x_kb" -gt 0 ] && agents="${agents}${agents:+  }codex $(human "$x_kb")"
+    [ "$m_kb" -gt 0 ] && agents="${agents}${agents:+  }MCP $(human "$m_kb")"
+    [ "$v_kb" -gt 0 ] && agents="${agents}${agents:+  }nvim $(human "$v_kb")"
+    [ -n "$agents" ] && add "$agents"
+  fi
+
+  risk=$(reflow_risk)
+  [ -n "$risk" ] && add "${RED}⚠ reflow위험 ${risk}${FG}"
+
+  printf ' %s' "$out"
+  exit 0
+fi
+
+# ============================================================
+# 기본 : status-right (짧게)
+# ============================================================
+if [ "$proc_ok" != 1 ]; then
+  g_out="#[fg=colour196,bold]G:?#[default]"
+elif [ "$((g_kb / 1024))" -ge "$GHOSTTY_WARN_MB" ]; then
+  g_out="#[fg=colour196,bold]G:$(human "$g_kb")#[default]"
+else
+  g_out="G:$(human "$g_kb")"
+fi
+
+if [ "$swap_ok" != 1 ]; then
+  sw_out="#[fg=colour196,bold]sw:?#[default]"
+elif [ "$sw_used_mb" -ge "$SWAP_WARN_MB" ]; then
+  sw_out="#[fg=colour196,bold]sw:$(human $((sw_used_mb * 1024)))#[default]"
+elif [ "$sw_used_mb" -ge "$SWAP_CAUTION_MB" ]; then
+  sw_out="#[fg=colour214]sw:$(human $((sw_used_mb * 1024)))#[default]"
+else
+  sw_out="sw:$(human $((sw_used_mb * 1024)))"
+fi
+
+if [ "$c_n" -gt 0 ]; then
+  printf '%s  C:%s×%d  %s' "$g_out" "$(human "$c_kb")" "$c_n" "$sw_out"
+else
+  printf '%s  %s' "$g_out" "$sw_out"
+fi

--- a/dot_tmux.conf.tmpl
+++ b/dot_tmux.conf.tmpl
@@ -163,6 +163,21 @@ bind -n M-F11 display-popup -h 85% -w 90% -E "workmux dashboard"
 bind G run-shell "workmux last-done"     # 마지막으로 끝난 에이전트로 이동
 bind Tab run-shell "workmux last-agent"  # 마지막 에이전트로 이동
 
+{{ if eq .chezmoi.os "darwin" -}}
+# ============================================================
+# 메모리 모니터링 (prefix + Option+m) — macOS only
+#
+# 상태바 둘째 줄에 요약이 상시 표시되고, 이 키로 상세를 popup으로 본다.
+# prefix M / prefix m 은 tmux 기본(select-pane -M/-m, 마크 pane)이 쓰므로
+# 건드리지 않고 M-m 을 쓴다. TPM(I/U/M-u/C-r/C-s)과도 겹치지 않는다.
+#
+# tmux-mem-status 는 vm_stat·sysctl vm.*/hw.* 에 의존하는 Darwin 전용이라
+# 이 블록 전체를 darwin 분기 안에 둔다. 분기 밖에 두면 server(Linux)에서
+# 둘째 줄이 영구히 "MEM 0M/0M 0%" 로 — 즉 완전히 건강한 유휴 기계로 — 보인다.
+# ============================================================
+bind M-m display-popup -h 80% -w 80% -E "$HOME/.local/bin/tmux-mem-status --detail"
+{{ end -}}
+
 # ============================================================
 # OSC 시퀀스 패스스루
 # ============================================================
@@ -175,13 +190,54 @@ set -g allow-passthrough on
 # 스타일
 set -g status-style "bg=colour236,fg=colour248"
 set -g status-left-length 30
-set -g status-right-length 60
+set -g status-right-length 70
 
 # 왼쪽: 세션 이름
 set -g status-left "#[fg=colour16,bg=colour75,bold] #S #[fg=colour75,bg=colour236] "
 
-# 오른쪽: 날짜/시간
+# 오른쪽: 날짜/시간만
+#
+# 리소스 표시는 두 번째 줄(status-format[1])로 옮겼다. 첫 줄은 윈도우 목록에
+# 쓴다 — worktree 이름이 길어서 렌더 폭이 535 칼럼이나 필요한데 가용 공간은
+# 300 칼럼 안팎이다. 여기에 리소스까지 넣으면 잘림이 더 심해진다.
+#
+# 주의: tmux-continuum이 런타임에 자기 저장 스크립트를 status-right 앞에
+# 덧붙인다(출력은 없다). 그래서 여기 값이 그대로 보이지 않고 앞에 #()가
+# 하나 더 붙어 있는 것이 정상이다.
 set -g status-right "#[fg=colour248] %m/%d %H:%M "
+
+{{ if eq .chezmoi.os "darwin" -}}
+# ============================================================
+# 상태바 두 번째 줄: 리소스 모니터링 — macOS only
+#
+#  MEM 15.0G/24.0G 62% ██████░░░░ │ 압축 8.7G │ 스왑 3.0G/4.0G │ 압박 경고 │
+#  LOAD 13.69 15.74 9.82 114%/12코어 ▼ │ Ghostty 125M +2M/9m │
+#  claude 2.4G×6  codex 832M  MCP 1.7G  nvim 662M
+#
+# 실측 표시 폭 180 칼럼(East Asian Width 기준, #[...] 제외). reflow 위험 경고가
+# 붙으면 "⚠ reflow위험 main 134/319" 29칼럼이 더해져 209 칼럼이 된다.
+# 그보다 좁으면 tmux가 잘라내고 align=left 라서 오른쪽부터 사라진다 — 즉 에이전트
+# 내역이 먼저 날아간다. 하필 reflow 경고가 뜨는 상황(74GB 사고 조건)에서 가장 길어
+# 지므로, 좁은 화면에서는 잘림을 전제로 읽어야 한다. 왼쪽에 중요한 지표를 둔 순서
+# (MEM → 스왑 → LOAD → Ghostty Δ → 에이전트)가 그 대비다.
+#
+# 화면 한 줄을 더 쓰는 대가로 첫 줄을 윈도우 목록에 온전히 내주고, 짧은
+# status-right에 억지로 밀어넣을 때보다 훨씬 많은 정보를 담는다.
+#
+# status-format[1] 기본값은 pane 목록(P: 접두사)이지만 교체할 수 있다.
+#
+# 지표 선택은 tmux-mem-cpu-load / tmux-cpu-mem-monitor 관례
+# (메모리 used/total + 막대 + load average 3개)를 따르되 두 가지를 바꿨다:
+#   - 즉시성 CPU% 대신 load average. macOS에서 CPU%를 얻으려면 top -l 1 이
+#     필요한데 실측 675ms로 5초 주기에 과하다. sysctl vm.loadavg 는 37ms다.
+#     코어 수로 나눈 포화도(114%/12코어)가 CPU%보다 해석하기 쉽다.
+#   - Ghostty RSS의 시간 변화량(Δ). 어떤 플러그인도 안 하지만 이 환경에서는
+#     가장 중요하다. 절대값 "125M"만으로는 누수 중인지 알 수 없고
+#     "125M ▲+300M/9m" 이어야 판단이 된다. 10분에 50MB 이상이면 빨강.
+# ============================================================
+set -g status 2
+set -g status-format[1] "#[align=left]#[fg=colour248]#($HOME/.local/bin/tmux-mem-status --wide)"
+{{ end -}}
 
 # 윈도우 탭: 비활성 (상태별 색상 분기)
 #   activity (출력 중)    = 초록 ● (진행 중)


### PR DESCRIPTION
분리 **2/3**. 스택은 (1) refactor/remove-quick-terminal → **(2) 이 PR** → (3) feat/skill-move-window-to-session.

## 내용

```
MEM 15.0G/24.0G 62% ██████░░░░ │ 압축 8.7G │ 스왑 3.0G/4.0G │ 압박 경고 │
LOAD 13.69 15.74 9.82 114%/12코어 ▼ │ Ghostty 125M +2M/9m │
claude 2.4G×6  codex 832M  MCP 1.7G  nvim 662M
```

- `~/.local/bin/tmux-mem-status` 신규 (327줄). `--wide`는 상태바용 한 줄, `--detail`은 popup용 상세
- `status-format[1]`로 상태바 둘째 줄을 쓴다. 첫 줄을 윈도우 목록에 온전히 내주기 위한 선택입니다 — worktree 이름이 길어 렌더 폭이 535칼럼 필요한데 가용 공간은 300칼럼 안팎이라, 리소스까지 넣으면 잘림이 심해집니다
- `prefix + M-m` 상세 popup. `prefix M`/`m`은 tmux 기본(`select-pane -M/-m`)이, TPM은 `I/U/M-u/C-r/C-s`를 쓰므로 어느 쪽과도 겹치지 않습니다

## 지표 선택

`tmux-mem-cpu-load` 관례(used/total + 막대 + load average 3개)를 따르되 둘을 바꿨습니다.

- **즉시성 CPU% 대신 load average** — macOS에서 CPU%는 `top -l 1`이 필요해 실측 675ms인데 `sysctl vm.loadavg`는 37ms입니다. 5초 주기에 675ms는 과합니다. 코어 수로 나눈 포화도(`114%/12코어`)가 CPU%보다 해석하기 쉽습니다
- **Ghostty RSS의 시간 변화량(Δ)** — 절대값 `125M`만으로는 누수 중인지 알 수 없고 `125M ▲+300M/9m`이어야 판단이 됩니다. 10분에 50MB 이상이면 빨강

## 검증

- `chezmoi execute-template`으로 `dot_tmux.conf.tmpl` 렌더 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)