### PR TITLE
feat(skills): move-window-to-session 추가와 worktree 스킬 개정

### DIFF
--- a/dot_agents/skills/create-worktree/SKILL.md
+++ b/dot_agents/skills/create-worktree/SKILL.md
@@ -7,12 +7,42 @@ description: Use when creating a new git worktree for a branch to work on in iso
 
 git worktree를 만들고 workmux로 tmux 윈도우를 연다. pane 레이아웃은
 `~/.config/workmux/config.yaml`(좌 nvim / 우상 / 우하)이 담당하므로 여기서
-tmux를 직접 조작하지 않는다.
+tmux를 직접 조작하지 않는다. 새 workmux 윈도우는 `main` 세션에 연다
+(이미 다른 세션으로 옮겨 둔 worktree는 예외 — 아래 "부모 tmux 세션" 참조).
 
 ## 파라미터
 
 - **args** (필수): 브랜치명 (예: `278-feat/chat-infrastructure`, `ZF-100-feat/login`)
 - args가 비어있으면 사용자에게 브랜치명을 물어본다.
+
+## 부모 tmux 세션
+
+window mode의 `workmux add`와 `workmux open` 호출에 `--parent-session main`을
+넘긴다. 실행 중인 에이전트가 `personal` 같은 다른 세션에 있어도 현재 세션을 부모로
+사용하지 않는다.
+
+```bash
+tmux list-sessions -F '#{session_name}' | grep -qxF -- main && echo 있음 || echo 없음
+```
+
+`has-session -t main`을 쓰지 않는 이유: tmux 타깃은 접두사 매칭을 하므로
+`maintenance` 세션만 있어도 exit 0을 낸다(실측). 없는데 있다고 판정하면 아래 오류
+처리가 발동하지 않는다.
+
+`main` 세션이 없으면 현재 세션으로 대체하지 말고 사용자에게 오류를 알린다.
+
+**예외 1 — 이미 옮겨 둔 worktree.** `workmux open`은 기존 worktree도 여는 명령이다.
+git config의 `workmux.worktree.{이름}.window-session`이 `main`이 아니면 그것은
+`move-window-to-session`으로 **의도적으로 옮긴** 것이므로, `--parent-session`을
+생략해 그 값을 존중한다. 무조건 붙이면 옮겨 둔 창을 조용히 `main`으로 되끌고 온다.
+
+```bash
+git -C {worktree경로} config --get workmux.worktree.{이름}.window-session
+```
+
+**예외 2 — 지원되지 않는 조합.** `--parent-session`은 session mode, 샌드박스 안,
+그리고 여러 worktree를 한 번에 만드는 경우(`--count`, `--foreach`, 여러 `--agent`,
+stdin)에는 거부된다. 그때는 생략한다.
 
 ## 실행 순서
 
@@ -32,19 +62,21 @@ git -C "$ROOT" config --get filter.git-crypt.smudge   # 값이 있으면 git-cry
 ### 스크립트가 있을 때 (git-crypt 저장소)
 
 `workmux add`를 쓰지 않는다. workmux는 내부적으로 `git worktree add`를 실행하는데,
-git-crypt 저장소에서는 그것이 smudge 필터 에러로 **실패한다**.
+git-crypt 저장소에서는 그것이 smudge 필터 에러로 **실패한다**. 아래 `--no-checkout`
+서술은 이 git-crypt 경로에 대한 것이다 — 래퍼의 비-git-crypt 분기는 평범한
+`git worktree add`를 쓴다.
 
 ```bash
-./scripts/create-worktree.sh {브랜치명}    # 필터 우회·키 링크·재체크아웃 + 의존성 설치
-workmux open {디렉토리명} --target-name {윈도우이름}  # 이슈 번호가 있을 때
-workmux open {디렉토리명}                             # 이슈 번호가 없을 때
+./scripts/create-worktree.sh {브랜치명}    # --no-checkout 생성·키 링크·체크아웃 + 의존성 설치
+workmux open {디렉토리명} --target-name {윈도우이름} --parent-session main  # 이슈 번호가 있을 때
+workmux open {디렉토리명} --parent-session main                            # 이슈 번호가 없을 때
 ```
 
 - **스크립트가 실패하면 여기서 멈춘다.** 종료 코드를 확인하고, 실패했으면
-  `workmux open`으로 넘어가지 않는다. 스크립트는 worktree를 만든 뒤 키 링크·재체크아웃·
-  의존성 설치를 하므로 뒤쪽에서 죽어도 worktree는 남는다 — 그 상태로 `workmux open`을
-  실행하면 성공해버려서 파일이 암호화된 채이거나 의존성이 없는 worktree를 정상으로
-  보고하게 된다.
+  `workmux open`으로 넘어가지 않는다. 스크립트는 worktree를 `--no-checkout`으로 만든 뒤
+  키 링크·체크아웃·의존성 설치를 하므로 뒤쪽에서 죽어도 worktree는 남는다 — 그 상태로
+  `workmux open`을 실행하면 성공해버려서 파일이 암호화된 채이거나 의존성이 없는
+  worktree를 정상으로 보고하게 된다.
 - 스크립트의 확인 프롬프트는 `-y`나 `yes |`로 우회하지 않고 사용자에게 직접 확인받는다.
 - **스크립트 출력에서 worktree 절대경로를 확보한다.** `workmux open`에 넘길
   디렉토리명은 그 경로의 basename이다 (아래 "이름 파생" 참조).
@@ -56,8 +88,8 @@ workmux open {디렉토리명}                             # 이슈 번호가 �
 workmux가 생성과 윈도우 구성을 한 번에 한다.
 
 ```bash
-workmux add {브랜치명} --target-name {윈도우이름}   # 이슈 번호가 있을 때
-workmux add {브랜치명}                              # 이슈 번호가 없을 때
+workmux add {브랜치명} --target-name {윈도우이름} --parent-session main  # 이슈 번호가 있을 때
+workmux add {브랜치명} --parent-session main                            # 이슈 번호가 없을 때
 ```
 
 ## 이름 파생
@@ -82,7 +114,7 @@ workmux add {브랜치명}                              # 이슈 번호가 없�
   들어가지만, `workmux add`는 브랜치명 슬러그를 써서 저장소 이름이 **없다**. 그래서
   `add` 경로에서는 두 저장소가 같은 브랜치명을 쓰면 두 번째가
   `✗ A tmux window named '...' already exists`로 실패한다 — 그때는
-  `--target-name {repo명}-{짧은이름}`으로 재시도한다.
+  `--target-name {repo명}-{짧은이름} --parent-session main`으로 재시도한다.
 
   workmux는 target name을 소문자로 정규화한다. 사용자에게 안내하거나 이후 명령에
   재사용할 이름은 정규화된 소문자 쪽이다.
@@ -93,20 +125,22 @@ workmux add {브랜치명}                              # 이슈 번호가 없�
 ## 마무리
 
 ```bash
-workmux list                                  # worktree 등록 확인 (MUX 열 ✓)
-tmux list-windows -a -F '#{window_name}'      # 실제 윈도우 이름 확인
+workmux list
+tmux list-windows -a -F '#{session_name}:#{window_index}\t#{window_name}'
 ```
 
 `workmux list`의 어떤 열에도 윈도우 이름이 없다. `MUX ✓`는 윈도우가 열렸다는 것만
 알려주므로, 사용자에게 윈도우 이름을 안내하기 전에 `tmux list-windows`로 실제 이름을
-확인한다 — 추측한 이름을 안내하면 사용자가 `workmux close`에 없는 이름을 넘기게 된다.
+확인한다. 실제 윈도우가 **git config의 `window-session`이 가리키는 세션**에 있는지도
+함께 검증한다 (새로 만든 것이면 `main`). 추측한 이름을 안내하면 사용자가
+`workmux close`에 없는 이름을 넘기게 된다.
 
 ## 주의사항
 
 - **git-crypt 저장소에서 `workmux add`를 쓰지 않는다.** 위 분기를 반드시 지킨다.
 - 에이전트(claude·codex)는 자동 실행되지 않는다. 레이아웃 설정이 nvim만 띄우고
   나머지 pane은 빈 셸로 열며, 필요할 때 사용자가 직접 시작한다.
-- 개발 서버는 이 레이아웃에 없다. Quick Command나 별도 윈도우로 띄운다 —
+- 개발 서버는 이 레이아웃에 없다. 별도 윈도우나 pane으로 띄운다 —
   worktree마다 상주시키면 포트가 충돌하고 개당 1~2GB를 쓴다.
 - 레이아웃을 바꾸려면 스킬이 아니라 `~/.config/workmux/config.yaml`을 고친다.
   저장소별로 다르게 하려면 저장소 루트에 `.workmux.yaml`을 둔다.

--- a/dot_agents/skills/move-window-to-session/SKILL.md
+++ b/dot_agents/skills/move-window-to-session/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: move-window-to-session
+description: Use when moving a tmux window to another session, reorganizing windows across tmux sessions, or splitting workmux worktree windows out of the main session
+---
+
+# Move Window To Session
+
+tmux 윈도우를 다른 세션으로 옮기고, 원본 세션의 번호 구멍을 메우고, workmux 기록과
+resurrect 저장까지 맞춘다.
+
+**순서가 핵심이다.** `tmux move-window`만 하면 workmux는 옛 세션을 계속 가리키고,
+저장 전에 재부팅되면 이동 자체가 사라진다. workmux에는 세션 간 윈도우 이동 명령이
+없어서(0.1.243까지 확인) 이 정리를 대신해 줄 도구가 없다 —
+`workmux --help`에 그런 명령이 생기면 이 스킬을 그것으로 대체한다.
+
+## 파라미터
+
+- **args** (선택): `<윈도우이름|세션:번호> <대상세션>`
+- args가 비어있으면 아래로 목록을 보여주고 사용자에게 선택을 요청한다.
+
+```bash
+tmux list-windows -a -F '#{session_name}:#{window_index}  #{window_name}  #{window_panes}p'
+```
+
+윈도우 여러 개를 받으면 각각에 대해 실행 순서를 반복하고, resurrect 저장은 **맨 마지막에 한 번만** 한다.
+
+## 이동 전에 잡아둘 것
+
+`move-window`는 배정된 인덱스를 출력하지 않고, 2단계 재정렬이 번호를 또 바꾼다.
+그래서 번호로 뒤를 쫓지 않고 **이동에도 불변인 식별자를 미리 잡는다.**
+pane id와 window id는 `move-window`로 바뀌지 않는다.
+
+```bash
+WID=$(tmux display-message -p -t {원본세션}:{번호} '#{window_id}')   # @N
+PANES=$(tmux list-panes -t {원본세션}:{번호} -F '#{pane_id}')        # %N %N ...
+```
+
+## 실행 전 필수 확인
+
+이동 전에 확인한다. 사후 복구가 어렵다.
+
+**1. 원본 세션이 비게 되는가**
+
+마지막 윈도우를 옮기면 **원본 세션이 소멸한다.** `detach-on-destroy`가 기본 `on`이라
+그 세션에 붙어 있던 클라이언트는 detach되고, 이 저장소는 `.zshrc`에서 `exec tmux`를
+하므로 **detach = Ghostty 창이 닫힌다.** 세션을 비울 상황이면 진행 전에 사용자에게 알린다.
+
+```bash
+tmux list-windows -t {원본세션} -F '#{window_index}' | wc -l   # 1이면 세션 소멸
+tmux list-clients -t {원본세션} -F '#{client_tty} #{client_session}'  # 붙어 있는 클라이언트
+```
+
+**2. 대상 세션이 있는가**
+
+`has-session`을 그냥 쓰면 안 된다. tmux 타깃은 **접두사 매칭**을 하므로
+`maintenance` 세션만 있어도 `has-session -t main`이 exit 0으로 "있음"을 낸다
+(실측). 그 상태로 1단계를 실행하면 세션이 새로 생기지도 않고 윈도우가 **엉뚱한
+기존 세션으로 조용히 들어간다** — 오타로 세션이 생기는 것보다 나쁘다.
+대소문자는 구분하므로(`ZZSRC` → exit 1) 대소문자 오타는 걸러진다.
+
+```bash
+tmux list-sessions -F '#{session_name}' | grep -qxF -- '{대상세션}' && echo 있음 || echo 없음
+```
+
+없으면 **오타로 엉뚱한 세션이 생기는 것을 막기 위해 이름을 사용자에게 확인받고** 만든다.
+
+```bash
+tmux new-session -d -s {대상세션}
+```
+
+## 실행 순서
+
+### 1. 이동 — 대상은 `세션:` 형태로만 지정한다
+
+```bash
+tmux move-window -s {원본세션}:{번호} -t {대상세션}:
+```
+
+`-t {대상세션}:{번호}`처럼 인덱스를 붙이면 그 번호가 쓰이고 있을 때
+`index in use: 0`으로 **실패한다.** 콜론까지만 쓰면 빈 번호에 붙는다.
+특정 위치에 꽂아야 할 때만 `-a`(뒤에 삽입) / `-b`(앞에 삽입)를 쓴다.
+
+`link-window`는 쓰지 않는다 — 윈도우가 두 세션에 동시에 속하게 되고,
+resurrect가 이를 링크로 저장하지 못해 복원 시 윈도우가 중복 생성된다.
+
+### 2. 원본 세션 번호 재정렬
+
+```bash
+tmux move-window -r -t {원본세션}:
+```
+
+`renumber-windows on`은 윈도우를 **닫을 때만** 발동하므로 이동 자리는 구멍으로 남는다.
+그리고 `-r`은 **`-t`가 가리키는 세션**을 재정렬한다 — `-r -s {원본세션}:0`은 조용히
+아무 일도 하지 않는다.
+
+### 3. workmux 기록 동기화 (workmux 윈도우일 때만)
+
+윈도우가 workmux worktree면 **두 곳**이 옛 세션명을 붙들고 있다. 둘 다 고친다.
+
+`{worktree명}`은 **`workmux list`의 `PATH` 열 basename(= 디렉터리명)**이다.
+`BRANCH` 열이나 tmux 윈도우 이름에서 유추하지 않는다 — 셋이 다 다를 수 있고
+(디렉터리 `fix-worktree-issue-window-name` ↔ 브랜치 `codex-pr-review-toolkit`),
+틀린 이름을 넘겨도 git은 **에러 없이** 새 섹션을 만들어 버린다. 실제 키는 옛 세션명을
+그대로 유지하므로 이 단계가 막으려던 실패가 그대로 남고 config에 쓰레기까지 쌓인다.
+
+```bash
+# (a) git config — workmux가 close/remove/open에서 윈도우를 찾는 근거
+git -C {worktree경로} config workmux.worktree.{worktree명}.window-session {대상세션}
+
+# (b) agent state — dashboard·last-done·last-agent 표시의 근거
+d="$HOME/.local/state/workmux/agents"
+sock=$(tmux display-message -p '#{socket_path}')
+boot=$(tmux display-message -p '#{start_time}')
+for p in $PANES; do
+  for f in "$d"/tmux__*.json; do
+    [ -e "$f" ] || continue
+    [ "$(jq -r '.pane_key.pane_id // ""' "$f")" = "$p" ] || continue
+    [ "$(jq -r '.pane_key.instance // ""' "$f")" = "$sock" ] || continue  # 다른 tmux 서버
+    [ "$(jq -r '.boot_id // ""' "$f")" = "$boot" ] || continue            # 이전 부팅 = resurrect 입력
+    jq --arg s "{대상세션}" --arg w "$(tmux display-message -p -t "$p" '#{window_name}')" \
+      '.session_name = $s | .window_name = $w' "$f" > "$f.tmp" && mv -- "$f.tmp" "$f"
+    echo "synced workmux agent state: $p → {대상세션}"
+  done
+done
+```
+
+**살아있는 pane의** state 파일은 삭제하지 않고 갱신한다. 지우면 에이전트 상태
+(윈도우 탭의 🤖/💬/✅, `prefix + G`의 `last-done` 대상)가 사라진다. 죽은 pane의
+고아 state를 지우는 것은 `remove-worktree` 스킬의 별개 절차다.
+
+돌고 있는 에이전트는 다음 status 이벤트에 `session_name`을 스스로 다시 쓰는 것으로
+보인다(`updated_ts`가 초 단위로 갱신된다). 확실히 이 블록이 필요한 대상은 이벤트가
+멈춘 **idle·done 기록**이다 — 그래도 전부 돌리는 편이 안전하고 비용도 없다.
+
+`instance`·`boot_id` 가드는 `remove-worktree` 스킬의 고아 정리와 같은 이유로 둔다 —
+다른 tmux 서버의 state를 건드리지 않고, 이전 부팅 state(`workmux resurrect`의 입력)를
+망가뜨리지 않는다.
+
+mode 자체를 세션으로 바꾸고 싶다면 이 스킬이 아니라 `workmux open {이름} --session`이다.
+다만 두 가지를 알고 써야 한다.
+
+- `--session`은 **mode 변경을 영구 저장한다.** 그 뒤로는 `--parent-session`이
+  `--parent-session requires window mode`로 거부되므로, `create-worktree`가 쓰는
+  조합이 깨진다. 되돌리려면 `--mode window`가 필요하다.
+- workmux가 레이아웃을 다시 구성하므로 **돌고 있는 에이전트가 유지되지 않는 것으로
+  보인다** — 문서에 명시가 없어 확인하지 못했다. 에이전트를 살린 채 옮기는 것이
+  목적이면 이 스킬의 `move-window`를 쓴다.
+
+### 4. resurrect 즉시 저장
+
+```bash
+"$(tmux show-options -gv @resurrect-save-script-path)"
+```
+
+continuum 자동 저장은 15분 주기라, 저장 전에 재부팅되면 이동 전 배치로 복원된다.
+경로를 하드코딩하지 말고 위 옵션에서 읽는다 — 플러그인 설치 경로(TPM / 패키지 매니저)가
+머신마다 다르다. 저장 내용이 직전 저장과 같으면 resurrect가 방금 쓴 파일을 지우므로
+새 `.txt`가 안 생길 수 있다. 정상이니 실패로 읽지 않는다.
+
+### 5. 마무리 보고
+
+```bash
+tmux display-message -p -t "$WID" '옮긴 윈도우: #{session_name}:#{window_index} #{window_name}'
+tmux list-windows -a -F '#{session_name}:#{window_index}  #{window_name}'
+```
+
+`$WID`로 조회하면 이름이 같은 윈도우가 둘 있어도 옮긴 그 윈도우를 정확히 짚는다.
+
+옮긴 윈도우의 새 위치, 원본 세션의 번호 상태, 원본 세션이 소멸했는지를 보고한다.
+
+## 함정
+
+| 증상 | 원인 | 대응 |
+|------|------|------|
+| `index in use: 0` | 대상 인덱스가 점유됨 | `-t {세션}:`으로 콜론까지만 지정 |
+| 원본에 번호 구멍 | `renumber-windows`는 close에만 발동 | `move-window -r -t {원본}:` |
+| `-r`이 먹지 않음 | `-s`로 세션을 줬다 / 대상 세션명이 틀렸다 (둘 다 exit 0 무동작) | `-r -t {원본}:` 로 정확한 이름 |
+| Ghostty 창이 닫힘 | 마지막 윈도우 이동 → 세션 소멸 → detach → `exec tmux`가 끝남 | 이동 전 잔여 윈도우 수 확인 |
+| dashboard가 옛 세션 표시 | agent state의 `session_name` 스테일 | 3-(b) |
+| `workmux close/remove`가 윈도우를 못 찾음 | git config `window-session` 스테일 | 3-(a) |
+| 재부팅 후 이동이 사라짐 | continuum 저장 주기 15분 | 4 |
+| 대상 세션에서 pane이 좁아 보임 | 대상 세션에 attach하는 시점의 클라이언트 크기로 맞춰짐 (`window-size latest`) | 정상. attach하면 해소된다 |
+
+## 사람이 직접 할 때
+
+에이전트 없이 손으로 할 때의 최소 절차. workmux 윈도우가 아니면 이걸로 충분하다.
+
+| 키 | 동작 |
+|----|------|
+| `prefix` → `.` | 대상 `세션:` 입력 (tmux 기본 `move-window`) |
+| `prefix` → `R` | 원본 세션 번호 재정렬 (그 세션 안에서 눌러야 한다) |
+| `prefix` → `C-s` | resurrect 즉시 저장 |
+
+workmux worktree 윈도우라면 3번 동기화가 빠지므로 이 스킬을 쓴다.

--- a/dot_agents/skills/remove-worktree/SKILL.md
+++ b/dot_agents/skills/remove-worktree/SKILL.md
@@ -21,10 +21,59 @@ workmux로 worktree와 tmux 윈도우를 함께 제거한다.
 ```bash
 workmux list                      # 대상 확인
 workmux remove {이름}             # worktree + tmux 윈도우 + 로컬 브랜치
+# 그리고 아래 "고아 agent state 정리"를 반드시 실행한다
 ```
 
 `workmux remove`는 기본적으로 **확인 프롬프트를 띄우고 미커밋 변경이 있으면 경고**한다.
 그 프롬프트를 `-f`로 우회하지 않고 사용자에게 직접 확인받는다.
+
+## 고아 agent state 정리 (workmux 0.1.233 버그 우회)
+
+**`workmux remove`·`close` 후에는 반드시 아래를 실행한다.** 안 하면 dashboard·sidebar·
+`workmux status`가 **전부** 빈 화면이 된다.
+
+```bash
+d="$HOME/.local/state/workmux/agents"
+live=$(tmux list-panes -a -F '#{pane_id}') || live=""
+if [ -d "$d" ] && [ -n "$live" ]; then
+  sock=$(tmux display-message -p '#{socket_path}')
+  boot=$(tmux display-message -p '#{start_time}')
+  for f in "$d"/tmux__*.json; do
+    [ -e "$f" ] || continue
+    [ "$(jq -r '.pane_key.instance // ""' "$f")" = "$sock" ] || continue  # 다른 tmux 서버
+    [ "$(jq -r '.boot_id // ""' "$f")" = "$boot" ] || continue            # 이전 부팅 = resurrect 입력
+    p=$(jq -r '.pane_key.pane_id // ""' "$f")
+    printf '%s\n' "$live" | grep -qxF -- "$p" && continue                 # 살아있는 pane
+    rm -f -- "$f" && echo "pruned stale workmux agent state: $p"
+  done
+fi
+```
+
+**왜 필요한가:** `remove`·`close`는 tmux 윈도우만 kill하고 agent state 파일은 지우지
+않는다. 원래는 reconcile이 나중에 수거하지만, v0.1.233의 `51bd57c6`(#209 수정)이 그
+수거 경로를 깨뜨렸다 — 없는 pane을 조회하면 tmux는 exit 0으로 빈 필드를 돌려주는데
+workmux가 이를 "판단 불가"로 보고 열거 **전체**를 에러로 중단한다. 그래서 **에이전트가
+돌던 worktree를 제거할 때마다 고아 파일이 하나씩 쌓이고 그 즉시 모든 뷰가 빈다.**
+`reap-agents`는 탈출구가 아니다 — 오래된 agent **프로세스**를 종료하는 명령이고
+state 파일은 지우지 않는다.
+
+두 가드는 workmux의 reconcile 로직을 그대로 따른 것이므로 **지우지 말 것**:
+- `instance` 비교 — 다른 tmux 서버의 state를 건드리지 않는다
+- `boot_id` 비교 — tmux/컴퓨터 크래시 후 남은 이전 부팅의 state는 `workmux resurrect`의
+  입력이다. 지우면 복구가 불가능해진다
+
+**삭제 조건은 upstream이 아니라 설치 버전이다.**
+[raine/workmux#213](https://github.com/raine/workmux/issues/213)은 upstream
+v0.1.234(2026-08-04)에서 이미 고쳐졌지만, 이 우회책은 **0.1.233에 고정된 머신**에
+필요하다. upstream 기준으로 읽고 지우면 `remove` 한 번에 모든 뷰가 비는 상태로
+되돌아간다. 아래가 참일 때만 이 섹션 전체를 삭제한다.
+
+```bash
+workmux --version   # 0.1.234 이상이면 이 섹션은 죽은 코드다
+```
+
+관련: 0.1.233은 `--parent-session`에 넘긴 세션명의 대소문자를 보존하지 않는다
+(v0.1.234에서 수정). `main`은 소문자라 현재 영향은 없다.
 
 ### 자주 쓰는 변형
 
@@ -46,6 +95,14 @@ workmux remove {이름}             # worktree + tmux 윈도우 + 로컬 브랜�
 ## 마무리
 
 `workmux list`로 최종 상태를 안내한다. 삭제된 항목이 목록에서 사라졌는지 확인한다.
+
+**`workmux list`만으로는 위 고아 state 실패를 잡을 수 없다.** 고아가 있어도 표는
+정상처럼 exit 0으로 출력되고 AGENT 열만 조용히 빈다. `workmux status`는 에러를
+찍으면서도 exit 0을 반환하므로 종료 코드로도 구분되지 않는다. 문자열로 확인한다.
+
+```bash
+workmux status 2>&1 | grep -q '^Error:' && echo "고아 state 남음 — prune 재실행 필요"
+```
 
 ## 주의사항
 

--- a/dot_claude/skills/create-worktree/SKILL.md
+++ b/dot_claude/skills/create-worktree/SKILL.md
@@ -10,12 +10,42 @@ allowed-tools: Bash
 
 git worktree를 만들고 workmux로 tmux 윈도우를 연다. pane 레이아웃은
 `~/.config/workmux/config.yaml`(좌 nvim / 우상 / 우하)이 담당하므로 여기서
-tmux를 직접 조작하지 않는다.
+tmux를 직접 조작하지 않는다. 새 workmux 윈도우는 `main` 세션에 연다
+(이미 다른 세션으로 옮겨 둔 worktree는 예외 — 아래 "부모 tmux 세션" 참조).
 
 ## 파라미터
 
 - **args** (필수): 브랜치명 (예: `278-feat/chat-infrastructure`, `ZF-100-feat/login`)
 - args가 비어있으면 사용자에게 브랜치명을 물어본다.
+
+## 부모 tmux 세션
+
+window mode의 `workmux add`와 `workmux open` 호출에 `--parent-session main`을
+넘긴다. 실행 중인 에이전트가 `personal` 같은 다른 세션에 있어도 현재 세션을 부모로
+사용하지 않는다.
+
+```bash
+tmux list-sessions -F '#{session_name}' | grep -qxF -- main && echo 있음 || echo 없음
+```
+
+`has-session -t main`을 쓰지 않는 이유: tmux 타깃은 접두사 매칭을 하므로
+`maintenance` 세션만 있어도 exit 0을 낸다(실측). 없는데 있다고 판정하면 아래 오류
+처리가 발동하지 않는다.
+
+`main` 세션이 없으면 현재 세션으로 대체하지 말고 사용자에게 오류를 알린다.
+
+**예외 1 — 이미 옮겨 둔 worktree.** `workmux open`은 기존 worktree도 여는 명령이다.
+git config의 `workmux.worktree.{이름}.window-session`이 `main`이 아니면 그것은
+`move-window-to-session`으로 **의도적으로 옮긴** 것이므로, `--parent-session`을
+생략해 그 값을 존중한다. 무조건 붙이면 옮겨 둔 창을 조용히 `main`으로 되끌고 온다.
+
+```bash
+git -C {worktree경로} config --get workmux.worktree.{이름}.window-session
+```
+
+**예외 2 — 지원되지 않는 조합.** `--parent-session`은 session mode, 샌드박스 안,
+그리고 여러 worktree를 한 번에 만드는 경우(`--count`, `--foreach`, 여러 `--agent`,
+stdin)에는 거부된다. 그때는 생략한다.
 
 ## 실행 순서
 
@@ -35,19 +65,21 @@ git -C "$ROOT" config --get filter.git-crypt.smudge   # 값이 있으면 git-cry
 ### 스크립트가 있을 때 (git-crypt 저장소)
 
 `workmux add`를 쓰지 않는다. workmux는 내부적으로 `git worktree add`를 실행하는데,
-git-crypt 저장소에서는 그것이 smudge 필터 에러로 **실패한다**.
+git-crypt 저장소에서는 그것이 smudge 필터 에러로 **실패한다**. 아래 `--no-checkout`
+서술은 이 git-crypt 경로에 대한 것이다 — 래퍼의 비-git-crypt 분기는 평범한
+`git worktree add`를 쓴다.
 
 ```bash
-./scripts/create-worktree.sh {브랜치명}    # 필터 우회·키 링크·재체크아웃 + 의존성 설치
-workmux open {디렉토리명} --target-name {윈도우이름}  # 이슈 번호가 있을 때
-workmux open {디렉토리명}                             # 이슈 번호가 없을 때
+./scripts/create-worktree.sh {브랜치명}    # --no-checkout 생성·키 링크·체크아웃 + 의존성 설치
+workmux open {디렉토리명} --target-name {윈도우이름} --parent-session main  # 이슈 번호가 있을 때
+workmux open {디렉토리명} --parent-session main                            # 이슈 번호가 없을 때
 ```
 
 - **스크립트가 실패하면 여기서 멈춘다.** 종료 코드를 확인하고, 실패했으면
-  `workmux open`으로 넘어가지 않는다. 스크립트는 worktree를 만든 뒤 키 링크·재체크아웃·
-  의존성 설치를 하므로 뒤쪽에서 죽어도 worktree는 남는다 — 그 상태로 `workmux open`을
-  실행하면 성공해버려서 파일이 암호화된 채이거나 의존성이 없는 worktree를 정상으로
-  보고하게 된다.
+  `workmux open`으로 넘어가지 않는다. 스크립트는 worktree를 `--no-checkout`으로 만든 뒤
+  키 링크·체크아웃·의존성 설치를 하므로 뒤쪽에서 죽어도 worktree는 남는다 — 그 상태로
+  `workmux open`을 실행하면 성공해버려서 파일이 암호화된 채이거나 의존성이 없는
+  worktree를 정상으로 보고하게 된다.
 - 스크립트의 확인 프롬프트는 `-y`나 `yes |`로 우회하지 않고 사용자에게 직접 확인받는다.
 - **스크립트 출력에서 worktree 절대경로를 확보한다.** `workmux open`에 넘길
   디렉토리명은 그 경로의 basename이다 (아래 "이름 파생" 참조).
@@ -59,8 +91,8 @@ workmux open {디렉토리명}                             # 이슈 번호가 �
 workmux가 생성과 윈도우 구성을 한 번에 한다.
 
 ```bash
-workmux add {브랜치명} --target-name {윈도우이름}   # 이슈 번호가 있을 때
-workmux add {브랜치명}                              # 이슈 번호가 없을 때
+workmux add {브랜치명} --target-name {윈도우이름} --parent-session main  # 이슈 번호가 있을 때
+workmux add {브랜치명} --parent-session main                            # 이슈 번호가 없을 때
 ```
 
 ## 이름 파생
@@ -85,7 +117,7 @@ workmux add {브랜치명}                              # 이슈 번호가 없�
   들어가지만, `workmux add`는 브랜치명 슬러그를 써서 저장소 이름이 **없다**. 그래서
   `add` 경로에서는 두 저장소가 같은 브랜치명을 쓰면 두 번째가
   `✗ A tmux window named '...' already exists`로 실패한다 — 그때는
-  `--target-name {repo명}-{짧은이름}`으로 재시도한다.
+  `--target-name {repo명}-{짧은이름} --parent-session main`으로 재시도한다.
 
   workmux는 target name을 소문자로 정규화한다. 사용자에게 안내하거나 이후 명령에
   재사용할 이름은 정규화된 소문자 쪽이다.
@@ -96,20 +128,22 @@ workmux add {브랜치명}                              # 이슈 번호가 없�
 ## 마무리
 
 ```bash
-workmux list                                  # worktree 등록 확인 (MUX 열 ✓)
-tmux list-windows -a -F '#{window_name}'      # 실제 윈도우 이름 확인
+workmux list
+tmux list-windows -a -F '#{session_name}:#{window_index}\t#{window_name}'
 ```
 
 `workmux list`의 어떤 열에도 윈도우 이름이 없다. `MUX ✓`는 윈도우가 열렸다는 것만
 알려주므로, 사용자에게 윈도우 이름을 안내하기 전에 `tmux list-windows`로 실제 이름을
-확인한다 — 추측한 이름을 안내하면 사용자가 `workmux close`에 없는 이름을 넘기게 된다.
+확인한다. 실제 윈도우가 **git config의 `window-session`이 가리키는 세션**에 있는지도
+함께 검증한다 (새로 만든 것이면 `main`). 추측한 이름을 안내하면 사용자가
+`workmux close`에 없는 이름을 넘기게 된다.
 
 ## 주의사항
 
 - **git-crypt 저장소에서 `workmux add`를 쓰지 않는다.** 위 분기를 반드시 지킨다.
 - 에이전트(claude·codex)는 자동 실행되지 않는다. 레이아웃 설정이 nvim만 띄우고
   나머지 pane은 빈 셸로 열며, 필요할 때 사용자가 직접 시작한다.
-- 개발 서버는 이 레이아웃에 없다. Quick Command나 별도 윈도우로 띄운다 —
+- 개발 서버는 이 레이아웃에 없다. 별도 윈도우나 pane으로 띄운다 —
   worktree마다 상주시키면 포트가 충돌하고 개당 1~2GB를 쓴다.
 - 레이아웃을 바꾸려면 스킬이 아니라 `~/.config/workmux/config.yaml`을 고친다.
   저장소별로 다르게 하려면 저장소 루트에 `.workmux.yaml`을 둔다.

--- a/dot_claude/skills/move-window-to-session/SKILL.md
+++ b/dot_claude/skills/move-window-to-session/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: move-window-to-session
+description: Use when moving a tmux window to another session, reorganizing windows across tmux sessions, or splitting workmux worktree windows out of the main session
+argument-hint: <window-name> <target-session>
+user-invocable: true
+allowed-tools: Bash
+---
+
+# Move Window To Session
+
+tmux 윈도우를 다른 세션으로 옮기고, 원본 세션의 번호 구멍을 메우고, workmux 기록과
+resurrect 저장까지 맞춘다.
+
+**순서가 핵심이다.** `tmux move-window`만 하면 workmux는 옛 세션을 계속 가리키고,
+저장 전에 재부팅되면 이동 자체가 사라진다. workmux에는 세션 간 윈도우 이동 명령이
+없어서(0.1.243까지 확인) 이 정리를 대신해 줄 도구가 없다 —
+`workmux --help`에 그런 명령이 생기면 이 스킬을 그것으로 대체한다.
+
+## 파라미터
+
+- **args** (선택): `<윈도우이름|세션:번호> <대상세션>`
+- args가 비어있으면 아래로 목록을 보여주고 사용자에게 선택을 요청한다.
+
+```bash
+tmux list-windows -a -F '#{session_name}:#{window_index}  #{window_name}  #{window_panes}p'
+```
+
+윈도우 여러 개를 받으면 각각에 대해 실행 순서를 반복하고, resurrect 저장은 **맨 마지막에 한 번만** 한다.
+
+## 이동 전에 잡아둘 것
+
+`move-window`는 배정된 인덱스를 출력하지 않고, 2단계 재정렬이 번호를 또 바꾼다.
+그래서 번호로 뒤를 쫓지 않고 **이동에도 불변인 식별자를 미리 잡는다.**
+pane id와 window id는 `move-window`로 바뀌지 않는다.
+
+```bash
+WID=$(tmux display-message -p -t {원본세션}:{번호} '#{window_id}')   # @N
+PANES=$(tmux list-panes -t {원본세션}:{번호} -F '#{pane_id}')        # %N %N ...
+```
+
+## 실행 전 필수 확인
+
+이동 전에 확인한다. 사후 복구가 어렵다.
+
+**1. 원본 세션이 비게 되는가**
+
+마지막 윈도우를 옮기면 **원본 세션이 소멸한다.** `detach-on-destroy`가 기본 `on`이라
+그 세션에 붙어 있던 클라이언트는 detach되고, 이 저장소는 `.zshrc`에서 `exec tmux`를
+하므로 **detach = Ghostty 창이 닫힌다.** 세션을 비울 상황이면 진행 전에 사용자에게 알린다.
+
+```bash
+tmux list-windows -t {원본세션} -F '#{window_index}' | wc -l   # 1이면 세션 소멸
+tmux list-clients -t {원본세션} -F '#{client_tty} #{client_session}'  # 붙어 있는 클라이언트
+```
+
+**2. 대상 세션이 있는가**
+
+`has-session`을 그냥 쓰면 안 된다. tmux 타깃은 **접두사 매칭**을 하므로
+`maintenance` 세션만 있어도 `has-session -t main`이 exit 0으로 "있음"을 낸다
+(실측). 그 상태로 1단계를 실행하면 세션이 새로 생기지도 않고 윈도우가 **엉뚱한
+기존 세션으로 조용히 들어간다** — 오타로 세션이 생기는 것보다 나쁘다.
+대소문자는 구분하므로(`ZZSRC` → exit 1) 대소문자 오타는 걸러진다.
+
+```bash
+tmux list-sessions -F '#{session_name}' | grep -qxF -- '{대상세션}' && echo 있음 || echo 없음
+```
+
+없으면 **오타로 엉뚱한 세션이 생기는 것을 막기 위해 이름을 사용자에게 확인받고** 만든다.
+
+```bash
+tmux new-session -d -s {대상세션}
+```
+
+## 실행 순서
+
+### 1. 이동 — 대상은 `세션:` 형태로만 지정한다
+
+```bash
+tmux move-window -s {원본세션}:{번호} -t {대상세션}:
+```
+
+`-t {대상세션}:{번호}`처럼 인덱스를 붙이면 그 번호가 쓰이고 있을 때
+`index in use: 0`으로 **실패한다.** 콜론까지만 쓰면 빈 번호에 붙는다.
+특정 위치에 꽂아야 할 때만 `-a`(뒤에 삽입) / `-b`(앞에 삽입)를 쓴다.
+
+`link-window`는 쓰지 않는다 — 윈도우가 두 세션에 동시에 속하게 되고,
+resurrect가 이를 링크로 저장하지 못해 복원 시 윈도우가 중복 생성된다.
+
+### 2. 원본 세션 번호 재정렬
+
+```bash
+tmux move-window -r -t {원본세션}:
+```
+
+`renumber-windows on`은 윈도우를 **닫을 때만** 발동하므로 이동 자리는 구멍으로 남는다.
+그리고 `-r`은 **`-t`가 가리키는 세션**을 재정렬한다 — `-r -s {원본세션}:0`은 조용히
+아무 일도 하지 않는다.
+
+### 3. workmux 기록 동기화 (workmux 윈도우일 때만)
+
+윈도우가 workmux worktree면 **두 곳**이 옛 세션명을 붙들고 있다. 둘 다 고친다.
+
+`{worktree명}`은 **`workmux list`의 `PATH` 열 basename(= 디렉터리명)**이다.
+`BRANCH` 열이나 tmux 윈도우 이름에서 유추하지 않는다 — 셋이 다 다를 수 있고
+(디렉터리 `fix-worktree-issue-window-name` ↔ 브랜치 `codex-pr-review-toolkit`),
+틀린 이름을 넘겨도 git은 **에러 없이** 새 섹션을 만들어 버린다. 실제 키는 옛 세션명을
+그대로 유지하므로 이 단계가 막으려던 실패가 그대로 남고 config에 쓰레기까지 쌓인다.
+
+```bash
+# (a) git config — workmux가 close/remove/open에서 윈도우를 찾는 근거
+git -C {worktree경로} config workmux.worktree.{worktree명}.window-session {대상세션}
+
+# (b) agent state — dashboard·last-done·last-agent 표시의 근거
+d="$HOME/.local/state/workmux/agents"
+sock=$(tmux display-message -p '#{socket_path}')
+boot=$(tmux display-message -p '#{start_time}')
+for p in $PANES; do
+  for f in "$d"/tmux__*.json; do
+    [ -e "$f" ] || continue
+    [ "$(jq -r '.pane_key.pane_id // ""' "$f")" = "$p" ] || continue
+    [ "$(jq -r '.pane_key.instance // ""' "$f")" = "$sock" ] || continue  # 다른 tmux 서버
+    [ "$(jq -r '.boot_id // ""' "$f")" = "$boot" ] || continue            # 이전 부팅 = resurrect 입력
+    jq --arg s "{대상세션}" --arg w "$(tmux display-message -p -t "$p" '#{window_name}')" \
+      '.session_name = $s | .window_name = $w' "$f" > "$f.tmp" && mv -- "$f.tmp" "$f"
+    echo "synced workmux agent state: $p → {대상세션}"
+  done
+done
+```
+
+**살아있는 pane의** state 파일은 삭제하지 않고 갱신한다. 지우면 에이전트 상태
+(윈도우 탭의 🤖/💬/✅, `prefix + G`의 `last-done` 대상)가 사라진다. 죽은 pane의
+고아 state를 지우는 것은 `remove-worktree` 스킬의 별개 절차다.
+
+돌고 있는 에이전트는 다음 status 이벤트에 `session_name`을 스스로 다시 쓰는 것으로
+보인다(`updated_ts`가 초 단위로 갱신된다). 확실히 이 블록이 필요한 대상은 이벤트가
+멈춘 **idle·done 기록**이다 — 그래도 전부 돌리는 편이 안전하고 비용도 없다.
+
+`instance`·`boot_id` 가드는 `remove-worktree` 스킬의 고아 정리와 같은 이유로 둔다 —
+다른 tmux 서버의 state를 건드리지 않고, 이전 부팅 state(`workmux resurrect`의 입력)를
+망가뜨리지 않는다.
+
+mode 자체를 세션으로 바꾸고 싶다면 이 스킬이 아니라 `workmux open {이름} --session`이다.
+다만 두 가지를 알고 써야 한다.
+
+- `--session`은 **mode 변경을 영구 저장한다.** 그 뒤로는 `--parent-session`이
+  `--parent-session requires window mode`로 거부되므로, `create-worktree`가 쓰는
+  조합이 깨진다. 되돌리려면 `--mode window`가 필요하다.
+- workmux가 레이아웃을 다시 구성하므로 **돌고 있는 에이전트가 유지되지 않는 것으로
+  보인다** — 문서에 명시가 없어 확인하지 못했다. 에이전트를 살린 채 옮기는 것이
+  목적이면 이 스킬의 `move-window`를 쓴다.
+
+### 4. resurrect 즉시 저장
+
+```bash
+"$(tmux show-options -gv @resurrect-save-script-path)"
+```
+
+continuum 자동 저장은 15분 주기라, 저장 전에 재부팅되면 이동 전 배치로 복원된다.
+경로를 하드코딩하지 말고 위 옵션에서 읽는다 — 플러그인 설치 경로(TPM / 패키지 매니저)가
+머신마다 다르다. 저장 내용이 직전 저장과 같으면 resurrect가 방금 쓴 파일을 지우므로
+새 `.txt`가 안 생길 수 있다. 정상이니 실패로 읽지 않는다.
+
+### 5. 마무리 보고
+
+```bash
+tmux display-message -p -t "$WID" '옮긴 윈도우: #{session_name}:#{window_index} #{window_name}'
+tmux list-windows -a -F '#{session_name}:#{window_index}  #{window_name}'
+```
+
+`$WID`로 조회하면 이름이 같은 윈도우가 둘 있어도 옮긴 그 윈도우를 정확히 짚는다.
+
+옮긴 윈도우의 새 위치, 원본 세션의 번호 상태, 원본 세션이 소멸했는지를 보고한다.
+
+## 함정
+
+| 증상 | 원인 | 대응 |
+|------|------|------|
+| `index in use: 0` | 대상 인덱스가 점유됨 | `-t {세션}:`으로 콜론까지만 지정 |
+| 원본에 번호 구멍 | `renumber-windows`는 close에만 발동 | `move-window -r -t {원본}:` |
+| `-r`이 먹지 않음 | `-s`로 세션을 줬다 / 대상 세션명이 틀렸다 (둘 다 exit 0 무동작) | `-r -t {원본}:` 로 정확한 이름 |
+| Ghostty 창이 닫힘 | 마지막 윈도우 이동 → 세션 소멸 → detach → `exec tmux`가 끝남 | 이동 전 잔여 윈도우 수 확인 |
+| dashboard가 옛 세션 표시 | agent state의 `session_name` 스테일 | 3-(b) |
+| `workmux close/remove`가 윈도우를 못 찾음 | git config `window-session` 스테일 | 3-(a) |
+| 재부팅 후 이동이 사라짐 | continuum 저장 주기 15분 | 4 |
+| 대상 세션에서 pane이 좁아 보임 | 대상 세션에 attach하는 시점의 클라이언트 크기로 맞춰짐 (`window-size latest`) | 정상. attach하면 해소된다 |
+
+## 사람이 직접 할 때
+
+에이전트 없이 손으로 할 때의 최소 절차. workmux 윈도우가 아니면 이걸로 충분하다.
+
+| 키 | 동작 |
+|----|------|
+| `prefix` → `.` | 대상 `세션:` 입력 (tmux 기본 `move-window`) |
+| `prefix` → `R` | 원본 세션 번호 재정렬 (그 세션 안에서 눌러야 한다) |
+| `prefix` → `C-s` | resurrect 즉시 저장 |
+
+workmux worktree 윈도우라면 3번 동기화가 빠지므로 이 스킬을 쓴다.

--- a/dot_claude/skills/remove-worktree/SKILL.md
+++ b/dot_claude/skills/remove-worktree/SKILL.md
@@ -24,10 +24,59 @@ workmux로 worktree와 tmux 윈도우를 함께 제거한다.
 ```bash
 workmux list                      # 대상 확인
 workmux remove {이름}             # worktree + tmux 윈도우 + 로컬 브랜치
+# 그리고 아래 "고아 agent state 정리"를 반드시 실행한다
 ```
 
 `workmux remove`는 기본적으로 **확인 프롬프트를 띄우고 미커밋 변경이 있으면 경고**한다.
 그 프롬프트를 `-f`로 우회하지 않고 사용자에게 직접 확인받는다.
+
+## 고아 agent state 정리 (workmux 0.1.233 버그 우회)
+
+**`workmux remove`·`close` 후에는 반드시 아래를 실행한다.** 안 하면 dashboard·sidebar·
+`workmux status`가 **전부** 빈 화면이 된다.
+
+```bash
+d="$HOME/.local/state/workmux/agents"
+live=$(tmux list-panes -a -F '#{pane_id}') || live=""
+if [ -d "$d" ] && [ -n "$live" ]; then
+  sock=$(tmux display-message -p '#{socket_path}')
+  boot=$(tmux display-message -p '#{start_time}')
+  for f in "$d"/tmux__*.json; do
+    [ -e "$f" ] || continue
+    [ "$(jq -r '.pane_key.instance // ""' "$f")" = "$sock" ] || continue  # 다른 tmux 서버
+    [ "$(jq -r '.boot_id // ""' "$f")" = "$boot" ] || continue            # 이전 부팅 = resurrect 입력
+    p=$(jq -r '.pane_key.pane_id // ""' "$f")
+    printf '%s\n' "$live" | grep -qxF -- "$p" && continue                 # 살아있는 pane
+    rm -f -- "$f" && echo "pruned stale workmux agent state: $p"
+  done
+fi
+```
+
+**왜 필요한가:** `remove`·`close`는 tmux 윈도우만 kill하고 agent state 파일은 지우지
+않는다. 원래는 reconcile이 나중에 수거하지만, v0.1.233의 `51bd57c6`(#209 수정)이 그
+수거 경로를 깨뜨렸다 — 없는 pane을 조회하면 tmux는 exit 0으로 빈 필드를 돌려주는데
+workmux가 이를 "판단 불가"로 보고 열거 **전체**를 에러로 중단한다. 그래서 **에이전트가
+돌던 worktree를 제거할 때마다 고아 파일이 하나씩 쌓이고 그 즉시 모든 뷰가 빈다.**
+`reap-agents`는 탈출구가 아니다 — 오래된 agent **프로세스**를 종료하는 명령이고
+state 파일은 지우지 않는다.
+
+두 가드는 workmux의 reconcile 로직을 그대로 따른 것이므로 **지우지 말 것**:
+- `instance` 비교 — 다른 tmux 서버의 state를 건드리지 않는다
+- `boot_id` 비교 — tmux/컴퓨터 크래시 후 남은 이전 부팅의 state는 `workmux resurrect`의
+  입력이다. 지우면 복구가 불가능해진다
+
+**삭제 조건은 upstream이 아니라 설치 버전이다.**
+[raine/workmux#213](https://github.com/raine/workmux/issues/213)은 upstream
+v0.1.234(2026-08-04)에서 이미 고쳐졌지만, 이 우회책은 **0.1.233에 고정된 머신**에
+필요하다. upstream 기준으로 읽고 지우면 `remove` 한 번에 모든 뷰가 비는 상태로
+되돌아간다. 아래가 참일 때만 이 섹션 전체를 삭제한다.
+
+```bash
+workmux --version   # 0.1.234 이상이면 이 섹션은 죽은 코드다
+```
+
+관련: 0.1.233은 `--parent-session`에 넘긴 세션명의 대소문자를 보존하지 않는다
+(v0.1.234에서 수정). `main`은 소문자라 현재 영향은 없다.
 
 ### 자주 쓰는 변형
 
@@ -49,6 +98,14 @@ workmux remove {이름}             # worktree + tmux 윈도우 + 로컬 브랜�
 ## 마무리
 
 `workmux list`로 최종 상태를 안내한다. 삭제된 항목이 목록에서 사라졌는지 확인한다.
+
+**`workmux list`만으로는 위 고아 state 실패를 잡을 수 없다.** 고아가 있어도 표는
+정상처럼 exit 0으로 출력되고 AGENT 열만 조용히 빈다. `workmux status`는 에러를
+찍으면서도 exit 0을 반환하므로 종료 코드로도 구분되지 않는다. 문자열로 확인한다.
+
+```bash
+workmux status 2>&1 | grep -q '^Error:' && echo "고아 state 남음 — prune 재실행 필요"
+```
 
 ## 주의사항
 


### PR DESCRIPTION
분리 **3/3**. 스택은 (1) refactor/remove-quick-terminal → (2) feat/tmux-resource-monitor → **(3) 이 PR**.

## move-window-to-session (신규)

tmux 윈도우를 다른 세션으로 옮기는 것 자체는 `tmux move-window` 한 줄이지만, 뒷정리가 세 곳으로 흩어져 있어 스킬로 묶었습니다.

- **git config `workmux.worktree.<name>.window-session`** — workmux가 `close`/`remove`/`open`에서 윈도우를 찾는 근거. workmux 0.1.233에는 세션 간 이동 명령도, 이 키를 자동 복구하는 경로도 없습니다
- **agent state의 `session_name`** — dashboard·`last-done` 표시의 근거. 삭제가 아니라 갱신합니다. 지우면 살아있는 pane의 에이전트 상태(🤖/💬/✅)가 사라집니다
- **resurrect 즉시 저장** — continuum 자동 저장은 15분 주기라 그 전에 재부팅되면 이동이 사라집니다. 경로는 `@resurrect-save-script-path`에서 읽습니다 (`@resurrect-dir`이 기본값이 아니므로 하드코딩 금지)

실기로 확인한 함정도 담았습니다.

| 증상 | 원인 |
|------|------|
| `index in use: 0` | `-t 세션:번호`로 인덱스를 붙였다 → `-t 세션:`으로 콜론까지만 |
| 원본에 번호 구멍 | `renumber-windows on`은 close에만 발동 |
| `-r`이 먹지 않음 | `move-window -r`은 `-s`가 아니라 **`-t` 세션**을 재정렬한다 |
| Ghostty 창이 닫힘 | 마지막 윈도우 이동 → 세션 소멸 → `detach-on-destroy` → `exec tmux`가 끝남 |

절차 전체를 실제 tmux/workmux에 돌려 검증했습니다 (임시 세션 2개 + 임시 state 파일 + 임시 git repo로 1~4단계 통과, 잔여물 0).

## create-worktree

- `--parent-session main`을 모든 `workmux add`/`open`에 넘깁니다. 에이전트가 다른 세션에서 돌고 있어도 현재 세션을 부모로 쓰지 않습니다
- git-crypt 래퍼가 `--no-checkout`으로 만든 뒤 체크아웃한다는 실제 순서로 정정
- 마무리 확인에서 윈도우가 `main` 세션에 있는지도 검증

## remove-worktree

- workmux 0.1.233의 **고아 agent state 정리 절차** 추가. `remove`·`close`가 state 파일을 남기는데 v0.1.233이 reconcile 수거 경로를 깨뜨려(raine/workmux#213) dashboard·`workmux status`가 **전부** 빈 화면이 됩니다

## main 쪽을 유지한 부분

옛 브랜치에는 #8보다 오래된 내용이 있어 그대로 덮으면 되돌아갑니다. 아래는 `origin/main`을 유지했습니다.

- `remove-worktree`의 "디렉토리명을 쓴다 / 윈도우 이름에서 유추하지 않는다" 문단 (#8)
- `docs/superpowers/{plans,specs}/2026-07-29-worktree-issue-window-name*` (#8이 정교화한 스펙)
- `remove-worktree/agents/openai.yaml`의 예시 — 옛 브랜치의 `392-...`는 윈도우 이름이라 위 규칙과 어긋납니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)