### PR TITLE
fix(zsh): nvm default 를 실제로 쓰게 하고 claude settings 를 관리에서 뺀다

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -15,6 +15,14 @@ tests/**
 # 제외한다. 사람이 정한 설정만 docs/codex-config-reference.toml에 기록해 둔다.
 .codex/config.toml
 
+# 이 저장소는 public이고, 홈의 settings.json에는 autoMode.environment가 들어 있다.
+# 그 안에 조직명·비공개 저장소 경로·시크릿 환경변수 이름·k8s 네임스페이스·민감 데이터
+# 위치가 담기므로 소스로 편입하면 그대로 공개된다. 반대로 관리하면 apply 때마다 그
+# 블록(과 modelSettings의 effortLevel)이 삭제된다. 양쪽 다 안 되므로 제외한다.
+# 사람이 정한 공통 설정(hooks·permissions 등)은 docs/claude-settings-reference.json에
+# 남겨 두었다 — 새 머신에서는 그것을 보고 직접 넣는다.
+.claude/settings.json
+
 # server: macOS 전용 항목만 제외
 {{ if eq .machine_type "server" }}
 .Brewfile

--- a/docs/claude-settings-reference.json
+++ b/docs/claude-settings-reference.json
@@ -122,7 +122,8 @@
     "context7@claude-plugins-official": true,
     "figma@claude-plugins-official": true,
     "codex@openai-codex": true,
-    "claude-md-management@claude-plugins-official": true
+    "claude-md-management@claude-plugins-official": true,
+    "claude-seo@agricidaniel-claude-seo": true
   },
   "extraKnownMarketplaces": {
     "superpowers-marketplace": {
@@ -135,6 +136,12 @@
       "source": {
         "source": "github",
         "repo": "openai/codex-plugin-cc"
+      }
+    },
+    "agricidaniel-claude-seo": {
+      "source": {
+        "source": "github",
+        "repo": "AgriciDaniel/claude-seo"
       }
     }
   },

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -101,6 +101,28 @@ export PATH="$HOME/.local/bin:$PATH"
 export PATH="$PATH:$HOME/.pub-cache/bin"
 export PATH="$PATH:$HOME/.maestro/bin"
 
+# nvm 경로를 PATH 맨 앞으로 끌어온다.
+#
+# nvm.sh 를 source 하는 것만으로는 `node` 가 nvm 판으로 잡히지 않는다. nvm 은 PATH 에
+# nvm 경로가 이미 있으면 **그 자리에서 버전만 교체**하기 때문이다(실측: 8번 위치의
+# v24.18.1/bin 이 v24.19.0/bin 으로 바뀌지만 위치는 8번 그대로). tmux 서버가 물려주는
+# PATH 에 nvm 이 Homebrew 뒤에 박혀 있으면 그 순서가 새 셸마다 재생산되고, 결과적으로
+# Homebrew node 가 계속 이긴다 — `nvm current` 가 `system` 을 내고 `node` 는
+# /opt/homebrew/bin/node 였다. Homebrew node 는 firebase-cli·supabase 의 의존성이라
+# 지울 수 없으므로 여기서 순서를 바로잡는다.
+#
+# `nvm use` 를 다시 부르지 않는다 — 위 이유로 효과가 없고 약 150ms 를 더한다. nvm.sh
+# 가 이미 올바른 버전의 경로를 넣어 두었으니 그 항목을 앞으로 옮기기만 하면 되고,
+# 이 방식은 외부 명령을 쓰지 않아 비용이 없다.
+if [[ -n "${NVM_DIR:-}" ]]; then
+    _nvm_paths=("${(@M)path:#$NVM_DIR/versions/node/*/bin}")
+    if (( $#_nvm_paths )); then
+        path=("${_nvm_paths[@]}" "${(@)path:#$NVM_DIR/versions/node/*/bin}")
+        export PATH
+    fi
+    unset _nvm_paths
+fi
+
 # ============================================================
 # Aliases
 # ============================================================

--- a/run_onchange_before_install-nvm.sh.tmpl
+++ b/run_onchange_before_install-nvm.sh.tmpl
@@ -24,7 +24,10 @@ nvm use default
 
 expected_nvm_version="${NVM_VERSION#v}"
 actual_nvm_version="$(nvm --version)"
-actual_node_version="$(node --version)"
+# PATH 로 찾지 않는다. nvm 은 PATH 에 nvm 경로가 이미 있으면 그 자리에서 버전만
+# 교체하므로, Homebrew node 가 앞에 있으면 `nvm use` 뒤에도 `node` 는 Homebrew 판을
+# 가리킨다(실측). nvm 이 default 로 제공하는 바이너리에 직접 물어본다.
+actual_node_version="$("$(nvm which default)" --version)"
 default_node_version="$(nvm version default)"
 
 if [[ "$actual_nvm_version" != "$expected_nvm_version" ]]; then


### PR DESCRIPTION
## nvm 이 PATH 에서 밀리는 문제

`nvm current` 가 `system` 이고 `node` 가 `/opt/homebrew/bin/node`(v26) 로 잡혀 있었다. nvm.sh 를 source 해도 소용없는 이유는 nvm 이 PATH 에 nvm 경로가 이미 있으면 **그 자리에서 버전만 교체**하기 때문이다.

실측 (PATH 위치):
```
[로드 전]   homebrew/bin=5   nvm .../v24.18.1/bin=8
[nvm.sh 후] homebrew/bin=5   nvm .../v24.19.0/bin=8   ← 버전만 바뀌고 위치는 그대로
[nvm use 후] homebrew/bin=5   nvm .../v24.19.0/bin=8   ← 여전히 8번
```

tmux 서버가 물려주는 PATH 에 nvm 이 Homebrew 뒤에 박혀 있으면 그 순서가 새 셸마다 재생산된다. Homebrew node 는 `firebase-cli`·`supabase` 의 의존성이라 지울 수 없다.

- `dot_zshrc.tmpl`: PATH 설정이 끝난 뒤 nvm 경로를 맨 앞으로 옮긴다. `nvm use` 는 다시 부르지 않는다 — 위 이유로 효과가 없고 약 150ms 를 더한다. zsh 파라미터 확장만 써서 외부 명령이 없어 비용이 0이다.
- `run_onchange_before_install-nvm.sh.tmpl`: 검증이 `node --version` 으로 PATH 를 보다가 Homebrew 판을 읽고 실패했다(`Expected Node.js v24.x, got v26.7.0`). 이 스크립트는 `run_onchange_before` 라서 실패하면 **apply 전체가 중단되고** brew-bundle 도 실행되지 않는다. nvm 이 default 로 제공하는 바이너리에 직접 물어보도록 고쳤다.

## .claude/settings.json 을 관리에서 제외

이 저장소는 **public** 인데 홈의 settings.json 에는 `autoMode.environment` 가 있고 그 안에 조직명·비공개 저장소 경로·시크릿 환경변수 이름·k8s 네임스페이스·민감 데이터 위치가 담긴다.

- 소스로 편입하면 → 공개된다
- 관리하면 → apply 때마다 그 블록과 `modelSettings` 의 `effortLevel` 이 삭제된다

홈이 소스의 상위집합이다(소스 전용 키 0개, 홈 전용 5개). `.codex/config.toml` 과 같은 방식으로 `.chezmoiignore` 에 이유와 함께 제외하고, 사람이 정한 공통 설정은 `docs/claude-settings-reference.json` 으로 옮겨 남겼다(`docs/**` 는 배포 제외).

**트레이드오프**: 새 머신에서는 hooks·permissions 를 참조본을 보고 직접 넣어야 한다.

## 검증

chezmoi 렌더 + `zsh -n` + `bash -n`·shellcheck 통과. 렌더된 zshrc 를 실제로 source 해 `node` 가 nvm v24.19.0, `nvm current` 가 v24.19.0, nvm 경로가 PATH 1번이 되는 것을 확인했다. nvm 미로드 셸에서도 오류가 없다. `chezmoi status` 에서 `.claude/settings.json` 항목이 사라졌다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)