### PR TITLE
docs(quality-goal): #28·#35 실전 1·2차 실행 보고서 기록

### DIFF
--- a/docs/development/2026-08-27-create-worktree-pr-session-2/report.md
+++ b/docs/development/2026-08-27-create-worktree-pr-session-2/report.md
@@ -1,0 +1,230 @@
+# Quality Goal Report
+
+- Task ID: 20260827T111202Z-28-35-create-worktree-스킬-재실행-pr-링크-입력-시-ea9373b7
+- Mode: standard
+- Status: NEEDS_REDESIGN
+- Created: 2026-08-27T11:12:02Z
+- Updated: 2026-08-27T11:12:02Z
+- Source goal: #28 #35 create-worktree 스킬 재실행 — PR 링크 입력 시 2-review 세션에 PR 번호 윈도우를 생성하고 대상 세션을 직접 지정하도록 확장한다. SPEC-011(창 탐지 규칙)과 SPEC-012({이름} 정의)를 Spec 초안에 선반영한다
+
+## Classification
+
+선택 모드: **standard** (사용자가 `--mode=standard` 명시. 위험 스캔 결과와 동일하므로
+다운그레이드 확인 불필요).
+
+**strict 트리거 0건.** 인증·인가·테넌시, 결제·정산·쿠폰 회계, PII·보안통제·시크릿,
+DB·스키마 마이그레이션·백필·파괴적 작업, 공개 API·웹훅·큐·멱등성·동시성, 프로덕션
+인프라 중 어느 것도 해당하지 않는다. 변경 대상은 chezmoi 소스 트리의 Markdown/YAML
+스킬 지침이며 롤백은 `git revert` + `chezmoi apply`로 단순하다. git-crypt 키 링크와
+unlock은 대상 저장소의 자체 래퍼가 전담하고(`zambaguni-front/scripts/create-worktree.sh:100-160`)
+이번 변경이 래퍼를 수정하지 않으므로 스킬 텍스트가 키 자료를 다루지 않는다.
+
+**standard 조건 4가지 성립.**
+
+1. 다중 파일·레이어 — #35가 지정한 3개 파일이 Claude/Codex 두 런타임 트리에 걸친다.
+2. 인터페이스·상태 전이 변경 — 대상 세션 인자와 PR 참조 모드 추가, `argument-hint`·
+   `description` 변경, 4단계 세션 선택 우선순위 신설.
+3. 비자명한 신규 인터페이스 의존 — `workmux add --pr`, `workmux list --json`,
+   `git fetch origin refs/pull/N/head`, `gh` 조회, `tmux list-panes -a`.
+4. 대안·비범위·수용 기준의 명시 필요 — #35에 비범위 절과 완료 조건, #28에도 완료 조건이
+   있으며 두 이슈를 충돌 없이 결합해야 한다.
+
+**이슈 라벨 증거.** #35에 `enhancement` 라벨(신규 기능 요청). #28은 라벨 없음. 라벨은
+보조 증거이며 위 위험 스캔 결과를 대체하지 않는다 — 스캔 단독으로도 standard가 성립한다.
+
+**이슈 재검증.** 두 이슈 모두 OPEN, 코멘트 0건이라 선행 실행 이후 요구사항 변경이 없다.
+
+## Review history
+
+| 아티팩트 | 라운드 | 점수 | 판정 | 블로커 | Critical/High | 게이트 실패 사유 |
+|---|---|---|---|---|---|---|
+| Spec | 1 | 80 | REVISE | 0건 | 0건 | `score_below_85`, `verdict_not_pass`, `check_failed:acceptance_criteria_objective` |
+| Spec | 2 | 88 | REVISE | 0건 | 0건 | `verdict_not_pass`, `check_failed:acceptance_criteria_objective` |
+
+Plan 및 코드 리뷰 라운드는 수행되지 않았다 (Spec 단계에서 종료).
+
+**선행 실행 대비.** 같은 목표의 2026-08-27 첫 실행은 75점(블로커 3건, High 3건) →
+82점(High 2건)이었다. 이번 실행은 그 두 High를 초안에 선반영해 시작한 결과 **처음부터
+블로커·High가 0건**이었고, 점수는 80 → 88로 통과선 85를 넘겼다. 남은 것은 Medium 2건
+뿐이다.
+
+**라운드 간 변화.** 라운드 1의 8건(Medium 6, Low 2)을 모두 개정했고, 라운드 2 리뷰어가
+8건 전부의 해소를 증거와 함께 확인했다. 개정 과정에서 AC-9의 대체 문구에 새 결함이
+생겨 SPEC-009로 잡혔고, 초안부터 있던 `--pr` 인자 정규화 누락이 SPEC-010으로 잡혔다.
+
+스킬 규칙상 Spec 리뷰는 최대 2라운드이므로(`references/spec-rubric.md`의 "After round 2
+without a passing gate, stop and record `NEEDS_REDESIGN`") 여기서 종료한다.
+
+## Blocking-finding resolutions
+
+**이번 실행에는 블로커로 지정된 항목이 없다.** 두 라운드 모두 `blockers` 배열이 비어
+있었고 Critical/High 심각도 발견도 0건이었다. 아래는 라운드 1의 Medium/Low 8건과 그
+해소 내용이며, 각 항목은 라운드 2 리뷰어가 독립적으로 해소를 확인했다.
+
+| ID | 심각도 | 해소 내용 | 라운드 2 확인 |
+|---|---|---|---|
+| SPEC-001 | Medium | R7.5가 `window_id`(`@N`)를 `move-window-to-session`에 그대로 넘겼으나 그 스킬의 계약은 `<윈도우이름\|세션:번호>`다. 호출 직전 `tmux display-message -p -t "{window_id}"`로 `세션:번호`를 해석해 넘기고, worktree 경로·handle을 컨텍스트로 전달하며, 사후엔 같은 `window_id`로 재확인하도록 고쳤다(D12) | "RESOLVED. ... This matches the skill's declared contract and its internal use of {worktree경로}/{worktree명}" |
+| SPEC-002 | Medium | AC-43이 R7.3(같은 세션 중복 창 금지)을 검증한다고 했으나 지목한 스모크 단계는 **다른** 세션을 써서 R7.5를 태우고 있었다. 스모크를 3차로 분리 — 1차 신규 생성, 2차 같은 세션(R7.3), 3차 다른 세션(R7.5·R2.4)(D10) | "RESOLVED. AC-46 and AC-48 now point at phases that actually create their branch conditions" |
+| SPEC-003 | Medium | Goal 5의 "회귀 없음"이 검증 불가였고, 현행 규칙 중 "git-crypt 필터는 있으나 래퍼가 없는 경우"가 누락돼 있었다. R6.10으로 그 규칙을 되살리고, 보존 대상 규칙 18개를 R9.6에 열거해 AC-56으로 확인하게 했다(D14) | "RESOLVED. R6.10 restates the rule and its citation was verified accurate; R9.6 enumerates 18 preserved rules" |
+| SPEC-004 | Medium | `argument-hint`만 갱신하고 `description`은 브랜치만 언급한 채였다. `description`은 에이전트가 라우팅에 쓰는 문장이라 PR 자연어 호출이 스킬에 도달하지 못할 수 있다. R9.5로 양쪽 갱신을 요구하고 AC-55로 검증(D13) | "RESOLVED. R9.5 requires updating the description frontmatter in both SKILL.md files" |
+| SPEC-005 | Medium | 형식은 유효하나 사라진 저장 세션이 매 호출 무조건 중단을 유발해 자기 교정 경로가 없었다. R2.5로 4단계 복구(알림 → 기본값 제시 → 확인 후 config 갱신 → 자동 생성 금지)를 정의 | "RESOLVED. R2 priority 2 now requires the stored session to exist; R2.5 defines the four-step recovery" |
+| SPEC-006 | Medium | AC-9의 "브랜치 유추 키 조회가 exit 1"이 미정의였고 우연 일치 시 올바른 구현에도 실패할 수 있었다. `workmux add --pr 31 --dry-run` 실측으로 **이 PR의 handle이 실제로 브랜치 슬러그와 같음**을 확인해 우려가 실재함을 입증하고, AC-9을 "존재하는 키가 handle 기준인지"로 바꾸며 브랜치 유추 프로브를 조건부 증거로 강등(D4) | "RESOLVED as to the original defect ... A distinct new defect in the replacement wording is filed as SPEC-009" |
+| SPEC-007 | Low | R4.2가 base 저장소와 현재 저장소를 비교하는데 두 값의 출처가 미정의였다. R4.0으로 입력 형태별 `{owner}/{repo}` 확정 표와 `gh repo view` + `git remote` 폴백·중단 규칙을 추가 | "RESOLVED. R4.0 defines {owner}/{repo} resolution per input form" |
+| SPEC-008 | Low | 증거 기록의 `awk`가 변수 미바인딩 형태라 출력을 낼 수 없는 명령이었고, 공백 경로 한계가 미기재였다. 실제 실행한 `-v wt="$WT"` 형태로 정정하고 R7.1에 공백 경로 한계와 그 경우의 불일치 처리를 명시 | "RESOLVED. The transcript now shows the executed form with the variable bound" |
+
+## Plan approval
+
+- Approval timestamp: 해당 없음 — Spec 단계에서 종료되어 Plan을 작성하지 않았다.
+- Plan digest: 해당 없음.
+
+사용자 승인 게이트(`AWAITING_PLAN_APPROVAL`)에 도달하지 않았다.
+
+## Changed files
+
+구현이 시작되지 않았으므로 **저장소 소스 파일 변경은 없다.** 이번 실행이 생성한 파일은
+산출물 문서뿐이다.
+
+| 경로 | 종류 | 내용 |
+|---|---|---|
+| `docs/development/2026-08-27-create-worktree-pr-session-2/spec.md` | 산출물 | 개정된 Spec (SHA-256 `130e179c1949748667f8e072f32bdcce00eea6c679f9472afd434eaae2654737`) |
+| `docs/development/2026-08-27-create-worktree-pr-session-2/report.md` | 산출물 | 이 보고서 |
+
+의도한 변경 대상이었으나 **손대지 않은** 파일:
+
+- `dot_agents/skills/create-worktree/SKILL.md`
+- `dot_claude/skills/create-worktree/SKILL.md`
+- `dot_agents/skills/create-worktree/agents/openai.yaml`
+
+baseline 리비전은 `6d8ccad16b4f8345130fe56913a2eead4169030f`이며, initial dirty path로
+선행 실행 산출물 `docs/development/2026-08-27-create-worktree-pr-session/`이 기록되었다.
+그 디렉터리는 이번 실행에서 읽기만 했고 수정하지 않았다.
+
+## Verification evidence
+
+구현 단계에 도달하지 않았으므로 **코드 검증은 수행되지 않았다.** 아래는 Spec 작성과
+분류 근거를 위해 실제 실행한 명령이다.
+
+### 실행한 명령
+
+| 명령 | 종료 코드 | 증거 |
+|---|---|---|
+| `git rev-parse --is-inside-work-tree` | 0 | `true` |
+| `codex --version` | 0 | `codex-cli 0.149.1` |
+| `codex exec --sandbox read-only --ephemeral --model gpt-5.6-terra -c model_reasoning_effort="low" "Reply with one non-empty line."` | 0 | 비어 있지 않은 응답 — 선택 모델 preflight 통과 |
+| `git check-ignore -v .claude/quality-state/` | 0 | `.gitignore:25` — 런타임 상태가 이미 무시됨 |
+| `gh issue view 28 --json state,labels,comments` | 0 | `OPEN`, 라벨 없음, 코멘트 0건 |
+| `gh issue view 35 --json state,labels,comments` | 0 | `OPEN`, `enhancement`, 코멘트 0건 |
+| `quality_state.py select-resume` | 0 | `{"match":null}` — 선행 실행이 터미널이라 resume 후보 아님 |
+| `workmux --version` | 0 | `workmux 0.1.248` |
+| `workmux add --help` | 0 | `--pr <NUMBER\|URL>`, `--name`, `--target-name`, `--parent-session`, `--dry-run` 존재 |
+| `workmux open --help` | 0 | `--pr` 없음. `--target-name`, `--parent-session` 있음 |
+| `workmux list --help` | 0 | `--json` 존재 |
+| `workmux list` | 0 | 디렉터리 `feat-quality-goal-skill` ↔ 브랜치 `chore/post-upgrade-skill-maintenance` (불일치 실례) |
+| `workmux list --json` | 0 | `handle`, `path`, `branch`, `is_open`, `mode`, `is_main` 필드 확인 |
+| `workmux add --pr 31 --dry-run` | 0 | Worktree `.../30-enhancement-tmux-open-pr-shortcut`, Target `30-enhancement-tmux-open-pr-shortcut` — **handle이 브랜치 슬러그와 일치**. 영속 변경 없음 |
+| `git -C {worktree} config --get-regexp '^workmux\.worktree\.'` | 0 | `workmux.worktree.feat-quality-goal-skill.mode`, `...window-session 3-personal` |
+| `git -C {worktree} config --get 'workmux.worktree.post-upgrade-skill-maintenance.window-session'` | 1 | 출력 없음 — 브랜치 유추 키는 값이 없음 |
+| `tmux list-panes -a -F '...' \| awk -v wt=...` | 0 | `3-personal:2 @19 %60 {worktree경로}` — 이름 독립 매칭 성공 |
+| `tmux -L quality-goal-nonexistent-socket list-sessions` | 1 | `error connecting to ...` — 서버 부재 감지 (별도 소켓, 실서버 무영향) |
+| `tmux list-sessions \| grep -qxF -- 'definitely-not-a-session'` | 1 | 없는 세션 판정 |
+| `tmux has-session -t 2` | 0 | 접두사 함정 재현 (세션 `2`는 없음) |
+| `tmux has-session -t 2-rev` | 0 | 접두사 함정 재현 |
+| `tmux list-sessions \| grep -qxF -- '2-rev'` | 1 | `grep -qxF`는 올바르게 불일치 판정 |
+| `gh repo view --json owner,name -q '...'` | 0 | `lee-kyu-hwan/dotfiles` |
+| `git remote get-url origin` | 0 | `git@github.com:lee-kyu-hwan/dotfiles.git` |
+| `gh pr view 31 --json state,headRefName,headRefOid` | 0 | `OPEN`, `30-enhancement/tmux-open-pr-shortcut`, `9cfc6267ced574945814536710cf1019a37dc354` |
+| `git ls-remote origin '30-enhancement/tmux-open-pr-shortcut'` | 0 | `9cfc6267...` — 원격 head 생존 |
+| `git ls-remote origin 'refs/pull/31/head'` | 0 | `9cfc6267...` 동일 |
+| `gh pr view 32 --json state,headRefName` | 0 | `OPEN`, `feat/codex-playwright-e2e-profile` |
+| `git config --get filter.git-crypt.smudge` (dotfiles) | 1 | 값 없음 — git-crypt 아님 |
+| `git config --get filter.git-crypt.smudge` (zambaguni-front) | 0 | `"git-crypt" smudge` |
+| `quick_validate.py dot_agents/skills/create-worktree` | 0 | `Skill is valid!` |
+| `quick_validate.py dot_claude/skills/create-worktree` | 0 | Claude 전용 키 안내 출력, 종료 코드는 0 |
+| `sed -n 3p` 두 SKILL.md | 0 | `description` 양쪽 동일, 브랜치만 언급 |
+| `validate_review.py validate` (라운드 1) | 0 | `{"valid":true,"errors":[]}` |
+| `validate_review.py gate` (라운드 1) | 3 | `score_below_85`, `verdict_not_pass`, `check_failed:acceptance_criteria_objective` |
+| `validate_review.py validate --prior` (라운드 2) | 0 | `{"valid":true,"errors":[]}` |
+| `validate_review.py gate --prior` (라운드 2) | 3 | `verdict_not_pass`, `check_failed:acceptance_criteria_objective` — **점수는 통과** |
+
+### 검증 카테고리 상태
+
+| 카테고리 | 상태 | 근거 |
+|---|---|---|
+| 표적 테스트 | `not configured` | `package.json`, `Makefile`, `justfile` 부재 확인 |
+| 전체 스위트 | `not configured` | 같음 |
+| 타입 체크 | `not configured` | 같음 |
+| 린트 | `not configured` | `.pre-commit-config.yaml`에 gitleaks 훅만 존재 (시크릿 스캔 전용) |
+| 빌드 | `not configured` | `package.json`, `.github/workflows` 부재 확인 |
+| E2E / 수동 검증 | **미실행** | 구현 단계에 도달하지 않아 Spec의 3층 스모크 테스트(dotfiles PR #31, 1~3차)를 실행하지 않았다. 통과로 기록하지 않는다. 다만 `--dry-run`으로 예상 산출물은 부작용 없이 확인했다 |
+
+## Remaining advisory findings
+
+### Medium (게이트 실패에 기여)
+
+| ID | 요약 | 영향 | 후속 조치 |
+|---|---|---|---|
+| SPEC-009 | AC-9의 대체 문구가 교란되어 올바른 구현에도 실패한다. workmux는 worktree 키를 **공유 저장소 config**에 handle로 구분해 쓰므로(`move-window-to-session/SKILL.md:113-115`), `git config --get-regexp '^workmux\.worktree\.'`는 저장소의 **모든** worktree 키를 돌려준다. 스모크 시점에 `workmux.worktree.feat-quality-goal-skill.*`가 남아 있어 "모든 키가 테스트 대상 handle 기준"이 성립하지 않는다. 반대로 대상 worktree로 범위를 좁히면 이번 케이스는 handle == 브랜치 슬러그라 동어반복이 된다 | R2.0의 유추 금지 규칙이 실행으로 검증되지 않는다 | (a) 키 단언을 테스트 대상 worktree로 한정하고 무관한 handle은 명시적으로 무시할 것. (b) handle == 브랜치 슬러그일 때도 판별력이 남는 프로브를 추가할 것 — 예를 들어 handle(`feat-quality-goal-skill`)과 브랜치(`chore/post-upgrade-skill-maintenance`)가 다른 **기존 worktree**에 대한 읽기 전용 검사. 그 worktree의 브랜치 유추 키가 exit 1임은 이미 실측되어 있다 |
+| SPEC-010 | `workmux add --pr {PR참조}`가 원시 사용자 입력을 그대로 넘긴다. `--pr`의 계약은 `<NUMBER\|URL>`인데(Spec 자신의 사실표 실측) R1.4가 허용하는 세 형태 중 `{owner}/{repo}#{번호}`와 표지 있는 자연어는 workmux가 거부한다. R4.0·R4.1이 번호와 저장소를 이미 분해하지만, `--pr`에 도달하기 전 정규화한다는 요구사항이 없다 | 세 입력 형태 중 둘이 실패한다 | PR 참조를 R4.0·R4.1이 확정한 `{번호}`(저장소가 다르면 정규 URL)로 환원하는 단계를 명시하고, R6.3과 Interfaces 블록을 `--pr {PR번호}`로 바꿀 것. 정규화된 값이 명령에 들어가는지 확인하는 AC를 추가할 것 |
+
+### 프로세스 관찰
+
+**#44 우회 효과.** 선행 실행에서 라운드 2 리뷰어가 이전 라운드 findings를 검증하지
+못했던 문제(이슈 #44)를 이번에는 finding ID와 함께 **설명 원문과 적용한 해소 내용**을
+전달해 우회했다. 그 결과 라운드 2 리뷰어가 8건 전부의 해소를 개별 증거와 함께 확인했고,
+"새 finding이 이전 항목을 재진술했을 가능성" 같은 불확실성이 사라졌다. 이 우회는
+`Review invocation contract`의 "prior open finding IDs" 규정을 넘어서므로, 계약 자체를
+넓힐지는 #44에서 다룰 사안이다.
+
+**`required_sections` 게이트 항목의 근거 부재.** 라운드 2 리뷰어가 이 항목을 확정하지
+못했다고 기록했다 — `spec-rubric.md:16`이 항목 이름만 대고 필수 섹션 목록을 열거하지
+않기 때문이다. 오케스트레이터는 `templates/spec.md`와 대조해 11개 섹션이 모두 존재함을
+확인했고 `true`로 기록했으나, 리뷰어가 독립적으로 확인할 수단이 없다. 루브릭에 목록을
+넣는 것이 후속 조치다.
+
+### 위생 항목
+
+`.claude/quality-state/`는 `.gitignore:25`에 이미 등록되어 있어 런타임 상태가
+`git status`에 노출되지 않는다. 별도 조치가 필요 없다.
+
+### quality-goal 스킬 결함 재확인 (#43)
+
+이 보고서를 `set-artifact --kind report`로 등록하지 못했다. 상태 파일의
+`artifacts.report`는 `null`로 남아 있다. `record-review`가 라운드 한도 소진을 감지하면
+스스로 `NEEDS_REDESIGN`으로 전이하고(`quality_state.py:590,595`), 그 뒤에는
+`terminal state is immutable`로 `set-artifact`가 거부된다. SKILL.md가 요구하는
+"터미널 전이 **전에** 보고서 등록"을 지킬 수 있는 시점이 존재하지 않는다. 선행 실행에서
+발견해 이슈 #43으로 접수된 결함이며 이번 실행에서 동일하게 재현되었다. 알려진 결함이라
+우회를 시도하지 않았다.
+
+보고서 파일 자체는 정상 경로
+`docs/development/2026-08-27-create-worktree-pr-session-2/report.md`에 존재한다.
+
+## Final status
+
+- Status: `NEEDS_REDESIGN`
+- Machine-readable reason: `REVIEW_LIMIT_EXHAUSTED:spec`
+
+Spec 리뷰가 규정된 최대 2라운드를 소진했고 두 라운드 모두 게이트를 통과하지 못했다.
+다만 실패의 성격이 선행 실행과 다르다.
+
+| 항목 | 선행 실행 | 이번 실행 |
+|---|---|---|
+| 최종 점수 | 82 (통과선 85 미달) | **88 (통과선 초과)** |
+| 블로커 | 3건 → 0건 | **0건 → 0건** |
+| Critical/High | 3건 → 2건 | **0건 → 0건** |
+| 게이트 실패 사유 | `score_below_85`, `verdict_not_pass`, `critical_or_high_finding` | `verdict_not_pass`, `check_failed:acceptance_criteria_objective` |
+
+점수와 심각도 기준은 모두 충족했고, 남은 실패 사유는 리뷰어 판정이 `PASS`가 아니라는
+것과 그에 대응하는 결정적 체크 하나다. 그 체크(`acceptance_criteria_objective`)를
+`false`로 기록한 근거가 SPEC-009 단 하나이며, 그 하나가 `verdict`를 `REVISE`로 묶고
+있다.
+
+구현은 시작되지 않았고 저장소 소스 파일은 변경되지 않았다. 사용자 승인 게이트에도
+도달하지 않았다.
+
+**남은 작업의 성격.** SPEC-009는 AC 하나의 판정식 문제이고, SPEC-010은 `--pr`에 넘길
+값을 정규화하라는 한 줄짜리 요구사항 추가다. 둘 다 해법이 리뷰어의 `required_resolution`에
+구체적으로 적혀 있고, SPEC-009의 판별 프로브에 쓸 데이터(handle과 브랜치가 다른 기존
+worktree)는 이미 실측되어 있다. 다음 실행에서 이 둘을 초안에 선반영하면 라운드 1에서
+통과할 가능성이 높다 — 이번 실행이 선행 실행의 High 2건을 선반영해 블로커 0건으로
+시작했던 것과 같은 방식이다.

--- a/docs/development/2026-08-27-create-worktree-pr-session-2/spec.md
+++ b/docs/development/2026-08-27-create-worktree-pr-session-2/spec.md
@@ -1,0 +1,1160 @@
+# Quality Goal Specification
+
+- Task ID: 20260827T111202Z-28-35-create-worktree-스킬-재실행-pr-링크-입력-시-ea9373b7
+- Mode: standard
+- Status: SPEC_REVIEW (round 2)
+- Created: 2026-08-27T11:12:02Z
+- Updated: 2026-08-27T11:12:02Z
+- Source goal: #28 #35 create-worktree 스킬 재실행 — PR 링크 입력 시 2-review 세션에 PR 번호 윈도우를 생성하고 대상 세션을 직접 지정하도록 확장한다. SPEC-011(창 탐지 규칙)과 SPEC-012({이름} 정의)를 Spec 초안에 선반영한다
+
+## Problem and context
+
+`create-worktree` 스킬은 현재 브랜치명 하나만 입력으로 받고, workmux 윈도우를 항상
+`1-main` 세션에 연다. 두 가지 한계가 실제 사용에서 드러났다.
+
+**한계 1 — PR 리뷰용 worktree를 PR 번호로 식별할 수 없다.** 현행 규칙은 브랜치명 맨
+앞의 숫자만 이슈 번호로 인식해 `{이슈번호}-{짧은이름}` 윈도우를 만든다
+(`dot_claude/skills/create-worktree/SKILL.md:145-147`). PR head 브랜치명에는 보통 PR
+번호가 아니라 원 이슈 번호가 들어 있다. 이 저장소의 PR #31이 그 사례다 — head 브랜치가
+`30-enhancement/tmux-open-pr-shortcut`이라 현행 규칙으로는 창 이름이 `30-...`이 되어
+PR #31을 가리키지 못한다.
+
+**한계 2 — 대상 세션을 지정할 수 없어 불필요한 이동이 발생한다.** 이슈 #35가 기록한
+실제 사례에서 사용자가 `2-review`를 명시했음에도 현행 스킬은 `1-main`에 창을 연 뒤
+`move-window-to-session` 전체 절차를 밟아야 했다. 처음부터
+`--parent-session 2-review`를 쓰면 전부 불필요한 작업이다.
+
+**선행 실행의 결과.** 같은 목표로 2026-08-27에 수행한 quality-goal 실행이
+`NEEDS_REDESIGN`(`REVIEW_LIMIT_EXHAUSTED:spec`)으로 종료됐다. 산출물은
+`docs/development/2026-08-27-create-worktree-pr-session/`에 있다. 종료 사유는 설계
+결함이 아니라 두 개의 미정의 구간이었다 — 창 탐지 방법과 workmux git config 키의
+`{이름}`. 이 Spec은 그 둘을 실측 근거와 함께 처음부터 채운다(R2.0, R7.1).
+
+### 측정된 사실 (2026-08-27 실측)
+
+| 사실 | 관찰 명령 | 결과 |
+|---|---|---|
+| workmux 버전 | `workmux --version` | `workmux 0.1.248` |
+| `--pr` 플래그 | `workmux add --help` | `--pr <NUMBER\|URL>` |
+| `--pr`와 positional | `workmux add --help` | "`[BRANCH_NAME]` ... When used with `--pr`, this becomes the custom local branch name" |
+| `add`의 이름·세션 플래그 | `workmux add --help` | `--name`, `--target-name`, `--parent-session`, `--dry-run` 모두 존재 |
+| `workmux open`의 `--pr` 부재 | `workmux open --help` | `--pr` 없음. `--target-name`, `--parent-session`은 있음 |
+| `workmux list --json` | `workmux list --help` | `--json  Output as JSON` |
+| JSON 필드 | `workmux list --json` | `handle`, `path`, `branch`, `is_open`, `mode`, `is_main`, `project` |
+| tmux 세션 | `tmux list-sessions -F '#{session_name}'` | `1-main`, `2-review`, `3-personal`, `4-eslint`, `5-quick` |
+| dotfiles git-crypt | `git config --get filter.git-crypt.smudge` | 값 없음. 래퍼도 없음 |
+| zambaguni-front git-crypt | 같음 | `"git-crypt" smudge`. 래퍼 존재 |
+| 현재 저장소 판정 | `gh repo view --json owner,name -q '.owner.login + "/" + .name'` | `lee-kyu-hwan/dotfiles` |
+| PR #31 | `gh pr view 31 --json state,headRefName,headRefOid` | `OPEN`, `30-enhancement/tmux-open-pr-shortcut`, `9cfc6267ced574945814536710cf1019a37dc354` |
+| PR #31 원격 head | `git ls-remote origin '30-enhancement/tmux-open-pr-shortcut'` | `9cfc6267...` |
+| PR #31 pull ref | `git ls-remote origin 'refs/pull/31/head'` | `9cfc6267...` 동일 |
+| PR #32 | `gh pr view 32 --json state,headRefName` | `OPEN`, `feat/codex-playwright-e2e-profile` (숫자 접두사 없음) |
+| tmux 서버 부재 | `tmux -L quality-goal-nonexistent-socket list-sessions` | exit 1 + `error connecting to ...` |
+| 없는 세션 판정 | `... \| grep -qxF -- 'definitely-not-a-session'` | exit 1 |
+| `has-session` 접두사 함정 | `tmux has-session -t 2` / `-t 2-rev` | 둘 다 exit 0 (그런 세션 없음) |
+| 같은 조건 `grep -qxF` | `... \| grep -qxF -- '2-rev'` | exit 1 (올바름) |
+| `quick_validate.py` (dot_agents) | 아래 "frontmatter 검증" | `Skill is valid!`, exit 0 |
+| `quick_validate.py` (dot_claude) | 같음 | `Unexpected key(s) ... argument-hint, user-invocable`, **exit 0** |
+| 현재 `description` | `sed -n 3p` 두 파일 | 양쪽 동일: "Use when creating a new git worktree for a branch to work on in isolation from the main workspace" |
+
+### `workmux add --pr`의 실제 산출물 (dry-run 실측)
+
+`--dry-run`은 영속 변경 없이 결과를 보여 준다. PR #31에 대해 실행한 결과다.
+
+```
+$ workmux add --pr 31 --dry-run
+PR #31: feat(tmux): prefix + P 로 현재 브랜치의 PR 을 브라우저에서 연다
+Branch: 30-enhancement/tmux-open-pr-shortcut
+Worktree: /Users/lee-kyu-hwan/code/dotfiles__worktrees/30-enhancement-tmux-open-pr-shortcut
+Base:     origin/30-enhancement/tmux-open-pr-shortcut
+Target:   30-enhancement-tmux-open-pr-shortcut (window)
+```
+
+여기서 두 가지가 확정된다.
+
+1. **handle은 브랜치 슬러그다** — `30-enhancement/tmux-open-pr-shortcut`의 `/`를 `-`로
+   바꾼 `30-enhancement-tmux-open-pr-shortcut`. 이 저장소에는 `worktree_naming` 설정이
+   없으므로 기본 전략이 적용된 결과다.
+2. **`--target-name`을 주면 handle과 창 이름이 갈라진다** — handle은 위 그대로
+   `30-enhancement-tmux-open-pr-shortcut`이지만 창 이름은 `31-tmux-open-pr-shortcut`이
+   된다. 이것이 R7.1이 창 이름으로 매칭하면 안 되는 이유의 **PR 모드 직접 사례**다.
+
+handle이 브랜치에서 파생될 수 있다는 사실은 AC-9의 판정 기준에도 영향을 준다 —
+"브랜치에서 유추한 키 조회가 실패해야 한다"는 조건은 이 경우 성립하지 않는다. AC-9은
+그 대신 "실제로 존재하는 유일한 키가 handle 기준 키인지"로 판정한다.
+
+### 워크트리 식별자 실측 (R2.0의 근거)
+
+이 저장소의 살아 있는 worktree 하나가 이름 유추의 위험을 보여준다. handle이 항상
+브랜치에서 파생되는 것은 **아니다**.
+
+```
+$ workmux list
+BRANCH                                AGE  AGENT  MUX  UNMERGED  PATH
+chore/post-upgrade-skill-maintenance  2d   -      ✓    -         ../dotfiles__worktrees/feat-quality-goal-skill
+```
+
+디렉터리명(`feat-quality-goal-skill`)과 브랜치명(`chore/post-upgrade-skill-maintenance`)이
+전혀 다르다. 실제 git config 키는 디렉터리명 쪽이다.
+
+```
+$ git -C ../dotfiles__worktrees/feat-quality-goal-skill config --get-regexp '^workmux\.worktree\.'
+workmux.worktree.feat-quality-goal-skill.mode window
+workmux.worktree.feat-quality-goal-skill.window-session 3-personal
+
+$ git -C ... config --get 'workmux.worktree.post-upgrade-skill-maintenance.window-session'
+(출력 없음, exit 1)
+```
+
+`move-window-to-session/SKILL.md:104-108`은 이 상황을 "틀린 이름을 넘겨도 git은
+**에러 없이** 새 섹션을 만들어 버린다"고 경고한다 — 읽기는 빈 값을 주고, 쓰기는 조용히
+쓰레기 섹션을 만들며 진짜 키는 옛 값을 유지한다.
+
+`workmux list --json`은 이 이름을 `handle`로 직접 준다.
+
+```json
+{ "handle": "feat-quality-goal-skill",
+  "path": "/Users/.../dotfiles__worktrees/feat-quality-goal-skill",
+  "branch": "chore/post-upgrade-skill-maintenance",
+  "is_open": true, "mode": "window", "is_main": false }
+```
+
+**두 사례를 합치면**: handle은 브랜치 슬러그일 수도(dry-run 사례) 완전히 다를 수도(위
+사례) 있다. 어느 쪽이든 유추하지 말고 `handle`을 읽어야 한다는 결론은 같다.
+
+### 창 위치 실측 (R7.1의 근거)
+
+`is_open: true`인 위 worktree의 실제 창을 이름에 의존하지 않고 찾을 수 있다.
+
+```
+$ WT=/Users/lee-kyu-hwan/code/dotfiles__worktrees/feat-quality-goal-skill
+$ tmux list-panes -a -F '#{session_name}:#{window_index} #{window_id} #{pane_id} #{pane_current_path}' \
+    | awk -v wt="$WT" '$4 == wt || index($4, wt"/") == 1'
+3-personal:2 @19 %60 /Users/lee-kyu-hwan/code/dotfiles__worktrees/feat-quality-goal-skill
+```
+
+`workmux list --json`의 `is_open`, git config의 `window-session`(`3-personal`), pane
+경로 매칭 결과가 모두 일치한다. `window_id`(`@19`)와 `pane_id`(`%60`)는 `move-window`로
+바뀌지 않는 안정 식별자다(`move-window-to-session/SKILL.md:32-39`).
+
+### 래퍼 스크립트의 브랜치 판별
+
+`zambaguni-front/scripts/create-worktree.sh:82-98` 실측. 래퍼는
+`git fetch --prune origin` 후 3단계로 판별한다.
+
+1. `refs/remotes/origin/{BRANCH}`가 있으면 → tracking 브랜치 모드
+2. `refs/heads/{BRANCH}`가 있으면 → 기존 로컬 브랜치 모드
+3. **둘 다 없으면 → 현재 HEAD 기준으로 새 브랜치 생성 (`-b`)**
+
+3번이 결정적이다. 같은 저장소 PR이면 래퍼 자신의 fetch가 `origin/{head}`를 만들어 1번이
+적용되지만, **fork PR의 head 브랜치는 `origin`에 없다.** `git fetch --prune origin`은
+`refs/pull/*/head`를 가져오지 않으므로 3번으로 떨어져 **PR 내용이 전혀 없는 빈 브랜치를
+현재 HEAD에서 만들고** 겉보기에 성공한 worktree를 남긴다. 이 실패는 조용하다.
+
+## Goals
+
+1. PR 참조를 입력하면 PR 번호로 식별되는 리뷰용 worktree 윈도우를 만든다. 창 이름은
+   PR head 브랜치의 이슈 번호가 아니라 PR 번호를 쓴다.
+2. 대상 tmux 세션을 호출 시 지정할 수 있게 하고, 지정된 세션에 처음부터 직접 창을
+   만들어 `1-main` 경유 이동을 없앤다.
+3. 세션 선택 규칙을 결정적 우선순위로 일반화하고, Claude와 Codex 두 원본이 동일하게
+   읽게 한다.
+4. worktree 식별과 창 탐지를 이름 유추가 아닌 안정 식별자로 규정해, 잘못된 git config
+   키와 중복 창 생성을 막는다.
+5. 현행 스킬의 기존 규칙을 회귀 없이 보존한다. 보존 대상은 R9.6에 열거하고 AC-56으로
+   검증한다.
+6. 유령 세션, 저장소 불일치, 브랜치 충돌, PR 내용이 없는 빈 worktree, 사라진 저장
+   세션을 부작용이 생기기 전에 차단하거나 복구 경로를 제공한다.
+
+## Non-goals
+
+- tmux 세션 자동 생성. 선택 세션이 없으면 중단하거나 확인받는다(R2.5).
+- workmux session mode 전환(`--session`, `--mode session`)이나 pane 레이아웃 변경.
+- `move-window-to-session` 스킬 내부 동작·입력 계약 변경. 그 스킬이 **받아들이는 형식
+  으로** 인자를 맞춰 호출한다(R7.5).
+- `remove-worktree` 스킬 변경.
+- 대상 저장소의 `scripts/create-worktree.sh` 래퍼 수정. 3단계 판별은 그대로 두고
+  스킬이 호출 전에 전제를 보장한다.
+- workmux의 `worktree_naming` 설정 변경. handle 파생 규칙은 workmux에 맡기고 읽기만
+  한다.
+- 개발 서버나 에이전트 자동 실행.
+- PR 리뷰 자체의 수행.
+- `review/pr-{번호}` 같은 별칭 브랜치 생성.
+- GitHub 쓰기 작업(코멘트, 라벨, 상태 변경).
+- `workmux` 자체의 기능 추가나 버그 수정.
+- 선행 실행 산출물(`docs/development/2026-08-27-create-worktree-pr-session/`) 수정.
+  baseline의 initial dirty path로 기록되어 보존된다.
+- quality-goal 스킬 자체의 결함(#43, #44) 수정. 별도 이슈로 추적된다.
+
+## Requirements
+
+### R1. 입력 규격
+
+- **R1.1** 첫 번째 positional 인자는 브랜치명 또는 PR 참조이며 필수다. 비어 있으면
+  사용자에게 물어본다.
+- **R1.2** 두 번째 positional 인자는 정확한 tmux 세션명이며 선택이다.
+- **R1.3** 세 번째 이상의 positional 인자가 오면 추측하지 말고 사용법을 안내하고
+  중단한다. positional 형태 호출에만 적용된다(R1.6 참조).
+- **R1.4** PR 모드는 다음 형태에서만 자동 선택된다.
+  - 전체 GitHub PR URL: `https://github.com/{owner}/{repo}/pull/{번호}`
+  - `{owner}/{repo}#{번호}` 형식
+  - 자연어 문장에서 숫자 앞뒤에 PR 표지가 있는 경우 ("PR 1313", "1313번 PR",
+    "pull request 1313")
+- **R1.5** 표지 없는 맨 숫자(`1313`)는 PR 참조로 보지 않는다. GitHub는 이슈와 PR이
+  번호 공간을 공유하므로 맨 숫자를 PR로 단정하면 엉뚱한 대상을 체크아웃할 수 있다.
+  표지가 없으면 브랜치 모드로 해석하거나, 브랜치로도 해석되지 않으면 확인한다.
+- **R1.6** 자연어 호출은 `(브랜치명|PR참조, 대상세션)` 2-튜플로 환원한다.
+  - 첫 요소: 문장에서 발견된 브랜치명 또는 R1.4 형태의 PR 참조. 두 개 이상이면 중단
+    하고 확인한다.
+  - 둘째 요소: 문장에서 발견된 tmux 세션명. 두 개 이상이면 중단하고 확인한다.
+  - 환원 결과가 2-튜플을 넘지 않으므로 R1.3의 중단은 자연어 호출에서 발동하지 않는다.
+- **R1.7** 세션명을 접두사로 보정하거나 존재하는 세션 목록에서 추측하지 않는다.
+- **R1.8** Claude frontmatter의 `argument-hint`는
+  `<branch-name|pr-ref> [target-session]`로 갱신한다.
+
+### R2. worktree 식별자와 세션 선택
+
+- **R2.0 워크트리 식별자 정의.** `workmux.worktree.{이름}.window-session`을 비롯한
+  모든 workmux git config 키의 `{이름}`은 **workmux worktree handle**이며 다음으로
+  얻는다.
+
+  ```bash
+  workmux list --json    # 각 항목의 handle 필드 (= path 필드의 basename)
+  ```
+
+  **브랜치명이나 tmux 창 이름에서 유추하면 안 된다.** handle은 브랜치 슬러그와 같을
+  수도(`workmux add --pr 31 --dry-run` 실측: `30-enhancement-tmux-open-pr-shortcut`)
+  전혀 다를 수도(이 저장소 실측: 디렉터리 `feat-quality-goal-skill` / 브랜치
+  `chore/post-upgrade-skill-maintenance`) 있어 규칙으로 예측할 수 없다. 창 이름은
+  `--target-name`으로 바뀌므로 더더욱 근거가 못 된다. 틀린 키를 넘겨도 git은 오류 없이
+  새 섹션을 만들고 진짜 키는 옛 값을 유지하므로
+  (`move-window-to-session/SKILL.md:104-108`), 읽기는 빈 값을 주고 쓰기는 조용히
+  실패한다. 그 결과 R2 우선순위 2가 빈 값으로 떨어져 R2.1이 막으려던 실패가 재발한다.
+
+  `workmux list --json`을 쓸 수 없으면 worktree 절대경로의 basename을 폴백으로 쓰되,
+  `path` 필드와 대조해 확인한다. 대조할 수단조차 없으면 중단한다.
+
+세션(`SELECTED_SESSION`)은 다음 순서로 결정한다.
+
+1. 사용자가 이번 호출에서 명시한 대상 세션
+2. 기존 worktree의 `workmux.worktree.{handle}.window-session` 값이 `^[0-9]+-.+$`를
+   만족하고 **그 세션이 실제로 존재할 때** 그 값 (R2.5)
+3. 입력 모드 기본값 — PR 모드이면 `2-review`
+4. 전역 기본값 `1-main`
+
+- **R2.1** 저장값이 모드 기본값보다 우선한다. 저장값은 사용자가 직접 창을 옮긴 행동의
+  기록이고 모드 기본값은 관습이다. 관습이 기록을 덮으면 현행 "예외 1"이 막으려던
+  실패가 `2-review` 이름으로 재발한다.
+- **R2.2** 저장값이 `^[0-9]+-.+$`를 만족하지 않으면 레거시 값으로 보고 우선순위 2에서
+  제외하며, 선택된 세션으로 갱신한다. 판정은 셸 glob(`[0-9]*-*`)이 아니라 정규식으로
+  한다 — glob의 첫 `*`는 임의 문자열이라 `1legacy-session`이나 `1-`가 통과한다.
+- **R2.3** 선택 세션이 확정되기 전에는 어떤 workmux 명령도 실행하지 않는다.
+- **R2.4** 명시 세션(우선순위 1)이 유효한 저장값(우선순위 2)을 덮은 경우, 창을 연 뒤
+  `workmux.worktree.{handle}.window-session`이 명시 세션을 가리키는지 확인하고 다르면
+  갱신한다. 갱신하지 않으면 다음번 세션 미명시 호출이 옛 세션으로 되돌아간다.
+- **R2.5 사라진 저장 세션의 복구.** 저장값이 형식은 유효하나 그 세션이 지금 존재하지
+  않으면(닫혔거나 이름이 바뀜) 막다른 길이 되지 않게 한다. 우선순위 2를 건너뛰고
+  다음을 수행한다.
+
+  1. 저장값이 가리키는 세션이 사라졌음을 그 값과 함께 사용자에게 알린다.
+  2. 우선순위 3·4로 결정되는 세션을 제시하고 확인받는다.
+  3. 확인되면 그 세션으로 진행하고 `window-session`을 갱신한다.
+  4. 세션을 자동 생성하지 않는다.
+
+  이 규칙이 없으면 R3.5의 무조건 중단이 매 호출마다 반복되어 자기 교정 경로가 없다.
+  스킬이 `window-session`을 직접 쓰는 것은 R2.2·R2.4·R2.5·R8.2 네 곳뿐이다.
+
+### R3. tmux 세션 검증
+
+- **R3.1** `tmux list-sessions -F '#{session_name}'`을 단독 실행해 종료 코드를 먼저
+  확인한다.
+- **R3.2** exit 1과 `error connecting to ...`이면 tmux 서버 부재로 보고하고 중단한다.
+  "세션이 없다"와 구분한다.
+- **R3.3** 목록 조회 성공 후 `grep -qxF -- "$SELECTED_SESSION"`으로 전체 문자열 일치를
+  확인한다.
+- **R3.4** `has-session -t`를 쓰지 않는다. 접두사 매칭 때문에 `has-session -t 2`와
+  `-t 2-rev`가 모두 exit 0이다(실측).
+- **R3.5** 선택 세션이 없으면 자동 생성하지 않는다. 저장값에서 온 경우는 R2.5의 복구
+  경로를 타고, 사용자가 명시한 경우는 오타 가능성을 알리고 중단한다. workmux는 존재
+  하지 않는 `--parent-session` 값을 오류 없이 받아 세션을 만들고 git config에 영구
+  저장하므로, 이 검사가 유일한 안전망이다.
+- **R3.6** 현행의 "`1-main` 존재 확인"은 "선택 세션 존재 확인"으로 일반화한다.
+
+### R4. PR 참조 해석
+
+- **R4.0 저장소 판정.** PR 참조에서 `{owner}/{repo}`를, 현재 작업 대상에서 현재
+  저장소를 각각 확정한다. 둘 다 이름이 있어야 R4.2의 비교가 성립한다.
+
+  | 입력 형태 | `{owner}/{repo}` 출처 |
+  |---|---|
+  | 전체 PR URL | URL 경로의 `{owner}/{repo}` |
+  | `{owner}/{repo}#{번호}` | 문자열 그대로 |
+  | 표지 있는 자연어 (`PR 1313`) | 명시되지 않았으므로 **현재 저장소로 간주** |
+
+  현재 저장소는 다음으로 얻는다.
+
+  ```bash
+  gh repo view --json owner,name -q '.owner.login + "/" + .name'
+  ```
+
+  이 명령이 실패하면 `git remote get-url origin`을 폴백으로 쓰고 `{owner}/{repo}`를
+  파싱한다. 둘 다 실패하면 저장소를 확정할 수 없으므로 중단한다.
+- **R4.1** PR 번호, head 브랜치명, head 커밋 OID, 상태를 조회한다.
+
+  ```bash
+  gh pr view {번호} --repo {owner}/{repo} --json number,state,headRefName,headRefOid
+  ```
+
+  조회 필드는 소비되는 것만 요청한다 — `number`·`headRefName`·`headRefOid`는 이름
+  파생과 검증에, `state`는 R4.7에 쓰인다. base 저장소는 R4.0에서 이미 확정되므로 별도
+  필드가 필요 없고, fork 여부는 R4.6의 pull ref가 균일하게 처리한다.
+- **R4.2** R4.0의 `{owner}/{repo}`와 현재 저장소가 다르면 중단한다. 자연어 형태는
+  현재 저장소로 간주되므로 이 비교가 자동으로 통과한다.
+- **R4.3** PR head 브랜치의 worktree가 이미 있으면 **새 worktree를 만들지 않는다.**
+  별칭 브랜치도 만들지 않는다. 생성 단계만 건너뛰고 R7의 창 처리로 넘어간다. 전체
+  작업 중단이 아니다.
+- **R4.4** 같은 이름의 로컬 브랜치가 있는데 R4.1의 head OID와 다른 커밋을 가리키면
+  덮어쓰지 않고 중단한다.
+- **R4.5** `gh`가 없거나 인증되지 않았거나 조회가 실패하면 보고하고 중단한다. 추측
+  하지 않는다.
+- **R4.6 PR head 브랜치 확보.** worktree를 새로 만들기 전에 PR head 커밋이 로컬에서
+  `{head브랜치명}`으로 도달 가능함을 보장한다. 래퍼는 브랜치가 로컬과 `origin` 양쪽에
+  없으면 현재 HEAD에서 빈 브랜치를 만들므로(래퍼 82-98행), 이 보장 없이 래퍼를 부르면
+  PR 내용이 없는 worktree가 조용히 생긴다.
+
+  ```bash
+  # 로컬 브랜치가 이미 있으면 R4.4의 OID 비교로 판정이 끝나 있다.
+  # 없을 때만 pull ref에서 가져온다. fork PR도 이 ref로 동일하게 처리된다.
+  git fetch origin "refs/pull/{PR번호}/head:{head브랜치명}"
+  git rev-parse --verify "refs/heads/{head브랜치명}"   # == R4.1의 headRefOid
+  ```
+
+  fetch 실패나 OID 불일치면 중단하고 래퍼를 부르지 않는다. 래퍼 없는 경로는
+  `workmux add --pr`가 체크아웃을 직접 하므로 사전 fetch 대신 사후 검증(R6.8)으로 같은
+  보장을 얻는다.
+- **R4.7 PR 상태 처리.** `state`가 `OPEN`이 아니면(`CLOSED`, `MERGED`) 알리고 계속할지
+  확인한다. 자동 중단하지 않는다 — 머지된 PR을 사후에 들여다보는 것은 정당한 용도다.
+  다만 head 브랜치가 삭제되었을 수 있으므로 R4.6의 fetch 실패 가능성을 함께 안내한다.
+
+### R5. 윈도우 이름 파생
+
+- **R5.1** 짧은 이름은 브랜치명(PR 모드에서는 PR head 브랜치명)에서 마지막 `/`까지를
+  제거한 부분이다. `392-feat/add-partner-chat-enabled` → `add-partner-chat-enabled`.
+- **R5.2** 브랜치 모드에서 이슈 번호는 브랜치명 맨 앞의 숫자 또는 `ZF-숫자`만 인식한다.
+- **R5.3** PR 모드의 윈도우 이름은 `{PR번호}-{짧은이름}`이다. PR head 브랜치가 이슈
+  번호로 시작하더라도 PR 번호를 쓴다.
+- **R5.4** 브랜치 모드에서 이슈 번호가 없으면 `--target-name`을 생략한다.
+- **R5.5** workmux가 target name을 소문자로 정규화하므로, 안내와 재사용에 쓰는 이름은
+  정규화된 소문자다.
+- **R5.6** 창 이름 충돌 시 재시도 이름은 모드별로 다르다.
+  - 브랜치 모드: `{repo명}-{짧은이름}` (현행 규칙 유지)
+  - PR 모드: `{PR번호}-{repo명}-{짧은이름}` — PR 번호를 보존한다.
+
+### R6. 생성·오픈 경로
+
+- **R6.1** 경로 분기는 저장소 루트(`git rev-parse --show-toplevel`) 기준으로
+  `scripts/create-worktree.sh` 존재 여부로 판정한다. 상대 경로로 판정하면 서브디렉터리
+  나 기존 worktree 안에서 부를 때 false가 된다.
+- **R6.2** git-crypt 저장소에서 `workmux add`를 쓰지 않는다. PR 모드도 마찬가지다.
+- **R6.3** 래퍼 없는 저장소의 PR 모드는 positional 브랜치명을 생략한다.
+
+  ```bash
+  workmux add --pr {PR참조} \
+    --target-name {PR번호}-{짧은이름} \
+    --parent-session {선택세션}
+  ```
+
+  positional을 주면 그것이 커스텀 로컬 브랜치명이 되어 PR head 브랜치가 쓰이지 않는다.
+  `--target-name`과 `--parent-session`이 `--pr`와 함께 쓸 수 있음은 `workmux add --help`
+  실측으로 확인했다.
+- **R6.4** 래퍼 있는 저장소의 PR 모드는 R4.6으로 head 브랜치를 확보한 뒤 실행한다.
+
+  ```bash
+  ./scripts/create-worktree.sh {head브랜치명}
+  workmux open {handle} \
+    --target-name {PR번호}-{짧은이름} \
+    --parent-session {선택세션}
+  ```
+
+- **R6.5** 래퍼가 실패하면 종료 코드를 확인해 중단하고 `workmux open`으로 넘어가지
+  않는다. 확인 프롬프트를 `-y`나 `yes |`로 우회하지 않는다. 실행 권한이 없으면 경로를
+  바꾸지 말고 오류로 보고한다.
+- **R6.6** 모든 `workmux add`/`workmux open` 예시가 고정 `1-main`이 아니라 선택 세션
+  변수를 쓴다.
+- **R6.7** `--parent-session` 미지원 조합(session mode, 샌드박스 안, `--count`,
+  `--foreach`, 여러 `--agent`, stdin)에서는 플래그를 생략한다.
+- **R6.8 PR worktree 내용 검증.** 생성 직후 worktree의 HEAD가 R4.1의 `headRefOid`와
+  같은지 확인한다. 다르면 PR 내용이 없는 worktree이므로 성공으로 보고하지 않는다.
+- **R6.9 경로·handle 확보.** 생성 후 worktree 경로와 handle을 명령 출력에서 얻는다.
+  경로나 이름을 추측하지 않는다.
+  - 래퍼 경로: 래퍼가 출력하는 worktree 절대경로를 쓴다. handle은
+    `workmux list --json`에서 `path`가 그 경로와 같은 항목의 `handle`이다.
+  - `workmux add --pr` 경로: 생성 후 `workmux list --json`에서 `branch`가 PR head
+    브랜치와 일치하는 항목의 `handle`과 `path`를 읽는다. workmux의 디렉터리 명명은
+    `worktree_naming` 설정에 좌우되므로 규칙으로 추정하지 않는다.
+  - 실행 전 `workmux add ... --dry-run`으로 예상 경로·handle을 미리 볼 수 있다.
+    영속 변경이 없으므로 확인용으로 쓴다.
+- **R6.10 git-crypt 필터가 있으나 래퍼가 없는 저장소.** 현행 규칙을 유지한다 —
+  `filter.git-crypt.smudge` 값이 있는데 `scripts/create-worktree.sh`가 없으면
+  사용자에게 확인받고 진행한다(`dot_claude/skills/create-worktree/SKILL.md:106`).
+  R6.1의 분기가 래퍼 존재 여부만 보므로, 이 확인 없이는 R6.2가 금지하는
+  `workmux add` 경로로 조용히 들어간다.
+
+### R7. 기존 worktree 상태별 동작
+
+- **R7.0 worktree 존재·경로 판정.** 세션 선택(R2)보다 먼저 대상 브랜치의 worktree
+  존재 여부와 경로를 확정한다. 저장 세션을 읽으려면 handle이 필요하고, handle은
+  `workmux list --json`에서 경로로 찾기 때문이다.
+
+  ```bash
+  git worktree list --porcelain   # branch refs/heads/{브랜치명} 항목의 worktree 경로
+  workmux list --json             # 그 경로와 일치하는 항목의 handle
+  ```
+
+- **R7.1 창 열림 여부와 위치 판정.** 창이 열려 있는지, 어느 세션·어느 창인지를
+  **이름이 아닌 안정 식별자로** 판정한다. 3단계를 모두 쓴다.
+
+  1. **열림 여부** — `workmux list --json`에서 해당 handle 항목의 `is_open`.
+  2. **세션** — `git config --get workmux.worktree.{handle}.window-session`.
+  3. **실제 창·pane** — 창 이름에 의존하지 않고 pane의 작업 디렉터리로 매칭한다.
+
+     ```bash
+     tmux list-panes -a -F '#{session_name}:#{window_index} #{window_id} #{pane_id} #{pane_current_path}' \
+       | awk -v wt="{worktree절대경로}" '$4 == wt || index($4, wt"/") == 1'
+     ```
+
+     실측 결과 `3-personal:2 @19 %60 {worktree경로}`를 정확히 짚었다.
+
+  **창 이름으로 매칭하지 않는다.** 창 이름은 `--target-name`으로 결정되며 모드마다
+  파생 규칙이 다르다. PR #31 dry-run 실측이 직접 사례다 — handle은
+  `30-enhancement-tmux-open-pr-shortcut`인데 PR 모드 창 이름은
+  `31-tmux-open-pr-shortcut`이다. 이름으로 찾으면 열려 있는 창을 놓치고 R7.3의 중복
+  창 금지가 조용히 실패한다.
+
+  **확보한 `window_id`(`@N`)와 `pane_id`(`%N`)를 이후 조작의 기준으로 삼는다.** 둘은
+  `move-window`로 바뀌지 않는 반면 `session:index`는 바뀐다
+  (`move-window-to-session/SKILL.md:32-39`).
+
+  **매칭기의 한계.** 위 `awk`는 공백으로 필드를 나누므로 **worktree 경로에 공백이 있으면
+  동작하지 않는다.** 경로에 공백이 있으면 이 매칭을 신뢰하지 말고 아래 불일치 처리로
+  넘어간다. pane의 cwd는 사용자가 `cd`로 바꿀 수도 있어 완전하지 않다.
+
+  **불일치 처리.** `is_open`이 참인데 매칭 0건이면(경로에 공백, 또는 사용자가 `cd` 함)
+  추측하지 말고 `window-session`이 가리키는 세션의 창 목록을 보여 주고 확인받는다.
+  매칭 2건 이상이면 그대로 보고하고 확인받는다.
+
+- **R7.2** 창이 닫혀 있으면(`is_open`이 거짓) 선택 세션으로 직접 연다.
+- **R7.3** 창이 열려 있고 선택 세션과 같은 세션이면 중복 창을 만들지 않고 기존 위치를
+  안내한다.
+- **R7.4** 창이 열려 있고 다른 세션이며 사용자가 대상을 명시하지 않았으면 기존 위치를
+  존중한다(R2 우선순위 2가 이미 그 값을 선택하므로 R7.3으로 귀결된다).
+- **R7.5 열린 창의 명시적 이동.** 창이 열려 있고 다른 세션이며 사용자가 대상을
+  명시했으면, `workmux open`으로 재구성하지 않고 `move-window-to-session` 스킬을 쓴다.
+  살아 있는 pane과 에이전트 상태를 보존하기 위해서다.
+
+  그 스킬의 입력 계약은 `<윈도우이름|세션:번호> <대상세션>`이므로
+  (`move-window-to-session/SKILL.md:21`), R7.1이 확보한 `window_id`를 **그대로 넘기지
+  않는다.** 호출 직전에 `window_id`로 현재 위치를 해석해 `세션:번호` 형태로 넘긴다.
+
+  ```bash
+  SRC=$(tmux display-message -p -t "{window_id}" '#{session_name}:#{window_index}')
+  # move-window-to-session 에 넘기는 인자: "$SRC" "{선택세션}"
+  ```
+
+  `window_id`로 해석하는 이유는 그 사이 다른 창이 열리고 닫혀 번호가 밀렸을 수 있기
+  때문이다. 호출이 끝난 뒤에도 같은 `window_id`로 최종 위치를 재확인한다.
+
+  그 스킬은 내부적으로 worktree 경로와 worktree명(= handle)도 쓰므로
+  (`move-window-to-session/SKILL.md:114`), R7.0·R7.1에서 확보한 경로와 handle을 함께
+  전달한다. 그 스킬의 3-(a) 단계가 `window-session`을 대상 세션으로 갱신하므로 R2.4는
+  덮어쓰기가 아니라 **확인**으로 동작한다.
+
+- **R7.6** 같은 브랜치의 worktree가 이미 있으면 새로 만들지 않고 기존 경로를 안내한다.
+  R4.3과 같은 규칙이며 PR 모드에도 동일하게 적용된다.
+
+### R8. 생성 후 검증
+
+- **R8.1** `tmux list-windows -a -F '#{session_name}:#{window_index}\t#{window_name}'`로
+  실제 윈도우 이름과 세션을 확인한다. `workmux list`에는 윈도우 이름 열이 없으므로
+  추측해서 안내하면 사용자가 `workmux close`에 없는 이름을 넘기게 된다.
+- **R8.2** 실제 세션이 선택 세션과 다르면 알리고, 잘못 만들어진 세션과 git config 값을
+  함께 정리한다.
+- **R8.3** 결과 보고에 worktree 경로, handle, 브랜치, 실제 세션, 실제 윈도우 이름을
+  포함한다. PR 모드에서는 PR 번호와 head OID도 포함한다.
+
+### R9. 문서 동기화
+
+- **R9.1** 두 SKILL.md 본문은 Claude 전용 frontmatter를 제외하고 동일해야 한다.
+- **R9.2** 현존하는 workmux 버전 표기 불일치(`dot_agents:43` vs `dot_claude:46`)를
+  더 정확한 `dot_claude` 쪽 문구로 통일한다.
+- **R9.3** `openai.yaml`의 `default_prompt`에 대상 세션 또는 PR 참조 사례를 반영한다.
+- **R9.4** 홈의 적용본을 직접 수정하지 않는다. chezmoi 원본만 고치고 `chezmoi apply`로
+  적용한다.
+- **R9.5 `description` frontmatter 갱신.** 두 SKILL.md의 `description`은 현재 양쪽 다
+  "Use when creating a new git worktree for a branch to work on in isolation from the
+  main workspace"로, **브랜치만 언급한다**(실측). 에이전트는 이 문장으로 호출을
+  라우팅하므로, PR 참조와 대상 세션이 유효한 입력이 된 뒤에도 이대로 두면 "PR 31을
+  2-review에 열어줘" 같은 R1.4·R1.6 호출이 스킬에 도달하지 못할 수 있다. PR 참조와
+  대상 세션 지정을 포함하도록 양쪽 모두 갱신한다.
+- **R9.6 보존 대상 규칙 목록 (Goal 5의 검증 근거).** 아래 현행 규칙은 재작성 후에도
+  두 SKILL.md에 남아 있어야 한다. 각 항목은 해당 요구사항이 계승하거나 그대로 유지한다.
+
+  | # | 보존 규칙 | 계승 위치 |
+  |---|---|---|
+  | 1 | git-crypt 저장소에서 `workmux add` 금지 | R6.2 |
+  | 2 | 래퍼 실패 시 중단, `workmux open` 미진행 | R6.5 |
+  | 3 | 래퍼 확인 프롬프트 자동 우회 금지 | R6.5 |
+  | 4 | 래퍼 실행 권한 없으면 경로 변경 없이 오류 보고 | R6.5 |
+  | 5 | git-crypt 필터 있는데 래퍼 없으면 사용자 확인 후 진행 | R6.10 |
+  | 6 | 저장소 루트 기준 경로 분기 | R6.1 |
+  | 7 | `has-session` 금지와 접두사 함정 근거 | R3.4 |
+  | 8 | 유령 세션 위험 서술(workmux가 없는 세션을 만들고 config에 저장) | R3.5 |
+  | 9 | 레거시 `window-session` 값의 정규식 판정과 glob 반례 | R2.2 |
+  | 10 | `--parent-session` 미지원 조합 예외 | R6.7 |
+  | 11 | 창 이름 충돌 재시도 | R5.6 |
+  | 12 | `workmux list`에 윈도우 이름 열이 없으므로 `tmux list-windows`로 확인 | R8.1 |
+  | 13 | `workmux open`이 `git worktree list`로 찾으므로 `worktree_dir` 밖 형제 디렉터리도 인식 | R6.9 서술에 포함 |
+  | 14 | 에이전트 자동 실행 안 함 | 주의사항 절 유지 |
+  | 15 | 개발 서버는 별도 윈도우·pane (포트 충돌, 개당 1~2GB) | 주의사항 절 유지 |
+  | 16 | 레이아웃은 `~/.config/workmux/config.yaml`, 저장소별은 `.workmux.yaml` | 주의사항 절 유지 |
+  | 17 | 같은 브랜치 worktree가 있으면 기존 경로 안내 | R7.6 |
+  | 18 | 이슈 번호는 브랜치명 맨 앞의 숫자 또는 `ZF-숫자`만 | R5.2 |
+
+## Acceptance criteria
+
+검증 유형: **[실행]**(명령 종료 코드·출력으로 판정), **[문서]**(두 SKILL.md에 해당
+규칙이 기술되어 있는지 검토로 판정).
+
+| ID | 기준 | 검증 방법 | 커버 |
+|---|---|---|---|
+| AC-1 | 입력 계약이 `<브랜치명\|PR참조> [대상세션]`으로 문서화되고 첫 인자 누락 시 묻는다 | [문서] 파라미터 절 | R1.1, R1.2 |
+| AC-2 | positional 3개 이상이면 사용법 안내 후 중단 | [문서] R1.3 | R1.3 |
+| AC-3 | PR 모드 트리거 3종이 열거된다 | [문서] R1.4 | R1.4 |
+| AC-4 | 표지 없는 맨 숫자를 PR로 해석하지 않는 규칙과 근거가 기술된다 | [문서] R1.5 | R1.5 |
+| AC-5 | 자연어 → 2-튜플 환원과 "두 개 이상 중단"이 기술된다 | [문서] R1.6 | R1.6 |
+| AC-6 | 세션명 접두사 보정·추측 금지가 기술된다 | [문서] R1.7 | R1.7 |
+| AC-7 | `argument-hint`가 `<branch-name\|pr-ref> [target-session]`이다 | [실행] `grep -q` → exit 0 | R1.8 |
+| AC-8 | `{이름}`이 `workmux list --json`의 `handle`로 정의되고, 브랜치·창 이름 유추 금지가 **양방향 실측 반례**(브랜치와 같은 경우·다른 경우)와 함께 기술된다 | [문서] R2.0 | R2.0 |
+| AC-9 | 실제 존재하는 workmux worktree 키가 handle 기준 키뿐이다 | [실행] 스모크에서 `git config --get-regexp '^workmux\.worktree\.'` 출력의 모든 키가 `workmux.worktree.{H}.{속성}` 형태이고 `{H}` == `workmux list --json`의 `handle`. handle이 브랜치 슬러그와 다른 경우에 한해 브랜치 유추 키 조회가 exit 1임을 증거로 추가 기록 | R2.0 |
+| AC-10 | 세션 우선순위가 명시값 > 저장값 > 모드 기본값 > `1-main`으로 기술된다 | [문서] 저장값이 모드 기본값보다 위임을 확인 | R2.1 |
+| AC-11 | 레거시 저장값을 정규식으로 판정하고 glob을 금지하는 근거가 기술된다 | [문서] R2.2 | R2.2 |
+| AC-12 | 선택 세션 확정 전 workmux 명령 금지가 기술된다 | [문서] R2.3 | R2.3 |
+| AC-13 | 명시 세션이 저장값을 덮으면 git config가 명시 세션을 가리킨다 | [실행] 스모크 3차에서 `window-session`이 `2-review` → `3-personal`로 바뀜 | R2.4 |
+| AC-14 | 형식은 유효하나 사라진 저장 세션에 복구 경로가 있다 | [문서] R2.5의 4단계(알림·제시·확인 후 갱신·자동 생성 금지) | R2.5 |
+| AC-15 | tmux 서버 부재를 세션 부재와 구분해 감지한다 | [실행] `tmux -L quality-goal-nonexistent-socket list-sessions` → exit 1 + `error connecting to`. + [문서] 구분 서술 | R3.1, R3.2 |
+| AC-16 | 없는 세션은 `grep -qxF`로 부재 판정되고 자동 생성하지 않는다 | [실행] `... \| grep -qxF -- 'definitely-not-a-session'` → exit 1. + [문서] R3.5 | R3.3, R3.5 |
+| AC-17 | `has-session` 접두사 함정이 실측 근거와 함께 금지된다 | [실행] `has-session -t 2` → 0, `-t 2-rev` → 0, `grep -qxF 2-rev` → 1. + [문서] R3.4 | R3.4 |
+| AC-18 | 고정 `1-main` 검사가 선택 세션 검사로 일반화된다 | [실행] 아래 "`1-main` 잔존 검사" | R3.6, R6.6 |
+| AC-19 | `{owner}/{repo}`와 현재 저장소의 확정 방법이 입력 형태별로 기술된다 | [문서] R4.0의 표와 `gh repo view` 명령·폴백 | R4.0 |
+| AC-20 | PR 조회가 소비되는 필드만 요청하고 각 소비처가 명시된다 | [문서] R4.1 | R4.1 |
+| AC-21 | base 저장소 불일치 시 중단하며, 비교 대상 두 값이 R4.0에서 확정된 것임이 기술된다 | [문서] R4.2 | R4.2 |
+| AC-22 | 기존 worktree면 생성만 건너뛰고 R7으로 진행(전체 중단 아님) | [문서] R4.3 + 흐름도 분기 일치 | R4.3, R7.6 |
+| AC-23 | 동명 로컬 브랜치가 head OID와 다르면 중단 | [문서] R4.4 | R4.4 |
+| AC-24 | `gh` 부재·미인증·실패 시 추측 없이 중단 | [문서] R4.5 | R4.5 |
+| AC-25 | 래퍼 경로에서 `refs/pull/{N}/head`로 head를 확보하고 실패 시 래퍼를 부르지 않는다 | [문서] R4.6의 명령·중단 규칙 + 래퍼 3단계 판별 근거 | R4.6 |
+| AC-26 | CLOSED·MERGED PR에 대한 동작이 정의된다 | [문서] R4.7 | R4.7 |
+| AC-27 | 짧은 이름이 마지막 `/` 뒤로 파생된다 | [문서] R5.1 | R5.1 |
+| AC-28 | 브랜치 모드 이슈 번호 규칙이 유지된다 | [문서] R5.2 | R5.2 |
+| AC-29 | PR head가 이슈 번호로 시작해도 창 이름에 PR 번호가 쓰인다 | [실행] 스모크 1차에서 창 이름이 `31-tmux-open-pr-shortcut`이고 `30-`으로 시작하지 않음 | R5.3 |
+| AC-30 | 이슈 번호 없으면 `--target-name` 생략 | [문서] R5.4 | R5.4 |
+| AC-31 | 소문자 정규화가 안내에 반영된다 | [문서] R5.5 | R5.5 |
+| AC-32 | PR 모드 충돌 재시도가 PR 번호를 보존한다 | [문서] R5.6의 모드별 구분 | R5.6 |
+| AC-33 | 경로 분기를 저장소 루트 기준으로 판정한다 | [문서] R6.1 | R6.1 |
+| AC-34 | git-crypt 저장소에서 `workmux add`를 쓰지 않는다 | [문서] R6.2 + git-crypt 분기에 래퍼 호출만 존재 | R6.2 |
+| AC-35 | 래퍼 없는 PR 경로가 positional을 생략하고 `--pr`를 쓴다 | [실행] 스모크 1차에서 worktree 브랜치가 `30-enhancement/tmux-open-pr-shortcut` | R6.3 |
+| AC-36 | 래퍼 있는 PR 경로가 확보 → 래퍼 → `workmux open` 순서로 기술된다 | [문서] R6.4 | R6.4 |
+| AC-37 | 래퍼 실패·권한 없음 시 창을 열지 않고 프롬프트를 우회하지 않는다 | [문서] R6.5 | R6.5 |
+| AC-38 | `--parent-session` 미지원 조합 예외가 유지된다 | [문서] R6.7 | R6.7 |
+| AC-39 | 생성된 worktree HEAD가 PR head OID와 일치한다 | [실행] 스모크 1차에서 `git -C {wt} rev-parse HEAD` == `9cfc6267ced574945814536710cf1019a37dc354` | R6.8 |
+| AC-40 | 경로·handle을 명령 출력에서 얻고 추측하지 않는다 | [문서] R6.9의 경로별 획득 방법. + [실행] 스모크 1차에서 `workmux list --json`으로 handle을 읽어 보고 | R6.9 |
+| AC-41 | git-crypt 필터가 있으나 래퍼가 없으면 사용자 확인 후 진행한다 | [문서] R6.10 | R6.10 |
+| AC-42 | worktree 존재 판정이 세션 선택보다 먼저다 | [문서] 흐름도에서 R7.0이 R2보다 앞 | R7.0 |
+| AC-43 | 창 열림·위치 판정이 이름이 아닌 `is_open` + pane 경로 + 안정 식별자로 규정되고, PR 모드 실측 사례(handle `30-enhancement-tmux-open-pr-shortcut` vs 창 이름 `31-tmux-open-pr-shortcut`)가 근거로 제시된다 | [문서] R7.1. + [실행] 스모크 1차에서 pane 경로 매칭이 방금 만든 창을 정확히 1건 반환 | R7.1 |
+| AC-44 | 매칭 0건·2건 이상과 경로 공백 한계에서 추측하지 않는다 | [문서] R7.1의 한계·불일치 처리 | R7.1 |
+| AC-45 | 창이 닫혀 있으면 선택 세션으로 직접 연다 | [문서] R7.2 | R7.2 |
+| AC-46 | **선택 세션과 같은 세션에** 이미 열려 있으면 중복 창을 만들지 않는다 | [실행] 스모크 2차에서 창이 있는 세션(`2-review`)을 그대로 지정해 재호출 → pane 경로 매칭 결과가 1건 유지 | R7.3 |
+| AC-47 | 세션 미명시 시 기존 위치를 존중한다 | [문서] R7.4 | R7.4 |
+| AC-48 | 열린 창의 명시적 이동이 `move-window-to-session`의 입력 계약(`세션:번호`)에 맞춰 호출되고, `window_id`로 직전 해석·사후 재확인한다 | [문서] R7.5의 인자 구성·해석 명령. + [실행] 스모크 3차에서 창이 `3-personal`로 이동하고 `window_id`가 동일 | R7.5 |
+| AC-49 | 생성 후 실제 세션·창 이름을 `tmux list-windows`로 확인한다 | [실행] 스모크 1차에서 실행·기록 | R8.1 |
+| AC-50 | 세션 불일치 시 잘못된 세션과 git config를 정리한다 | [문서] R8.2 | R8.2 |
+| AC-51 | 보고에 경로·handle·브랜치·세션·창이름(+PR번호·head OID) 포함 | [실행] 스모크 1차 보고에 7항목 존재 | R8.3 |
+| AC-52 | 두 SKILL.md 본문이 Claude frontmatter 외에 동일하다 | [실행] `diff` 출력이 `3a4,6`과 그 3줄만 | R9.1, R9.2 |
+| AC-53 | `openai.yaml` `default_prompt`에 세션 또는 PR 사례 반영 | [실행] `grep -qE '2-review\|pull/'` → exit 0 | R9.3 |
+| AC-54 | chezmoi 원본만 수정되고 적용본이 일치한다 | [실행] `chezmoi apply` 후 3개 파일 `cmp` → exit 0 | R9.4 |
+| AC-55 | 두 SKILL.md의 `description`이 PR 참조와 대상 세션을 포함하도록 갱신된다 | [실행] 두 파일 3행에 대해 `grep -qiE 'pull request\|PR' && grep -qiE 'session'` → exit 0. 두 파일의 `description`이 서로 동일 | R9.5 |
+| AC-56 | R9.6의 보존 규칙 18개가 모두 두 SKILL.md에 남아 있다 | [실행/검토] 각 항목을 두 파일에서 확인. 누락 0건 | R9.6, Goal 5 |
+| AC-57 | PR 모드 신규 worktree에서 세션 미명시 시 `2-review`가 선택된다 | [실행] 스모크 1차에서 창이 `2-review`에 열림 | R2 우선순위 3 |
+| AC-58 | 두 스킬이 frontmatter 검증 기준선을 만족한다 | [실행] 아래 "frontmatter 검증" | 도구 위생 |
+| AC-59 | 공백 오류·시크릿 유출 없음 | [실행] `git diff --check` → 0, `pre-commit run --all-files` 통과 | 저장소 위생 |
+
+### 요구사항 전수 대응 확인
+
+R1.1→AC-1, R1.2→AC-1, R1.3→AC-2, R1.4→AC-3, R1.5→AC-4, R1.6→AC-5, R1.7→AC-6,
+R1.8→AC-7, R2.0→AC-8·AC-9, R2.1→AC-10, R2.2→AC-11, R2.3→AC-12, R2.4→AC-13,
+R2.5→AC-14, R3.1→AC-15, R3.2→AC-15, R3.3→AC-16, R3.4→AC-17, R3.5→AC-16, R3.6→AC-18,
+R4.0→AC-19, R4.1→AC-20, R4.2→AC-21, R4.3→AC-22, R4.4→AC-23, R4.5→AC-24, R4.6→AC-25,
+R4.7→AC-26, R5.1→AC-27, R5.2→AC-28, R5.3→AC-29, R5.4→AC-30, R5.5→AC-31, R5.6→AC-32,
+R6.1→AC-33, R6.2→AC-34, R6.3→AC-35, R6.4→AC-36, R6.5→AC-37, R6.6→AC-18, R6.7→AC-38,
+R6.8→AC-39, R6.9→AC-40, R6.10→AC-41, R7.0→AC-42, R7.1→AC-43·AC-44, R7.2→AC-45,
+R7.3→AC-46, R7.4→AC-47, R7.5→AC-48, R7.6→AC-22, R8.1→AC-49, R8.2→AC-50, R8.3→AC-51,
+R9.1→AC-52, R9.2→AC-52, R9.3→AC-53, R9.4→AC-54, R9.5→AC-55, R9.6→AC-56.
+**미대응 요구사항 없음.**
+
+### `1-main` 잔존 검사 (AC-18의 실행 정의)
+
+```bash
+grep -n -- '1-main' dot_agents/skills/create-worktree/SKILL.md \
+                    dot_claude/skills/create-worktree/SKILL.md
+```
+
+**허용되는 잔존 용례**
+
+1. R2 우선순위 4순위를 설명하는 "전역 기본값 `1-main`" 서술
+2. 우선순위 예시 표에서 기본값 결과를 보이는 셀
+3. 유령 세션 위험이나 레거시 마이그레이션을 설명하며 예시로 드는 문장
+
+**금지되는 잔존 용례** — 하나라도 남으면 AC-18 실패.
+
+1. `--parent-session 1-main` 리터럴이 실행 명령 예시에 있음
+2. `grep -qxF -- 1-main`처럼 검증 대상이 고정됨
+3. `git config ... window-session 1-main`처럼 기록 값이 고정됨
+4. "`1-main` 세션이 없으면 여기서 멈춘다"처럼 중단 조건이 묶임
+5. "새로 만든 것이면 `1-main`"처럼 사후 검증 기대값이 고정됨
+
+### frontmatter 검증 (AC-58의 실행 정의)
+
+```bash
+QV=/Users/lee-kyu-hwan/.claude/plugins/marketplaces/claude-plugins-official/plugins/skill-creator/skills/skill-creator/scripts/quick_validate.py
+python3 "$QV" /Users/lee-kyu-hwan/code/dotfiles/dot_claude/skills/create-worktree
+python3 "$QV" /Users/lee-kyu-hwan/code/dotfiles/dot_agents/skills/create-worktree
+```
+
+실측 기준선(변경 전): `dot_agents` → `Skill is valid!` exit 0. `dot_claude` →
+`Unexpected key(s) in SKILL.md frontmatter: argument-hint, user-invocable.` **exit 0**.
+
+판정 기준은 **종료 코드 0 + `dot_claude`의 메시지가 위 Claude 전용 키 안내에서 늘어나지
+않을 것.** 새로운 종류의 경고가 추가되면 실패로 본다.
+
+## Architecture
+
+스킬은 실행 코드가 아니라 에이전트가 읽고 따르는 절차 문서다. "아키텍처"는 문서가
+기술하는 결정 흐름과 그것이 호출하는 외부 도구 경계를 뜻한다.
+
+### 결정 흐름
+
+worktree 식별(R7.0)과 창 탐지(R7.1)가 세션 선택(R2)보다 **앞선다** — 저장 세션을
+읽으려면 handle이 필요하고 handle은 경로로 찾기 때문이다.
+
+```
+1. 입력 파싱 (R1)
+     ├─ positional 3개 이상 → 사용법 안내 후 중단
+     ├─ PR 참조 판정 (R1.4 / R1.5)
+     └─ 자연어면 2-튜플 환원 (R1.6)
+          ↓
+2. 저장소 확정 (R4.0)  [PR 모드]
+     PR 참조에서 {owner}/{repo} / gh repo view로 현재 저장소
+          ↓
+3. PR 해석 (R4.1, R4.2, R4.5, R4.7)
+     ├─ 번호·head브랜치·headRefOid·state 조회
+     ├─ base 저장소 불일치 → 중단
+     └─ state != OPEN → 알리고 확인
+          ↓
+4. worktree 식별 (R7.0)
+     git worktree list --porcelain → 경로
+     workmux list --json           → handle (없으면 신규)
+          ↓
+5. 창 탐지 (R7.1)  [worktree가 있을 때만]
+     is_open → window-session → pane 경로 매칭 → window_id/pane_id 확보
+          ↓
+6. 세션 선택 (R2)
+     명시값 > 유효·생존 저장값 > 모드 기본값(PR→2-review) > 1-main
+     저장값이 형식 유효하나 세션 부재 → R2.5 복구
+          ↓
+7. 세션 검증 (R3)
+     list-sessions 종료 코드 → grep -qxF 전체 일치 → 없으면 중단 또는 R2.5
+          ↓
+8. 이름 파생 (R5)
+          ↓
+9. 분기
+     ├─ [worktree 있음] (R4.3 → R7.2~R7.5)
+     │     ├─ is_open 거짓 → 선택 세션으로 workmux open
+     │     ├─ is_open 참 & 같은 세션 → 안내만 (중복 창 금지)
+     │     └─ is_open 참 & 다른 세션 & 명시됨
+     │           → window_id로 세션:번호 해석 → move-window-to-session
+     │
+     └─ [worktree 없음] → 브랜치 안전 검사 (R4.4) → 생성 (R6)
+           ├─ 래퍼 있음: R4.6 fetch → 래퍼 → workmux open
+           ├─ 래퍼 없음: workmux add --pr (positional 생략)
+           └─ git-crypt 필터 있으나 래퍼 없음 → 사용자 확인 (R6.10)
+          ↓
+10. 생성 후 검증 (R6.8, R6.9, R8, R2.4)
+     HEAD == headRefOid → handle·경로 확보 → tmux 대조 → git config 확인
+```
+
+### 구성 요소와 책임 경계
+
+| 구성 요소 | 책임 | 이번 변경 |
+|---|---|---|
+| `dot_claude/.../SKILL.md` | Claude Code가 읽는 절차 + Claude 전용 frontmatter | 본문 확장, `argument-hint`·`description` 갱신 |
+| `dot_agents/.../SKILL.md` | Codex·공용 에이전트가 읽는 절차 | 본문 동일 확장, `description` 갱신 |
+| `dot_agents/.../agents/openai.yaml` | Codex UI 메타데이터 | `default_prompt` 갱신 |
+| `workmux` (0.1.248) | worktree 생성·창 구성·`--pr` 체크아웃·`list --json` 상태 조회·`--dry-run` 미리보기 | 호출만 |
+| 대상 저장소의 `scripts/create-worktree.sh` | git-crypt worktree 생성·키 링크·의존성 설치 | 호출만. 3단계 판별의 전제를 R4.6이 보장 |
+| `gh` | PR 메타데이터·현재 저장소 조회 (읽기 전용) | 신규 의존 |
+| `git fetch origin refs/pull/N/head` | PR head 커밋 확보 | 신규 의존 (래퍼 경로) |
+| `tmux list-panes -a` | 이름 독립 창 매칭 | 신규 의존 (R7.1) |
+| `move-window-to-session` 스킬 | 열린 창 이동 + 메타데이터 동기화 | 호출만. **입력 계약에 맞춰 `세션:번호`로 호출** |
+| `~/.config/workmux/config.yaml` | pane 레이아웃, `base_branch: auto` | 변경 없음 |
+
+### 결정: 두 원본의 동기화 방식
+
+- **대안 A — 심볼릭 링크**: Claude 전용 frontmatter가 파일 앞에 있어야 하므로 파일
+  전체를 링크할 수 없다. 탈락.
+- **대안 B — 생성 스크립트**: 변경 범위(#35가 지정한 3개 파일)를 넘어서고 chezmoi
+  흐름에 빌드 단계를 넣는다. 탈락.
+- **대안 C — 수동 유지 + `diff` 검증(채택)**: 기존 관행과 같고 추가 장치가 없다.
+
+## Interfaces and data flow
+
+### 스킬 입력 계약
+
+```
+<브랜치명|PR참조> [대상세션]
+```
+
+| 입력 | 모드 | 대상 세션 | 창 이름 |
+|---|---|---|---|
+| `1290-bug/partner-robots-yeti-disallow` | 브랜치 | `1-main` (기본) | `1290-partner-robots-yeti-disallow` |
+| `1290-bug/... 2-review` | 브랜치 | `2-review` (명시) | 같음 |
+| `fix/login-bug` | 브랜치 | `1-main` | `--target-name` 생략 |
+| `https://github.com/owner/repo/pull/1247` | PR | `2-review` (모드 기본) | `1247-{짧은이름}` |
+| `zambaguni/zambaguni-front#1313` | PR | `2-review` | `1313-snap-board-grid-windowing` |
+| `.../pull/1247 3-personal` | PR | `3-personal` (명시) | `1247-...` |
+| 위 PR + 저장값 `3-personal`(생존), 세션 미명시 | PR | `3-personal` (저장값 우선) | `1247-...` |
+| 위 PR + 저장값 `3-personal`, `2-review` 명시 | PR | `2-review` (명시 우선) + config 갱신 | `1247-...` |
+| 위 PR + 저장값 `9-gone`(형식 유효, 세션 부재) | PR | R2.5 복구 → 확인 후 `2-review` | `1247-...` |
+| `1313` (표지 없는 맨 숫자) | 브랜치 또는 확인 요청 | — | — |
+| "PR 1313을 2-review에 열어줘" | PR (표지 있음, 저장소는 현재 저장소) | `2-review` | `1313-...` |
+
+### 외부 명령 계약
+
+**저장소·PR 메타데이터 (읽기 전용)**
+
+```bash
+gh repo view --json owner,name -q '.owner.login + "/" + .name'
+gh pr view {번호} --repo {owner}/{repo} --json number,state,headRefName,headRefOid
+```
+
+**worktree 식별과 창 탐지**
+
+```bash
+git worktree list --porcelain
+workmux list --json          # handle, path, branch, is_open, mode
+git config --get workmux.worktree.{handle}.window-session
+tmux list-panes -a -F '#{session_name}:#{window_index} #{window_id} #{pane_id} #{pane_current_path}'
+```
+
+**PR head 확보 (래퍼 경로)**
+
+```bash
+git fetch origin "refs/pull/{PR번호}/head:{head브랜치명}"
+git rev-parse --verify "refs/heads/{head브랜치명}"
+```
+
+**생성 — 래퍼 없음 / 있음**
+
+```bash
+workmux add --pr {PR참조} --target-name {PR번호}-{짧은이름} --parent-session {선택세션}
+workmux add --pr {PR참조} --dry-run     # 사전 확인용, 영속 변경 없음
+
+./scripts/create-worktree.sh {head브랜치명}
+workmux open {handle} --target-name {PR번호}-{짧은이름} --parent-session {선택세션}
+```
+
+**열린 창 이동 (R7.5)**
+
+```bash
+SRC=$(tmux display-message -p -t "{window_id}" '#{session_name}:#{window_index}')
+# move-window-to-session 인자: "$SRC" "{선택세션}"  (+ 컨텍스트로 worktree 경로·handle)
+```
+
+**생성 후 검증**
+
+```bash
+git -C {worktree경로} rev-parse HEAD                  # == headRefOid
+git -C {worktree경로} rev-parse --abbrev-ref HEAD     # == head브랜치명
+tmux list-windows -a -F '#{session_name}:#{window_index}\t#{window_name}'
+git -C {worktree경로} config --get workmux.worktree.{handle}.window-session
+```
+
+### 상태 저장소
+
+| 위치 | 내용 | 읽기 | 쓰기 |
+|---|---|---|---|
+| `workmux.worktree.{handle}.window-session` | 창이 속한 세션 | R2 우선순위 2, R7.1 | R2.2·R2.4·R2.5·R8.2 네 경우만. workmux와 `move-window-to-session`도 각자 쓴다 |
+| `workmux list --json` | handle·path·branch·is_open·mode | R7.0, R7.1, R6.9 | 없음 |
+| tmux 서버 | 세션·윈도우·pane 목록 | R3, R7.1, R8.1 | 창 이동(R7.5)은 `move-window-to-session`이 수행. 세션 자동 생성은 금지 |
+| `git worktree list` | worktree 경로·브랜치 | R7.0 | 없음 |
+| `~/.local/state/workmux/agents/*.json` | 에이전트 상태 | — | `move-window-to-session`이 담당 |
+
+## Failure behavior
+
+| 실패 | 감지 | 동작 |
+|---|---|---|
+| positional 3개 이상 | 인자 개수 | 사용법 안내 후 중단 |
+| 자연어에서 브랜치·PR 참조 2개 이상 | R1.6 | 중단하고 확인 |
+| 자연어에서 세션명 2개 이상 | R1.6 | 중단하고 확인 |
+| 표지 없는 맨 숫자 | R1.5 | 브랜치로 해석하거나 확인. PR로 단정 금지 |
+| **현재 저장소를 확정 못 함** | `gh repo view`·`git remote` 모두 실패 | 중단. R4.2 비교가 성립하지 않으므로 진행 불가 |
+| `gh` 없음·미인증·조회 실패 | 종료 코드 | 보고 후 중단. 추측 금지 |
+| PR base 저장소 불일치 | R4.0의 두 값 비교 | 중단 |
+| PR state가 CLOSED·MERGED | R4.7 | 알리고 계속할지 확인. head 브랜치 삭제 가능성 안내 |
+| **PR head fetch 실패** | `git fetch` 종료 코드 | **중단. 래퍼를 부르지 않는다** — 부르면 빈 브랜치 worktree가 생긴다 |
+| **확보된 OID ≠ `headRefOid`** | `git rev-parse` 비교 | 중단. 래퍼를 부르지 않는다 |
+| **생성된 worktree HEAD ≠ `headRefOid`** | R6.8 | 성공으로 보고하지 않고 PR 내용 없음을 알린다 |
+| 동명 로컬 브랜치가 다른 커밋 | OID 비교 | 중단. 덮어쓰지 않음 |
+| PR head의 worktree가 이미 있음 | R7.0 | **중단이 아님.** 생성만 건너뛰고 R7 창 처리로 진행 |
+| **`is_open` 참인데 pane 매칭 0건** | R7.1 | 추측 금지. `window-session` 세션의 창 목록을 보여 주고 확인 |
+| **pane 매칭 2건 이상** | R7.1 | 그대로 보고하고 확인 |
+| **worktree 경로에 공백** | R7.1 매칭기 한계 | 매칭 결과를 신뢰하지 않고 불일치 처리로 넘어감 |
+| **handle을 얻지 못함** | `workmux list --json` 결과 없음 | 경로 basename 폴백 + `path` 대조. 대조 수단도 없으면 중단 |
+| tmux 서버 부재 | `list-sessions` exit 1 + `error connecting to` | "tmux 서버가 없다"로 보고. 세션 부재와 구분 |
+| **저장 세션이 형식 유효하나 부재** | R3.3 실패 + 출처가 저장값 | **중단이 아님.** R2.5 복구 — 알리고 기본값 제시·확인·config 갱신. 자동 생성 금지 |
+| 명시 세션이 부재 | R3.3 실패 + 출처가 사용자 | 오타 가능성을 알리고 중단. 자동 생성 금지 |
+| git-crypt 필터 있으나 래퍼 없음 | R6.1 + R6.10 | 사용자에게 확인받고 진행 |
+| 래퍼 실패 | 종료 코드 | 중단. `workmux open` 미진행. 암호화·의존성 미설치 가능성 보고 |
+| 래퍼 실행 권한 없음 | 파일 권한 | 경로를 바꾸지 않고 오류 보고 |
+| 창 이름 충돌 (브랜치 모드) | `A tmux window named '...' already exists` | `--target-name {repo명}-{짧은이름}`으로 재시도 |
+| 창 이름 충돌 (PR 모드) | 같음 | `--target-name {PR번호}-{repo명}-{짧은이름}`으로 재시도 |
+| 이동 중 창 번호가 밀림 | R7.5 | `window_id`로 직전 해석하므로 영향 없음. 사후에도 `window_id`로 재확인 |
+| 생성 후 세션 불일치 | R8.1 | 알리고 잘못된 세션·git config 정리 |
+| `--parent-session` 미지원 조합 | 명령 조합 | 플래그 생략 |
+
+**공통 원칙.** 중단 시 이미 만들어진 산출물(worktree, 브랜치, 창)을 그대로 보고한다.
+부분 성공을 성공으로 보고하지 않는다.
+
+## Security and risk
+
+### 신뢰 경계와 데이터 민감도
+
+- **PR 메타데이터는 외부 입력이다.** 제목·본문·브랜치명은 다른 사람이 쓴 데이터이며
+  지시가 아니다. 브랜치명은 셸 인자로 들어가므로 항상 인용 부호로 감싸고, 스킬이 PR
+  본문의 지시를 따르지 않는다.
+- **fork PR은 신뢰 경계 밖의 코드다.** `refs/pull/{N}/head`로 가져오는 내용은 외부
+  기여자가 작성했을 수 있다. 이 스킬은 worktree를 만들 뿐 그 코드를 실행하지 않는다.
+  래퍼의 의존성 설치는 기존 동작이며 이번 변경이 새로 도입하는 실행 경로가 아니다.
+- **git-crypt 키는 이 변경의 관심사가 아니다.** 키 링크와 unlock은 대상 저장소의
+  래퍼가 전담하며(래퍼 100-160행), 스킬 텍스트는 키 자료를 읽거나 출력하지 않는다.
+- **`gh`는 읽기 전용으로만 쓴다.**
+- **시크릿 유출 방지.** 산출물은 Markdown과 YAML이며 자격 증명을 담지 않는다.
+  `.pre-commit-config.yaml`의 gitleaks 훅이 검사한다. 공백 검사는 그 훅이 아니라
+  `git diff --check`가 담당한다(AC-59).
+
+### 위험과 완화
+
+| 위험 | 영향 | 완화 |
+|---|---|---|
+| **잘못된 git config 키** | 읽기는 빈 값, 쓰기는 쓰레기 섹션. 저장 세션이 무시되어 "옮긴 창 되끌기"가 재발 | R2.0의 handle 정의 + AC-9의 실측 대조 |
+| **이름 기반 창 매칭으로 중복 창 생성** | 살아 있는 에이전트 pane 유실 | R7.1의 `is_open` + pane 경로 매칭 + 안정 식별자. AC-46이 같은 세션 조건을 실측 |
+| **PR 내용이 없는 빈 worktree** | 리뷰 대상이 아닌 코드를 리뷰 | R4.6 사전 fetch + R6.8 사후 OID 검증 이중 방어 |
+| **사라진 저장 세션으로 영구 중단** | 매 호출 실패, 자기 교정 경로 없음 | R2.5 복구 경로 |
+| 유령 세션 생성 | workmux가 없는 세션을 만들고 config에 영구 저장 | R3.5 사전 검증 |
+| 의도적으로 옮긴 창 되끌기 | 사용자 배치가 조용히 무너짐 | R2.1 저장값 우선 |
+| 명시 세션 미반영 | 다음 호출이 옛 세션으로 되돌아감 | R2.4 |
+| **이동 중 창 번호 변동** | 엉뚱한 창을 옮김 | R7.5의 `window_id` 직전 해석 |
+| PR 번호와 이슈 번호 혼동 | 엉뚱한 창 이름 | R1.5, R5.3, R5.6. AC-29가 실측 |
+| 로컬 브랜치 덮어쓰기 | 미푸시 커밋 유실 | R4.4 |
+| 열린 창 재구성으로 에이전트 상태 유실 | 작업 손실 | R7.5 |
+| **`description` 미갱신으로 라우팅 실패** | PR 자연어 호출이 스킬에 도달하지 못함 | R9.5 + AC-55 |
+| 기존 규칙 유실 | 재작성 과정에서 안전장치가 사라짐 | R9.6 목록 + AC-56 |
+| 두 원본 drift | Claude와 Codex가 다르게 동작 | R9.1 + AC-52 |
+| 스모크 테스트 부작용 | 실제 worktree·창 생성 | 자신의 dotfiles PR #31 + `--dry-run` 사전 확인 + 정리 절차 |
+
+### 롤백
+
+산출물은 chezmoi 소스의 Markdown·YAML 3개 파일이다. 롤백은 `git revert` 또는
+`git checkout -- {경로}` 후 `chezmoi apply`이며 데이터 마이그레이션이 없다. 스모크
+테스트로 만들어진 worktree·창·로컬 브랜치는 Test strategy의 정리 절차로 제거한다.
+
+### 비적용 항목
+
+standard 등급이며 다음은 해당 사항이 없다.
+
+- **인증·인가·테넌시**: 권한 경계를 다루지 않는다. `gh`는 사용자 자신의 기존 자격
+  증명을 쓰며 이 변경이 권한을 넓히지 않는다.
+- **DB 스키마·마이그레이션·백필**: 영속 스키마가 없다.
+- **공개 API 호환성·멱등성·동시성**: 외부 노출 계약이 없다. 단일 사용자가 대화형으로
+  호출한다.
+- **프로덕션 변경**: 프로덕션 시스템을 건드리지 않는다.
+
+## Test strategy
+
+이 저장소에는 테스트 스위트·타입 체크·빌드가 없다(`package.json`, `Makefile`,
+`justfile`, `.github/workflows` 부재 실측). 검증은 세 층으로 한다.
+
+### 1층 — 부작용 없는 실행 검사
+
+| 검사 | 명령 | 커버 |
+|---|---|---|
+| frontmatter | `quick_validate.py` 2회, 기준선 대조 | AC-58 |
+| `argument-hint` | `grep -q` | AC-7 |
+| `description` | 두 파일 3행에 PR·session 표현 존재, 양쪽 동일 | AC-55 |
+| 두 본문 동일성 | `diff` → `3a4,6`과 그 3줄만 | AC-52 |
+| `1-main` 잔존 | 허용/금지 목록 대조 | AC-18 |
+| 보존 규칙 18개 | R9.6 목록을 두 파일에서 확인 | AC-56 |
+| `openai.yaml` | `grep -qE '2-review\|pull/'` | AC-53 |
+| tmux 서버 부재 | `tmux -L quality-goal-nonexistent-socket list-sessions` → exit 1 | AC-15 |
+| 없는 세션 판정 | `grep -qxF -- 'definitely-not-a-session'` → exit 1 | AC-16 |
+| 접두사 함정 | `has-session -t 2` → 0, `-t 2-rev` → 0, `grep -qxF 2-rev` → 1 | AC-17 |
+| chezmoi 일치 | `chezmoi diff` → `chezmoi apply` → 3개 파일 `cmp` | AC-54 |
+| 공백·시크릿 | `git diff --check`, `pre-commit run --all-files` | AC-59 |
+
+tmux 검사 3종은 읽기 전용이거나 별도 소켓을 쓰므로 실제 세션 배치를 바꾸지 않는다.
+예상 종료 코드는 2026-08-27에 실측했다.
+
+### 2층 — 문서 검토
+
+`[문서]` 기준은 절차 서술이므로 해당 규칙이 두 SKILL.md에 명시적으로 기술되어 있는지
+검토로 판정한다. 확인 대상은 수용 기준 표에 특정해 두었다.
+
+**이 층의 한계.** 문서 존재 검사는 "규칙이 올바르게 적혀 있음"만 보이고 "따랐을 때
+실제로 옳은 결과가 나옴"은 보이지 않는다. 그래서 위험도가 높은 항목들(유령 세션 방지,
+서버 부재 구분, 접두사 함정, git config 키 정합, 창 매칭 정확도, 중복 창 금지, 창
+이동, PR 번호 파생, worktree 내용, 세션 덮어쓰기, description 라우팅, 보존 규칙)은
+1층·3층의 실행 검사로 끌어올렸다. 남은 `[문서]` 기준은 실패 상황을 인위로 만들어야
+검증되는 것들(fetch 실패, 저장소 불일치, 래퍼 부재 등)이며, 이 한계를 보고서에
+기록한다.
+
+### 3층 — 실제 스모크 테스트
+
+**대상**: `lee-kyu-hwan/dotfiles` PR #31.
+
+**가용성 실측 (2026-08-27)**: `state=OPEN`, head 브랜치
+`30-enhancement/tmux-open-pr-shortcut`가 원격에 존재(`9cfc6267...`),
+`refs/pull/31/head`도 같은 OID.
+
+**선정 근거**: PR 번호(31)와 head 브랜치의 이슈 번호(30)가 달라 R5.3을 판별한다.
+dotfiles는 git-crypt가 아니고 래퍼도 없으므로 `workmux add --pr` 경로를 탄다.
+
+**사전 확인**: `workmux add --pr 31 --dry-run`으로 예상 경로·handle·target을 먼저
+본다. 영속 변경이 없다. 실측된 예상값은 worktree
+`.../dotfiles__worktrees/30-enhancement-tmux-open-pr-shortcut`, handle
+`30-enhancement-tmux-open-pr-shortcut`이다.
+
+**대체 계획**: 실행 시점에 #31이 닫혀 head 브랜치가 사라졌으면 같은 조건(PR 번호 ≠
+head 브랜치 접두사 숫자)을 만족하는 다른 열린 PR로 교체한다. PR #32는 head가
+`feat/codex-playwright-e2e-profile`로 숫자 접두사가 없어 AC-29를 판별하지 못하므로
+대체 대상이 아니다. 조건을 만족하는 PR이 없으면
+AC-9·13·29·35·39·40·43·46·48·49·51·57을 문서 검토로 강등하고 보고서에 한계로 명시한다.
+이 강등은 "조건 만족 PR 부재"가 관찰되었을 때만 발동한다.
+
+#### 1차 — 세션 미명시 신규 생성
+
+| 단계 | 관찰 | 커버 |
+|---|---|---|
+| 세션 미명시로 PR 모드 실행 | 창이 `2-review`에 열림 | AC-57 |
+| 창 이름 | `31-tmux-open-pr-shortcut` (`30-`으로 시작하지 않음) | AC-29 |
+| worktree 브랜치 | `rev-parse --abbrev-ref HEAD` == `30-enhancement/tmux-open-pr-shortcut` | AC-35 |
+| worktree HEAD | `rev-parse HEAD` == `9cfc6267ced574945814536710cf1019a37dc354` | AC-39 |
+| handle·경로 확보 | `workmux list --json`에서 `branch` 일치 항목의 `handle`·`path`를 읽어 보고 | AC-40 |
+| **git config 키 정합** | `git config --get-regexp '^workmux\.worktree\.'`의 모든 키가 `workmux.worktree.{handle}.*` 형태. handle이 브랜치 슬러그와 다를 때만 브랜치 유추 키 exit 1을 추가 증거로 기록 | AC-9 |
+| **창 매칭 정확도** | pane 경로 매칭이 방금 만든 창의 `window_id`를 정확히 1건 반환 | AC-43 |
+| 실제 창 위치 | `tmux list-windows -a` 출력 기록 | AC-49 |
+| 결과 보고 | 경로·handle·브랜치·세션·창이름·PR번호·head OID 7항목 | AC-51 |
+
+#### 2차 — 같은 세션 재호출 (R7.3의 조건)
+
+1차로 창이 `2-review`에 있는 상태에서 **같은 세션 `2-review`를 명시해** 재호출한다.
+
+| 단계 | 관찰 | 커버 |
+|---|---|---|
+| 같은 PR을 `2-review` 명시로 재호출 | 중복 창이 생기지 않음 — pane 경로 매칭 결과가 1건 유지, `window_id`도 동일 | AC-46 |
+
+이 단계가 R7.3의 "선택 세션 == 현재 세션" 분기를 실제로 태운다.
+
+#### 3차 — 다른 세션 명시 이동 (R7.5·R2.4의 조건)
+
+| 단계 | 관찰 | 커버 |
+|---|---|---|
+| 같은 PR을 `3-personal` 명시로 재호출 | 창이 `3-personal`로 이동하고 `window_id`가 1차와 동일(재생성 아님) | AC-48 |
+| git config 갱신 | `window-session`이 `2-review` → `3-personal`로 바뀜 | AC-13 |
+
+#### 정리 절차 (검증 후 필수)
+
+```bash
+workmux remove {handle}              # worktree + 창 제거
+git worktree list                    # 잔여물 없음 확인
+tmux list-windows -a                 # 잔여 창 없음 확인
+git branch --list '30-enhancement/tmux-open-pr-shortcut'   # 남아 있으면 그때만 -D
+```
+
+`workmux remove`가 로컬 브랜치까지 지우므로(`remove-worktree/SKILL.md:26`)
+`git branch -D`를 무조건 실행하지 않는다. 남아 있는지 먼저 확인하고 남았을 때만 지운다.
+
+**git-crypt 경로(AC-36)는 스모크 테스트하지 않는다.** `zambaguni-front` worktree
+생성은 의존성 설치로 개당 1~2GB를 쓰고 업무 저장소에 부작용을 남긴다. 문서 검토로
+판정하고 보고서에 한계로 기록한다. 다만 R4.6의 근거인 래퍼의 3단계 판별 로직은
+`zambaguni-front/scripts/create-worktree.sh:82-98`을 직접 읽어 확인했다.
+
+## Decisions
+
+### D1. 세션 우선순위에서 저장값이 모드 기본값보다 우선한다
+
+이슈 #35는 "명시값 > 모드 기본값 > 저장 세션 > 1-main"을 권장했다. 이를 뒤집어
+"명시값 > 저장 세션 > 모드 기본값 > 1-main"으로 채택했다.
+
+근거: 저장값은 사용자가 `move-window-to-session`으로 직접 창을 옮긴 행동의 기록이고,
+모드 기본값은 관습이다. 관습이 기록을 덮으면 현행 "예외 1"이 막으려던 실패가
+`2-review` 이름으로 재발한다. 사용자가 2026-08-27 확인에서 이 순서를 선택했다. 신규
+worktree에는 저장값이 없으므로 PR 모드 기본값 `2-review`가 정상 동작한다(AC-57 실측).
+
+### D2. PR 참조는 표지가 있을 때만 인식한다
+
+표지 없는 맨 숫자를 PR로 해석하지 않는다. GitHub는 이슈와 PR이 번호 공간을 공유하므로
+맨 숫자를 PR로 단정하면 엉뚱한 브랜치를 체크아웃할 수 있다. R1.4의 자연어 케이스가
+R1.5와 모순되지 않는 이유는 금지 대상이 **표지 없는** 맨 숫자이기 때문이다.
+
+### D3. PR 모드에서 positional 브랜치명을 생략한다
+
+`workmux add --help` 실측: "`[BRANCH_NAME]` ... When used with `--pr`, this becomes the
+custom local branch name". positional을 주면 PR head 대신 그 이름으로 로컬 브랜치가
+생긴다. 같은 `--help`에서 `--target-name`·`--parent-session`이 `--pr`와 공존 가능함도
+확인했다.
+
+### D4. worktree 식별자는 handle이며 유추하지 않는다
+
+`{이름}`을 `workmux list --json`의 `handle`(= `path` basename)로 정의했다.
+
+대안 비교:
+
+- **대안 A — 브랜치명 사용**: 실측 반례가 존재한다. 디렉터리
+  `feat-quality-goal-skill` / 브랜치 `chore/post-upgrade-skill-maintenance`에서 브랜치
+  유추 키 조회가 exit 1이다. 탈락.
+- **대안 B — tmux 창 이름 사용**: `--target-name`으로 결정되며 모드마다 다르다. 탈락.
+- **대안 C — 경로 basename 사용**: 대체로 handle과 같지만 `worktree_naming` 설정이
+  바뀌면 어긋날 수 있다. `workmux list --json`이 없을 때의 폴백으로만 두고 `path`
+  대조를 요구한다.
+- **대안 D — `workmux list --json`의 `handle`(채택)**: workmux 자신이 쓰는 이름을
+  직접 읽으므로 유추가 없다.
+
+**handle이 브랜치 슬러그와 같을 수도 있다.** `workmux add --pr 31 --dry-run` 실측에서
+handle이 `30-enhancement-tmux-open-pr-shortcut`으로 브랜치 슬러그와 일치했다. 이는
+대안 A를 정당화하지 않는다 — 같을 수도 다를 수도 있어 **예측이 불가능**하다는 것이
+핵심이고, 그래서 읽어야 한다. 이 사실은 AC-9의 판정 기준에도 반영했다(브랜치 유추 키
+조회 실패를 필수 조건이 아니라 조건부 증거로 강등).
+
+### D5. 창 탐지는 이름이 아닌 안정 식별자로 한다
+
+`is_open` → `window-session` → pane 경로 매칭 3단계를 쓰고, 얻은 `window_id`·`pane_id`를
+이후 조작의 기준으로 삼는다.
+
+대안 비교:
+
+- **대안 A — 창 이름 매칭**: 모드마다 파생 규칙이 다르다. PR #31 dry-run 실측이 직접
+  사례다 — handle `30-enhancement-tmux-open-pr-shortcut` vs PR 모드 창 이름
+  `31-tmux-open-pr-shortcut`. 열린 창을 놓치고 중복 창을 만든다. 탈락.
+- **대안 B — `session:index` 사용**: `move-window`와 번호 재정렬로 바뀐다
+  (`move-window-to-session/SKILL.md:32-39`). 추적 기준으로 부적합. 탈락.
+- **대안 C — 에이전트 state 파일 조회**: `~/.local/state/workmux/agents/*.json`은
+  에이전트가 붙은 pane만 담는다. 레이아웃이 nvim만 자동 실행하므로
+  (`~/.config/workmux/config.yaml:9-16`) 창이 있어도 항목이 없을 수 있다. 탈락.
+- **대안 D — `is_open` + pane 경로 + `window_id`(채택)**: 실측으로 tmux 실제 상태와
+  일치함을 확인했고 이름에 의존하지 않는다.
+
+pane cwd는 사용자가 바꿀 수 있고 매칭기가 공백 경로에 약하므로 완전하지 않다. 그래서
+0건·2건 이상·공백 경로에서 추측하지 않고 확인받는 규칙을 함께 둔다(R7.1).
+
+### D6. 래퍼는 고치지 않고 스킬이 전제를 보장한다
+
+래퍼의 "둘 다 없으면 현재 HEAD에서 새 브랜치"는 브랜치 모드에서는 올바른 동작이다.
+문제는 PR 모드에서 head가 `origin`에 없을 때(fork PR)뿐이다.
+
+- **대안 A — 래퍼에 `--pr` 지원 추가**: 다른 저장소를 고쳐야 하고 변경 범위 밖. 탈락.
+- **대안 B — 스킬이 호출 전 fetch로 전제 보장(채택)**: `refs/pull/{N}/head`를 로컬
+  브랜치로 가져오면 래퍼의 2번 경로로 확정된다. 같은 저장소 PR과 fork PR을 동일하게
+  처리한다.
+- **대안 C — PR 모드에서 git-crypt 저장소 미지원**: #28의 요구를 포기. 탈락.
+
+사후 검증(R6.8)을 함께 두어 전제 보장이 실패해도 조용한 성공이 되지 않게 한다.
+
+### D7. 기존 worktree는 중단이 아니라 창 처리로 분기한다
+
+이슈 #28의 "중단한다"는 **중복 worktree나 별칭 브랜치를 만들지 말라**는 뜻이지 창을
+열지 말라는 뜻이 아니다. 문자 그대로 전체 중단으로 읽으면 PR 리뷰 창을 두 번째부터
+영영 열 수 없어 Goal 2와 R7 전체가 무의미해진다. "생성 단계만 건너뛰고 R7으로 진행"
+으로 확정했다(R4.3).
+
+### D8. PR state는 소비하되 자동 중단하지 않는다
+
+`state`를 조회 필드에 넣고 R4.7에서 소비한다. CLOSED·MERGED PR을 사후에 들여다보는
+것은 정당한 용도이므로 자동 중단하지 않고 알린 뒤 확인받는다. 저장소 관련 필드는 R4.0이
+URL·현재 저장소에서 확정하므로 조회 필드에서 제외했고, fork 여부는 pull ref가 균일
+처리하므로 `isCrossRepository`도 넣지 않는다 — 요구만 하고 쓰지 않는 필드는 검증을
+형식화한다.
+
+### D9. workmux 버전 표기 불일치를 `dot_claude` 쪽으로 통일한다
+
+이슈 #35는 두 원본이 frontmatter만 다르다고 전제했으나 실측에서 `dot_agents:43`
+"0.1.233 실측"과 `dot_claude:46` "0.1.233 확인·0.1.248 재확인"이 다르다. 후자가 현재
+설치 버전까지 재확인한 더 정확한 서술이므로 그쪽으로 통일한다.
+
+### D10. 스모크 테스트를 3차까지 나눈다
+
+한 번의 호출로는 R7.3(같은 세션)과 R7.5(다른 세션)를 동시에 태울 수 없다. 두 분기는
+상호 배타적이므로 각각의 조건을 만드는 호출이 필요하다.
+
+- 1차 — 신규 생성, 세션 미명시 → R2 우선순위 3, 이름 파생, 내용 검증
+- 2차 — 같은 세션 명시 → R7.3의 중복 창 금지
+- 3차 — 다른 세션 명시 → R7.5의 이동과 R2.4의 config 갱신
+
+2차를 빼고 3차만 하면 R7.3의 분기 조건이 한 번도 실행되지 않는다.
+
+### D11. 정리 시 `git branch -D`를 조건부로 한다
+
+`remove-worktree/SKILL.md:26`에 따르면 `workmux remove`가 로컬 브랜치까지 지운다.
+무조건 실행하면 정리 중 오류가 난다. `git branch --list`로 확인한 뒤 남았을 때만
+지운다.
+
+### D12. `move-window-to-session`의 입력 계약에 맞춰 호출한다
+
+그 스킬의 계약은 `<윈도우이름|세션:번호> <대상세션>`이며 내부에서 `{원본세션}:{번호}`,
+`{worktree경로}`, `{worktree명}`을 쓴다. 스킬 수정은 비범위이므로 `window_id`를 그대로
+넘기지 않고, 호출 직전에 `tmux display-message -p -t "{window_id}"`로 현재
+`세션:번호`를 해석해 넘긴다(R7.5).
+
+`window_id`를 거쳐 해석하는 이유는 R7.1 시점과 호출 시점 사이에 다른 창이 열리고 닫혀
+번호가 밀렸을 수 있기 때문이다. 이동 후 재확인도 같은 `window_id`로 한다. 그 스킬의
+3-(a)가 `window-session`을 갱신하므로 R2.4는 덮어쓰기가 아니라 확인으로 동작한다.
+
+### D13. `description`도 갱신한다
+
+`argument-hint`만 고치면 Claude의 인자 힌트는 맞지만 **라우팅이 바뀌지 않는다.**
+`description`은 에이전트가 "이 요청에 이 스킬을 쓸까"를 판단하는 문장이고, 현재 양쪽
+파일 모두 브랜치만 언급한다(실측). PR 참조가 유효한 입력이 된 이상 그 문장도 PR과
+대상 세션을 포함해야 "PR 31을 2-review에 열어줘"가 스킬에 도달한다. 두 파일의
+`description`은 서로 동일하게 유지한다(R9.1의 본문 동일성과 별개로, frontmatter의
+`description`은 양쪽 공통 필드다).
+
+### D14. 보존 대상 규칙을 명시적으로 열거한다
+
+Goal 5의 "회귀 없음"은 검증 가능해야 한다. 재작성 과정에서 조용히 사라지기 쉬운 현행
+규칙 18개를 R9.6에 열거하고 AC-56으로 확인한다. 특히 5번(git-crypt 필터 있으나 래퍼
+없음)은 R6.1의 분기가 래퍼 존재만 보기 때문에 누락되면 R6.2가 금지하는 경로로 조용히
+들어간다.
+
+### D15. 스모크 테스트 대상은 dotfiles PR #31이다
+
+PR 번호(31)와 head 브랜치 이슈 번호(30)가 달라 R5.3을 판별하는 가용 케이스다.
+2026-08-27 실측으로 `state=OPEN`이고 head 브랜치가 원격에 살아 있음을 확인했으며,
+`--dry-run`으로 예상 산출물까지 미리 확인했다. PR #32는 head에 숫자 접두사가 없어
+대체 대상이 아니다. #31이 닫혔을 경우의 대체 계획은 Test strategy 3층에 있다.
+
+### D16. git-crypt 경로는 문서 검토 + 래퍼 소스 확인으로 검증한다
+
+실제 검증은 업무 저장소에 1~2GB 규모 부작용을 남긴다. 대신 R4.6의 근거가 되는 래퍼의
+브랜치 판별 로직을 소스에서 직접 읽어 확인했고 그 실측을 Problem and context에
+기록했다. 이 한계를 보고서에 명시한다.
+
+### 미해결 사항
+
+없다. 모든 중대 결정이 위에 해소되어 있다.

--- a/docs/development/2026-08-27-create-worktree-pr-session/report.md
+++ b/docs/development/2026-08-27-create-worktree-pr-session/report.md
@@ -1,0 +1,236 @@
+# Quality Goal Report
+
+- Task ID: 20260827T080329Z-28-35-create-worktree-스킬에-pr-링크-입력-시-2-r-6b97d528
+- Mode: standard
+- Status: NEEDS_REDESIGN
+- Created: 2026-08-27T08:03:29Z
+- Updated: 2026-08-27T08:03:34Z
+- Source goal: #28 #35 create-worktree 스킬에 PR 링크 입력 시 2-review 세션에 PR 번호 윈도우를 생성하고 대상 세션을 직접 지정할 수 있도록 확장한다
+
+## Classification
+
+선택 모드: **standard** (요청 모드 `auto`).
+
+**strict 트리거 없음.** 인증·인가·테넌시, 결제·정산·쿠폰 회계, PII·보안통제·시크릿,
+DB·스키마 마이그레이션·파괴적 작업, 공개 API·웹훅·큐·멱등성·동시성, 프로덕션 인프라
+중 어느 것도 해당하지 않는다. 변경 대상은 chezmoi 소스 트리의 Markdown 스킬 지침이며
+롤백은 `git revert` + `chezmoi apply`로 단순하다. git-crypt 키 링크는 대상 저장소의
+자체 래퍼에 위임되어 있고(`dot_claude/skills/create-worktree/SKILL.md:116`) 이번 변경이
+그 흐름을 보존하므로 스킬 텍스트가 키 자료를 직접 다루지 않는다.
+
+**standard 조건 4가지가 모두 성립.**
+
+1. 다중 파일·레이어 — 이슈 #35 "변경 대상"이 `dot_agents/skills/create-worktree/SKILL.md`,
+   `dot_agents/skills/create-worktree/agents/openai.yaml`,
+   `dot_claude/skills/create-worktree/SKILL.md` 3개 파일을 지정하며 Claude/Codex 두
+   런타임 트리에 걸친다.
+2. 인터페이스·상태 전이 변경 — 스킬 입력 계약에 선택적 대상 세션 인자와 PR URL 모드가
+   추가되고, Claude frontmatter `argument-hint`가 바뀌며, 4단계 세션 선택 우선순위가
+   신설된다.
+3. 비자명한 신규 인터페이스 의존 — `workmux add --pr <NUMBER|URL>` (workmux 0.1.248에
+   실재 확인) 및 git-crypt 경로의 `gh` PR 메타데이터 조회.
+4. 대안·비범위·수용 기준의 명시 필요 — #35에 "비범위" 절과 완료 조건이 있고 #28에도
+   완료 조건이 있으며, 두 이슈를 충돌 없이 결합해야 한다.
+
+**이슈 사실 검증 편차 1건.** 이슈 #35는 "두 원본의 차이가 Claude frontmatter뿐"이라고
+전제하나, 실측 `diff`에서 frontmatter 3줄 외에 workmux 버전 표기 문구가 1줄 다르다
+(`dot_agents:43` "0.1.233 실측" vs `dot_claude:46` "0.1.233 확인·0.1.248 재확인").
+Spec의 D5로 처리 방침을 정했다.
+
+## Review history
+
+| 아티팩트 | 라운드 | 점수 | 판정 | 블로커 | 게이트 |
+|---|---|---|---|---|---|
+| Spec | 1 | 75 | REVISE | SPEC-001, SPEC-002, SPEC-003 | 실패 — `score_below_85`, `verdict_not_pass`, `blockers_present`, `critical_or_high_finding`, `check_failed:acceptance_criteria_objective` |
+| Spec | 2 | 82 | REVISE | (없음) | 실패 — `score_below_85`, `verdict_not_pass`, `critical_or_high_finding` |
+
+Plan 및 코드 리뷰 라운드는 수행되지 않았다 (Spec 단계에서 종료).
+
+**라운드 간 변화.** 라운드 1의 블로커 3건과 Medium/Low 7건을 모두 개정했고, 라운드 2
+리뷰어가 SPEC-001·002·003·004·009의 해소를 증거와 함께 확인했다. 점수는 75 → 82로
+올랐으나 통과 기준 85에 미달했고, 개정 과정에서 드러난 새로운 High 2건(SPEC-011,
+SPEC-012)이 남았다. 스킬 규칙상 Spec 리뷰는 최대 2라운드이므로
+(`references/spec-rubric.md`의 "After round 2 without a passing gate, stop and record
+`NEEDS_REDESIGN`") 여기서 종료한다.
+
+## Blocking-finding resolutions
+
+| ID | 라운드 | 심각도 | 해소 내용 | 검증 증거 |
+|---|---|---|---|---|
+| SPEC-001 | 1 | High | git-crypt 래퍼 경로에서 PR head 브랜치를 확보하는 방법이 미정의였다. R4.6(`git fetch origin refs/pull/{N}/head:{head브랜치명}` + `git rev-parse --verify`)과 R6.8(생성 후 `HEAD == headRefOid` 검증)을 추가하고, 실패 행 3개와 AC-21·AC-34를 신설했다 | 라운드 2 리뷰어 확인: "R4.6 now mandates ... and R6.8 adds post-creation HEAD==headRefOid verification. The stated basis is accurate." 근거는 `zambaguni-front/scripts/create-worktree.sh:82-98`을 직접 읽어 확인 — 브랜치가 로컬·`origin` 양쪽에 없으면 현재 HEAD에서 `-b`로 빈 브랜치를 만든다 |
+| SPEC-002 | 1 | High | R4.3의 무조건 중단이 R7 창 처리와 모순이었다. "생성 단계만 건너뛰고 R7으로 진행"으로 재정의하고(D7), 흐름도 분기 순서를 `worktree 판정(R7.0) → 세션 선택(R2)`으로 교정했으며, 실패 표에 "중단이 아님" 행을 넣었다 | 라운드 2 리뷰어 확인: "R4.3 now says only the creation step is skipped and control passes to R7 window handling, the flow diagram step 7 matches, the failure table row states '중단이 아님', and D7 records the departure from issue #28's literal wording." |
+| SPEC-003 | 1 | High | 18개 요구사항에 대응 AC가 없었다. 요구사항을 51개(R1.1–R9.4)로 정리하고 AC를 48개로 확장한 뒤 "요구사항 전수 대응 확인" 목록을 추가했다 | 라운드 2 리뷰어 확인: "all 51 requirements ... appear in the requirement-to-AC mapping list with no omissions; I enumerated both lists and they match." |
+
+라운드 2에는 블로커로 지정된 항목이 없다. 아래 "Remaining advisory findings"의 SPEC-011·
+SPEC-012는 High 심각도이나 리뷰어가 `blockers` 배열에 넣지 않았고
+`new_blocker_evidence`도 제공하지 않았다. 게이트는 `critical_or_high_finding` 사유로
+실패했다.
+
+### 라운드 1의 Medium/Low 해소
+
+| ID | 심각도 | 해소 내용 |
+|---|---|---|
+| SPEC-004 | Medium | `1-main` 잔존 검사를 리터럴 grep에서 전수 감사(허용 3용례 / 금지 5용례 목록)로 확장. 라운드 2 리뷰어가 해소 확인 |
+| SPEC-005 | Medium | PR #31의 가용성을 실측으로 기록(`state=OPEN`, 원격 head `9cfc6267...` 생존, `refs/pull/31/head` 동일 OID)하고 대체 계획을 명시. 리뷰어의 "이미 머지되었을 것" 우려는 실측으로 반증됨 |
+| SPEC-006 | Medium | 고위험 3건(유령 세션 방지·tmux 서버 부재 구분·접두사 함정)을 문서 존재 검사에서 부작용 없는 실행 검사로 승격. 세 명령의 종료 코드를 실측 |
+| SPEC-007 | Medium | 명시 세션이 유효 저장값을 덮었을 때의 git config 갱신 규칙을 R2.4로 신설 |
+| SPEC-008 | Medium | 자연어 호출을 2-튜플로 환원하는 규칙(R1.6)과 "표지 있는 숫자"로 R1.5와의 모순을 해소(D2) |
+| SPEC-009 | Medium | PR 모드 충돌 재시도 이름을 `{PR번호}-{repo명}-{짧은이름}`으로 분리해 PR 번호를 보존(R5.6). 라운드 2 리뷰어가 해소 확인 |
+| SPEC-010 | Low | `quick_validate.py`의 절대 경로와 파일별 실측 기준선을 명시. `dot_claude`는 Claude 전용 키 안내가 나오지만 exit 0임을 기록 |
+
+SPEC-005·006·007·008·010은 라운드 2 리뷰어가 **검증하지 못했다** — 리뷰 호출 계약이
+"prior open finding IDs"만 전달하도록 규정되어 있어 라운드 1의 설명 원문이 전달되지
+않았기 때문이다. 리뷰어는 이를 `NOT VERIFIED`로 명시하고, 새 findings가 이들 중 하나를
+재진술했을 가능성을 배제할 수 없다고 기록했다. 오케스트레이터가 대조한 결과 SPEC-011·
+SPEC-012는 라운드 1의 어느 항목과도 일치하지 않는 새 발견이다.
+
+## Plan approval
+
+- Approval timestamp: 해당 없음 — Spec 단계에서 종료되어 Plan을 작성하지 않았다.
+- Plan digest: 해당 없음.
+
+사용자 승인 게이트(`AWAITING_PLAN_APPROVAL`)에 도달하지 않았다.
+
+## Changed files
+
+구현이 시작되지 않았으므로 **저장소 소스 파일 변경은 없다.** 이번 실행이 생성한 파일은
+산출물 문서뿐이다.
+
+| 경로 | 종류 | 내용 |
+|---|---|---|
+| `docs/development/2026-08-27-create-worktree-pr-session/spec.md` | 산출물 | 개정된 Spec (SHA-256 `8f001e7553c9c6fe707c20af9dc8925f3d10543a92a687335047ad8c75378693`) |
+| `docs/development/2026-08-27-create-worktree-pr-session/report.md` | 산출물 | 이 보고서 |
+
+의도한 변경 대상이었으나 **손대지 않은** 파일:
+
+- `dot_agents/skills/create-worktree/SKILL.md`
+- `dot_claude/skills/create-worktree/SKILL.md`
+- `dot_agents/skills/create-worktree/agents/openai.yaml`
+
+baseline 리비전 `6d8ccad16b4f8345130fe56913a2eead4169030f` 기준으로 사전 dirty 경로는
+없었고, 현재도 위 3개 파일은 수정되지 않았다.
+
+## Verification evidence
+
+구현 단계에 도달하지 않았으므로 **코드 검증은 수행되지 않았다.** 아래는 Spec 작성과
+분류 근거를 위해 실제 실행한 명령이다.
+
+### 실행한 명령
+
+| 명령 | 종료 코드 | 증거 |
+|---|---|---|
+| `git rev-parse --is-inside-work-tree` | 0 | `true` |
+| `codex --version` | 0 | `codex-cli 0.149.1` |
+| `codex exec --sandbox read-only --ephemeral --model gpt-5.6-terra -c model_reasoning_effort="low" "Reply with one non-empty line."` | 0 | `Acknowledged.` — 선택 모델 preflight 통과 |
+| `git check-ignore -v .claude/quality-state/` | 0 | `.gitignore:25:.claude/quality-state/` — 런타임 상태가 이미 무시됨 |
+| `workmux --version` | 0 | `workmux 0.1.248` |
+| `workmux add --help` | 0 | `--pr <NUMBER\|URL>` 존재. `[BRANCH_NAME] ... When used with --pr, this becomes the custom local branch name` |
+| `workmux open --help` | 0 | `--pr` 없음. `--target-name`, `--parent-session` 존재 |
+| `tmux list-sessions -F '#{session_name}'` | 0 | `1-main`, `2-review`, `3-personal`, `4-eslint`, `5-quick` |
+| `tmux -L quality-goal-nonexistent-socket list-sessions` | 1 | `error connecting to /private/tmp/tmux-501/quality-goal-nonexistent-socket (No such file or directory)` — 서버 부재 감지 근거 |
+| `tmux list-sessions -F '#{session_name}' \| grep -qxF -- 'definitely-not-a-session'` | 1 | 없는 세션 판정 근거 |
+| `tmux has-session -t 2` | 0 | 접두사 함정 재현 — 세션 `2`는 없으나 exit 0 |
+| `tmux has-session -t 2-rev` | 0 | 접두사 함정 재현 |
+| `tmux list-sessions -F '#{session_name}' \| grep -qxF -- '2-rev'` | 1 | `grep -qxF`가 올바르게 불일치 판정 |
+| `gh pr view 31 --repo lee-kyu-hwan/dotfiles --json state,headRefName,headRefOid` | 0 | `state=OPEN`, `30-enhancement/tmux-open-pr-shortcut`, `9cfc6267ced574945814536710cf1019a37dc354` |
+| `git ls-remote origin '30-enhancement/tmux-open-pr-shortcut'` | 0 | `9cfc6267...` — 원격 head 브랜치 생존 |
+| `git ls-remote origin 'refs/pull/31/head'` | 0 | `9cfc6267...` — 동일 OID |
+| `gh pr view 32 --repo lee-kyu-hwan/dotfiles --json state,headRefName` | 0 | `state=OPEN`, `feat/codex-playwright-e2e-profile` |
+| `git config --get filter.git-crypt.smudge` (dotfiles) | 1 | 값 없음 — git-crypt 아님. `scripts/create-worktree.sh`도 부재 |
+| `git config --get filter.git-crypt.smudge` (zambaguni-front) | 0 | `"git-crypt" smudge` — 래퍼 존재 |
+| `quick_validate.py dot_agents/skills/create-worktree` | 0 | `Skill is valid!` |
+| `quick_validate.py dot_claude/skills/create-worktree` | 0 | `Unexpected key(s) in SKILL.md frontmatter: argument-hint, user-invocable.` — 종료 코드는 0 |
+| `diff dot_agents/.../SKILL.md dot_claude/.../SKILL.md` | 1 | `3a4,6` (frontmatter 3줄) + 43/46행 버전 표기 1줄 |
+| `validate_review.py validate --input spec-review-round1.json --artifact spec` | 0 | `{"valid":true,"errors":[]}` |
+| `validate_review.py gate --input spec-review-round1.json --checks spec-checks-round1.json` | 3 | `{"passed":false,...}` |
+| `validate_review.py validate --input spec-review-round2.json --artifact spec --prior ...` | 0 | `{"valid":true,"errors":[]}` |
+| `validate_review.py gate --input spec-review-round2.json --checks spec-checks-round2.json --prior ...` | 3 | `{"passed":false,"reasons":["score_below_85","verdict_not_pass","critical_or_high_finding"]}` |
+
+### 검증 카테고리 상태
+
+| 카테고리 | 상태 | 근거 |
+|---|---|---|
+| 표적 테스트 | `not configured` | `package.json`, `Makefile`, `justfile` 부재 확인 |
+| 전체 스위트 | `not configured` | 같음 |
+| 타입 체크 | `not configured` | 같음 |
+| 린트 | `not configured` | `.pre-commit-config.yaml`에 gitleaks 훅만 존재 (시크릿 스캔 전용) |
+| 빌드 | `not configured` | `package.json`, `.github/workflows` 부재 확인 |
+| E2E / 수동 검증 | **미실행** | 구현 단계에 도달하지 않아 Spec의 3층 스모크 테스트(dotfiles PR #31)를 실행하지 않았다. 통과로 기록하지 않는다 |
+
+## Remaining advisory findings
+
+### High (게이트 실패 사유)
+
+| ID | 요약 | 영향 | 후속 조치 |
+|---|---|---|---|
+| SPEC-011 | R7.1–R7.4이 "창이 열려 있는지, 어느 세션인지"로 분기하지만 **그것을 판정하는 방법이 미정의**다. R7.0은 worktree 경로만 얻고, `tmux list-windows -a`는 R8.1의 사후 검증에만 등장한다. PR 모드에서 특히 위험하다 — 브랜치 모드로 먼저 만든 worktree의 창 이름은 `30-tmux-open-pr-shortcut`인데 PR 모드는 `31-tmux-open-pr-shortcut`을 파생하므로 이름 기반 매칭은 열린 창을 놓치고 R7.2(중복 창 금지)가 조용히 실패한다 | 중복 창 생성, 살아 있는 에이전트 pane 유실 가능 | R7에 창 탐지 규칙(명령과 매칭 키)을 신설하고, 창 이름이 다른 규칙으로 파생된 경우를 명시적으로 다룰 것. 규칙 텍스트만으로 충족되지 않는 AC를 붙일 것 |
+| SPEC-012 | `workmux.worktree.{이름}.window-session`의 `{이름}` 자리표시자가 **정의되지 않았다**. `move-window-to-session` 스킬은 이것이 `workmux list`의 `PATH` 열 basename이며 브랜치나 창 이름에서 유추하면 안 된다고 명시한다 — 틀린 키를 넘겨도 git이 오류 없이 새 섹션을 만들고 실제 키는 옛 값을 유지하기 때문이다. PR 모드는 창 이름·디렉터리명·브랜치가 모두 달라 이 위험이 커진다 | 저장값 읽기가 빈 값이 되어 모드 기본값으로 떨어지고, D1/R2.1이 막으려던 "의도적으로 옮긴 창을 되끌고 옴"이 그대로 재발 | R2 또는 Interfaces 절에서 `{이름}`을 `workmux list` PATH basename으로 정의하고 유추 금지를 명시할 것. 스모크 테스트에서 실제 기록된 키가 그 이름과 일치하는지 관찰하는 AC를 추가할 것 |
+
+### Medium
+
+| ID | 요약 | 영향 | 후속 조치 |
+|---|---|---|---|
+| SPEC-013 | AC-11이 R2.4(명시 세션이 저장값을 덮고 config를 갱신)를 `[실행]`으로 커버한다고 주장하지만, 정의된 스모크 테스트는 세션 미명시 실행 1회뿐이다. 그 관찰은 workmux가 쓴 모드 기본값을 볼 뿐 덮어쓰기 경로를 실행하지 않는다 | R2.4가 실제로는 문서 검토로만 검증됨 | 저장값과 다른 세션을 명시하는 2차 스모크 단계를 추가하거나, AC-11의 실행 주장을 축소하고 잔여 격차를 한계로 기록할 것 |
+
+### Low
+
+| ID | 요약 | 영향 | 후속 조치 |
+|---|---|---|---|
+| SPEC-014 | R4.1/AC-16이 `state`, `isCrossRepository`, `headRepositoryOwner`, `url`을 요구하지만 이를 소비하는 규칙이 없다. CLOSED/MERGED PR에 대한 동작이 미정의이고, fork 판별은 R4.6의 pull ref가 균일하게 처리하므로 `isCrossRepository`에 소비자가 없다 | 조회 형식과 사용 규칙이 어긋남 | `state`를 소비하는 규칙(CLOSED/MERGED 경고·확인)을 추가하거나 미사용 필드를 제거할 것 |
+| SPEC-015 | `{디렉토리명}`(R6.4)과 `{worktree경로}`(R6.8) 획득 방법이 `workmux add --pr` 경로에 대해 미정의다. 또한 정리 절차의 `workmux remove` 뒤 `git branch -D`는 중복이다 — `remove-worktree` 스킬은 `workmux remove`가 이미 로컬 브랜치를 지운다고 기록한다 | 정리 중 오류 메시지 발생 | 각 생성 경로별 경로 획득 방법을 명시하고, 브랜치 삭제를 조건부로 서술할 것 |
+
+### 프로세스 관찰
+
+라운드 2 리뷰어가 SPEC-005·006·007·008·010을 검증하지 못했다. 리뷰 호출 계약이 이전
+라운드의 **finding ID만** 전달하도록 규정되어 있어(`Review invocation contract`의
+"prior open finding IDs on rounds >= 2") 설명 원문과 증거 위치가 리뷰어에게 가지 않았기
+때문이다. 리뷰어는 자신의 새 findings가 이전 항목을 재진술했을 가능성을 배제할 수
+없다고 명시했다. 이 계약 자체를 넓힐지는 이 작업의 범위 밖이며, quality-goal 스킬
+유지보수 항목으로 남긴다.
+
+### 위생 항목
+
+`.claude/quality-state/`는 `.gitignore:25`에 이미 등록되어 있어 런타임 상태가
+`git status`에 노출되지 않는다. 별도 조치가 필요 없다.
+
+### quality-goal 스킬 자체의 순서 결함 (실측)
+
+이 보고서를 `set-artifact --kind report`로 등록하지 못했다. 상태 파일의
+`artifacts.report`는 `null`로 남아 있다.
+
+원인: `SKILL.md`는 "Render report.md ... and register it with `set-artifact --kind
+report` **BEFORE** transitioning into the terminal state"를 요구하지만,
+`scripts/quality_state.py`의 `record-review`가 라운드 한도 소진을 감지하면
+**스스로 `NEEDS_REDESIGN`으로 전이한다**(`quality_state.py:590,595`). 전이 후에는
+`terminal state is immutable: NEEDS_REDESIGN` 오류로 `set-artifact`가 거부된다
+(재현: exit 3). 즉 오케스트레이터가 규정된 순서를 지킬 수 있는 시점이 존재하지 않는다.
+
+동일한 문제가 `BLOCKED`(리뷰 출력 2회 무효 시)에서도 발생할 것으로 보인다 — 같은 함수가
+같은 방식으로 전이한다.
+
+**후속 조치 제안** (이 작업 범위 밖, `docs/quality-goal-maintenance.md` 항목):
+`record-review`의 자동 전이를 제거하고 오케스트레이터가 보고서 등록 후 명시적으로
+`transition`하게 하거나, 터미널 상태에서도 `set-artifact --kind report`만은 허용할 것.
+현 상태로는 모든 NEEDS_REDESIGN·BLOCKED 종료에서 보고서 포인터가 유실된다.
+
+보고서 파일 자체는 정상 경로
+(`docs/development/2026-08-27-create-worktree-pr-session/report.md`)에 존재한다.
+
+## Final status
+
+- Status: `NEEDS_REDESIGN`
+- Machine-readable reason: `SPEC_REVIEW_ROUND_LIMIT_REACHED_WITHOUT_PASS`
+
+Spec 리뷰가 규정된 최대 2라운드를 소진했고 두 라운드 모두 게이트를 통과하지 못했다
+(라운드 1: 75점 / 블로커 3건, 라운드 2: 82점 / High 2건, 통과 기준 85점 및 High 0건).
+`references/spec-rubric.md`의 "After round 2 without a passing gate, stop and record
+`NEEDS_REDESIGN`" 규칙에 따라 종료한다.
+
+구현은 시작되지 않았고 저장소 소스 파일은 변경되지 않았다. 사용자 승인 게이트에도
+도달하지 않았다.
+
+**남은 작업의 성격.** 두 High 항목은 Spec의 근본 설계 결함이 아니라 **미정의 구간**이다
+— 창 탐지 방법(SPEC-011)과 `{이름}` 자리표시자의 정의(SPEC-012)를 채우면 해소된다.
+두 항목 모두 `move-window-to-session` 스킬이 이미 답을 갖고 있다(창 매칭은
+`workmux list` PATH basename, 유추 금지 근거는 그 스킬의 104-108행). 다음 실행에서는
+이 두 정의를 Spec 초안에 미리 반영한 상태로 시작하는 것이 합리적이다.

--- a/docs/development/2026-08-27-create-worktree-pr-session/spec.md
+++ b/docs/development/2026-08-27-create-worktree-pr-session/spec.md
@@ -1,0 +1,792 @@
+# Quality Goal Specification
+
+- Task ID: 20260827T080329Z-28-35-create-worktree-스킬에-pr-링크-입력-시-2-r-6b97d528
+- Mode: standard
+- Status: SPEC_REVIEW (round 2)
+- Created: 2026-08-27T08:03:29Z
+- Updated: 2026-08-27T08:03:34Z
+- Source goal: #28 #35 create-worktree 스킬에 PR 링크 입력 시 2-review 세션에 PR 번호 윈도우를 생성하고 대상 세션을 직접 지정할 수 있도록 확장한다
+
+## Problem and context
+
+`create-worktree` 스킬은 현재 브랜치명 하나만 입력으로 받고, workmux 윈도우를 항상
+`1-main` 세션에 연다. 두 가지 한계가 실제 사용에서 드러났다.
+
+**한계 1 — PR 리뷰용 worktree를 PR 번호로 식별할 수 없다.** 현행 규칙은 브랜치명 맨
+앞의 숫자만 이슈 번호로 인식해 `{이슈번호}-{짧은이름}` 윈도우를 만든다
+(`dot_claude/skills/create-worktree/SKILL.md:145-147`). PR을 리뷰할 때는 PR 번호로
+창을 찾는 편이 자연스러운데, PR head 브랜치명에는 보통 PR 번호가 아니라 원 이슈 번호가
+들어 있다. 이 저장소의 PR #31이 그 사례다 — head 브랜치가
+`30-enhancement/tmux-open-pr-shortcut`이라 현행 규칙으로는 창 이름이 `30-...`이 되어
+PR #31을 가리키지 못한다.
+
+**한계 2 — 대상 세션을 지정할 수 없어 불필요한 이동이 발생한다.** 이슈 #35가 기록한
+실제 사례에서 사용자가 `2-review`를 명시했음에도 현행 스킬은 `1-main`에 창을 연 뒤
+`move-window-to-session` 전체 절차(이동 → 번호 재정렬 → git config·agent state 동기화
+→ resurrect 저장 → 재검증)를 밟아야 했다. 처음부터 `--parent-session 2-review`를 쓰면
+전부 불필요한 작업이다.
+
+**저장소 컨텍스트.** 스킬은 chezmoi 소스로 관리되며 Claude와 Codex가 각각 별도 원본을
+읽는다. 실측 결과 두 원본은 Claude 전용 frontmatter 3줄과 workmux 버전 표기 문구 1줄
+(`dot_agents:43` "0.1.233 실측" vs `dot_claude:46` "0.1.233 확인·0.1.248 재확인")에서
+차이가 난다. `~/.codex/skills/create-worktree`에는 별도 사본이 없다(실측).
+
+### 측정된 사실 (2026-08-27 실측)
+
+이 Spec이 의존하는 외부 사실은 모두 아래 관찰에 근거한다.
+
+| 사실 | 관찰 명령 | 결과 |
+|---|---|---|
+| workmux 버전 | `workmux --version` | `workmux 0.1.248` |
+| `--pr` 플래그 존재 | `workmux add --help` | `--pr <NUMBER\|URL>` 존재 |
+| `--pr`와 positional 관계 | `workmux add --help` | "`[BRANCH_NAME]` ... When used with `--pr`, this becomes the custom local branch name" |
+| `workmux open`의 `--pr` 부재 | `workmux open --help` | `--pr` 없음. `--target-name`, `--parent-session`은 있음 |
+| tmux 세션 목록 | `tmux list-sessions -F '#{session_name}'` | `1-main`, `2-review`, `3-personal`, `4-eslint`, `5-quick` |
+| dotfiles의 git-crypt 여부 | `git config --get filter.git-crypt.smudge` | 값 없음. `scripts/create-worktree.sh`도 없음 |
+| zambaguni-front의 git-crypt 여부 | 같은 명령 | `"git-crypt" smudge`. 래퍼 존재 |
+| PR #31 상태 | `gh pr view 31 --repo lee-kyu-hwan/dotfiles --json state,headRefName,headRefOid` | `state=OPEN`, head `30-enhancement/tmux-open-pr-shortcut`, OID `9cfc6267ced574945814536710cf1019a37dc354` |
+| PR #31 원격 head 브랜치 | `git ls-remote origin '30-enhancement/tmux-open-pr-shortcut'` | `9cfc6267...` — 원격에 존재 |
+| PR #31의 pull ref | `git ls-remote origin 'refs/pull/31/head'` | `9cfc6267...` — 동일 OID |
+| PR #32 상태 | `gh pr view 32 --json state,headRefName` | `state=OPEN`, head `feat/codex-playwright-e2e-profile` (숫자 접두사 없음) |
+
+### 래퍼 스크립트의 브랜치 판별 (SPEC-001의 근거)
+
+`zambaguni-front/scripts/create-worktree.sh:82-98` 실측. 래퍼는
+`git fetch --prune origin` 후 3단계로 판별한다.
+
+1. `refs/remotes/origin/{BRANCH}`가 있으면 → tracking 브랜치 모드
+2. `refs/heads/{BRANCH}`가 있으면 → 기존 로컬 브랜치 모드
+3. **둘 다 없으면 → 현재 HEAD 기준으로 새 브랜치 생성 (`-b`)**
+
+3번이 결정적이다. 같은 저장소 PR이면 래퍼 자신의 `git fetch --prune origin`이
+`origin/{head}`를 만들어 1번이 적용되지만, **fork PR의 head 브랜치는 `origin`에 없다.**
+`git fetch --prune origin`은 `refs/pull/*/head`를 가져오지 않으므로 3번으로 떨어져
+**PR 내용이 전혀 없는 빈 브랜치를 현재 HEAD에서 만들고**, 겉보기에 성공한 worktree를
+남긴다. 이 실패는 조용하다.
+
+## Goals
+
+1. PR 참조를 입력하면 PR 번호로 식별되는 리뷰용 worktree 윈도우를 만든다. 창 이름은
+   PR head 브랜치에 들어 있는 이슈 번호가 아니라 PR 번호를 쓴다.
+2. 대상 tmux 세션을 호출 시 지정할 수 있게 하고, 지정된 세션에 처음부터 직접 창을
+   만들어 `1-main` 경유 이동을 없앤다.
+3. 세션 선택 규칙을 명시값 / 저장값 / 모드 기본값 / 전역 기본값의 결정적 우선순위로
+   일반화하고, 그 규칙을 Claude와 Codex 두 원본이 동일하게 읽게 한다.
+4. 기존 브랜치 입력 동작과 이미 다른 세션으로 옮겨 둔 worktree 존중 규칙을 회귀 없이
+   보존한다.
+5. 유령 세션 생성, 저장소 불일치, 브랜치 충돌, **PR 내용이 없는 빈 worktree** 같은
+   실패를 부작용이 생기기 전에 차단한다.
+
+## Non-goals
+
+- tmux 세션 자동 생성. 선택 세션이 없으면 중단한다.
+- workmux session mode 전환(`--session`, `--mode session`)이나 pane 레이아웃 변경.
+  레이아웃은 `~/.config/workmux/config.yaml`이 계속 담당한다.
+- `move-window-to-session` 스킬 내부 동작 변경. 이번 스킬은 그것을 호출할 뿐이다.
+- `remove-worktree` 스킬 변경.
+- 대상 저장소의 `scripts/create-worktree.sh` 래퍼 수정. 래퍼의 3단계 판별은 그대로 두고
+  스킬이 호출 전에 전제를 보장한다.
+- 개발 서버나 에이전트(claude·codex) 자동 실행.
+- PR 리뷰 자체의 수행. 이 스킬은 리뷰 환경을 만들 뿐 리뷰하지 않는다.
+- `review/pr-{번호}` 같은 별칭 브랜치 생성. PR head 브랜치를 그대로 쓴다.
+- GitHub 쓰기 작업(코멘트, 라벨, 상태 변경).
+- `workmux` 자체의 기능 추가나 버그 수정.
+
+## Requirements
+
+### R1. 입력 규격
+
+- **R1.1** 첫 번째 positional 인자는 브랜치명 또는 PR 참조이며 필수다. 비어 있으면
+  사용자에게 물어본다.
+- **R1.2** 두 번째 positional 인자는 정확한 tmux 세션명이며 선택이다.
+- **R1.3** 세 번째 이상의 positional 인자가 오면 추측하지 말고 사용법을 안내하고
+  중단한다. 이 규칙은 **positional 형태 호출에만** 적용된다(R1.6 참조).
+- **R1.4** PR 모드는 다음 형태에서만 자동 선택된다.
+  - 전체 GitHub PR URL: `https://github.com/{owner}/{repo}/pull/{번호}`
+  - `{owner}/{repo}#{번호}` 형식
+  - 자연어 문장에서 숫자 앞뒤에 PR임을 나타내는 표지가 있는 경우
+    (예: "PR 1313", "1313번 PR", "pull request 1313")
+- **R1.5** 표지 없는 맨 숫자(`1313`)는 PR 참조로 보지 않는다. GitHub는 이슈와 PR이
+  번호 공간을 공유하므로 맨 숫자를 PR로 단정하면 엉뚱한 대상을 체크아웃할 수 있다.
+  표지가 없으면 브랜치 모드로 해석하거나, 브랜치로도 해석되지 않으면 사용자에게
+  확인한다.
+- **R1.6** 자연어 호출은 다음 규칙으로 `(브랜치명|PR참조, 대상세션)` 2-튜플로 환원한다.
+  - 첫 요소: 문장에서 발견된 브랜치명 또는 R1.4 형태의 PR 참조. 두 개 이상 발견되면
+    중단하고 사용자에게 확인한다.
+  - 둘째 요소: 문장에서 발견된 tmux 세션명. 두 개 이상 발견되면 중단하고 확인한다.
+  - 환원 결과가 2-튜플을 넘지 않으므로 R1.3의 "세 번째 positional" 중단은 자연어
+    호출에서 발동하지 않는다. 대신 위 두 "두 개 이상" 규칙이 같은 역할을 한다.
+- **R1.7** 세션명을 접두사로 보정하거나 존재하는 세션 목록에서 추측하지 않는다. 문장에
+  나온 문자열을 그대로 쓴다.
+- **R1.8** Claude frontmatter의 `argument-hint`는
+  `<branch-name|pr-ref> [target-session]`로 갱신한다.
+
+### R2. 세션 선택 우선순위
+
+선택 세션(`SELECTED_SESSION`)은 다음 순서로 결정한다.
+
+1. 사용자가 이번 호출에서 명시한 대상 세션
+2. 기존 worktree의 `workmux.worktree.{이름}.window-session` git config 값이
+   `^[0-9]+-.+$`를 만족할 때 그 값
+3. 입력 모드 기본값 — PR 모드이면 `2-review`
+4. 전역 기본값 `1-main`
+
+- **R2.1** 저장값이 모드 기본값보다 우선한다. 저장값은 사용자가 과거에 직접 창을 옮긴
+  행동의 기록이므로, 단순 관습인 모드 기본값이 그것을 덮으면 현행 "예외 1"이 막으려던
+  실패(의도적으로 옮긴 창을 조용히 되끌고 옴)가 그대로 재발한다.
+- **R2.2** 저장값이 `^[0-9]+-.+$`를 만족하지 않으면 규칙 이전 레거시 값으로 보고
+  우선순위 2에서 제외하며, 선택된 세션으로 git config를 갱신한다. 판정은 셸
+  glob(`[0-9]*-*`)이 아니라 정규식으로 한다 — glob의 첫 `*`는 숫자 반복이 아니라 임의
+  문자열이라 `1legacy-session`이나 `1-`가 통과한다.
+- **R2.3** 선택 세션이 확정되기 전에는 어떤 workmux 명령도 실행하지 않는다.
+- **R2.4** 명시 세션(우선순위 1)이 유효한 저장값(우선순위 2)을 덮은 경우, 창을 연 뒤
+  `workmux.worktree.{이름}.window-session`이 명시 세션을 가리키는지 확인하고 다르면
+  갱신한다. 스킬이 이 값을 직접 쓰는 것은 이 경우와 R2.2, R8.2 세 곳뿐이다. 갱신하지
+  않으면 다음번 세션 미명시 호출이 옛 세션으로 조용히 되돌아간다.
+
+### R3. tmux 세션 검증
+
+- **R3.1** `tmux list-sessions -F '#{session_name}'`을 단독 실행해 종료 코드를 먼저
+  확인한다.
+- **R3.2** exit 1과 `error connecting to ...`이면 tmux 서버 부재로 보고하고 중단한다.
+  "세션이 없다"와 구분해서 보고한다.
+- **R3.3** 목록 조회 성공 후 `grep -qxF -- "$SELECTED_SESSION"`으로 전체 문자열 일치를
+  확인한다.
+- **R3.4** `has-session -t`를 쓰지 않는다. tmux 타깃은 접두사 매칭을 하므로
+  `has-session -t 2`와 `has-session -t 2-rev`가 모두 exit 0이다(실측).
+- **R3.5** 선택 세션이 없으면 자동 생성하지 않고 중단한다. workmux는 존재하지 않는
+  `--parent-session` 값을 오류 없이 받아 세션을 만들고 git config에 영구 저장하므로,
+  이 검사가 유일한 안전망이다.
+- **R3.6** 현행의 "`1-main` 존재 확인"은 "선택 세션 존재 확인"으로 일반화한다. 선택
+  세션이 `2-review`라면 `1-main` 존재 여부는 생성에 필요하지 않다.
+
+### R4. PR 참조 해석
+
+- **R4.1** PR 번호, 실제 head 브랜치명, head 커밋 OID를 조회한다.
+
+  ```bash
+  gh pr view {번호} --repo {owner}/{repo} \
+    --json number,state,headRefName,headRefOid,headRepositoryOwner,isCrossRepository,url
+  ```
+
+- **R4.2** PR 링크의 base 저장소와 현재 저장소가 다르면 중단한다.
+- **R4.3** PR head 브랜치의 worktree가 이미 있으면 **새 worktree를 만들지 않는다.**
+  별칭 브랜치도 만들지 않는다. 이 경우 생성을 건너뛰고 R7의 기존 worktree 창 처리로
+  넘어간다. 전체 작업을 중단하는 것이 아니라 **생성 단계만** 건너뛴다.
+- **R4.4** 같은 이름의 로컬 브랜치가 있는데 R4.1의 head OID와 다른 커밋을 가리키면
+  덮어쓰지 않고 중단한다. 사용자의 미푸시 작업이 유실될 수 있기 때문이다.
+- **R4.5** `gh`가 없거나 인증되지 않았거나 PR 조회가 실패하면 그 사실을 보고하고
+  중단한다. PR 정보를 추측하지 않는다.
+- **R4.6** **PR head 브랜치 확보(SPEC-001).** worktree를 새로 만들기 전에, PR head
+  커밋이 로컬에서 `{head브랜치명}`으로 도달 가능함을 보장한다. 래퍼는 브랜치가 로컬과
+  `origin` 양쪽에 없으면 현재 HEAD에서 빈 브랜치를 만들므로(래퍼 82-98행 실측), 이
+  보장 없이 래퍼를 부르면 PR 내용이 없는 worktree가 조용히 생긴다.
+
+  ```bash
+  # 로컬 브랜치가 이미 있으면 R4.4의 OID 비교로 판정이 끝나 있다.
+  # 없을 때만 pull ref에서 가져온다. fork PR도 이 ref로 동일하게 처리된다.
+  git fetch origin "refs/pull/{PR번호}/head:{head브랜치명}"
+  # 확보 확인 — 실패하면 중단하고 래퍼를 부르지 않는다.
+  git rev-parse --verify "refs/heads/{head브랜치명}"   # == R4.1의 headRefOid
+  ```
+
+  fetch가 실패하거나 확보된 OID가 `headRefOid`와 다르면 중단한다. 이 요구는 래퍼가
+  있는 경로와 없는 경로 모두에 적용된다 — 다만 래퍼 없는 경로는 `workmux add --pr`가
+  체크아웃을 직접 하므로(R6.3) 사전 fetch 대신 **사후 검증**(R6.8)으로 같은 보장을
+  얻는다.
+
+### R5. 윈도우 이름 파생
+
+- **R5.1** 짧은 이름은 브랜치명(PR 모드에서는 PR head 브랜치명)에서 마지막 `/`까지를
+  제거한 부분이다. 예: `392-feat/add-partner-chat-enabled` → `add-partner-chat-enabled`.
+- **R5.2** 브랜치 모드에서 이슈 번호는 브랜치명 맨 앞의 숫자 또는 `ZF-숫자`만 인식한다.
+  맨 앞이 아니면 이슈 번호가 아니다. 현행 규칙을 그대로 유지한다.
+- **R5.3** PR 모드의 윈도우 이름은 `{PR번호}-{짧은이름}`이다. PR head 브랜치가 이슈
+  번호로 시작하더라도 PR 번호를 쓴다.
+- **R5.4** 브랜치 모드에서 이슈 번호가 없으면 `--target-name`을 생략한다. 현행 규칙을
+  유지한다.
+- **R5.5** workmux가 target name을 소문자로 정규화하므로, 사용자에게 안내하거나 이후
+  명령에 재사용할 이름은 정규화된 소문자다.
+- **R5.6** **창 이름 충돌 시 재시도(SPEC-009).** 충돌 재시도 이름은 모드별로 다르다.
+  - 브랜치 모드: `{repo명}-{짧은이름}` (현행 규칙 유지)
+  - PR 모드: `{PR번호}-{repo명}-{짧은이름}` — PR 번호를 반드시 보존한다. 현행
+    `{repo명}-{짧은이름}`을 그대로 쓰면 PR 번호가 사라져 이 변경의 목적 자체가 무너진다.
+
+### R6. 생성·오픈 경로
+
+- **R6.1** 경로 분기는 저장소 루트(`git rev-parse --show-toplevel`) 기준으로
+  `scripts/create-worktree.sh` 존재 여부로 판정한다. 상대 경로로 판정하면 서브디렉터리나
+  기존 worktree 안에서 부를 때 false가 된다. 현행 규칙을 유지한다.
+- **R6.2** git-crypt 저장소에서 `workmux add`를 쓰지 않는다. PR 모드에서도 마찬가지다.
+- **R6.3** 래퍼가 없는 저장소의 PR 모드는 positional 브랜치명을 생략하고 실행한다.
+
+  ```bash
+  workmux add --pr {PR참조} \
+    --target-name {PR번호}-{짧은이름} \
+    --parent-session {선택세션}
+  ```
+
+  positional을 주면 그것이 커스텀 로컬 브랜치명이 되어 PR head 브랜치가 쓰이지 않는다
+  (`workmux add --help` 실측).
+- **R6.4** 래퍼가 있는 저장소의 PR 모드는 R4.6으로 head 브랜치를 확보한 뒤 실행한다.
+
+  ```bash
+  ./scripts/create-worktree.sh {head브랜치명}
+  workmux open {디렉토리명} \
+    --target-name {PR번호}-{짧은이름} \
+    --parent-session {선택세션}
+  ```
+
+- **R6.5** 래퍼가 실패하면 종료 코드를 확인해 중단하고 `workmux open`으로 넘어가지
+  않는다. 래퍼의 확인 프롬프트를 `-y`나 `yes |`로 우회하지 않는다. 래퍼에 실행 권한이
+  없으면 경로를 바꾸지 말고 오류로 보고한다.
+- **R6.6** 모든 `workmux add`/`workmux open` 예시가 고정 `1-main`이 아니라 선택 세션
+  변수를 쓴다.
+- **R6.7** `--parent-session` 미지원 조합(session mode, 샌드박스 안, `--count`,
+  `--foreach`, 여러 `--agent`, stdin)에서는 플래그를 생략한다. 현행 예외를 유지한다.
+- **R6.8** **PR worktree 내용 검증(SPEC-001).** 생성 직후 worktree의 HEAD가 R4.1의
+  `headRefOid`와 같은지 확인한다. 다르면 PR 내용이 없는 worktree이므로 성공으로
+  보고하지 않고 사용자에게 알린다.
+
+  ```bash
+  git -C {worktree경로} rev-parse HEAD          # == headRefOid
+  git -C {worktree경로} rev-parse --abbrev-ref HEAD   # == head브랜치명
+  ```
+
+### R7. 기존 worktree 상태별 동작
+
+- **R7.0** 세션 선택(R2)보다 먼저 대상 브랜치의 worktree 존재 여부와 경로를 확정한다.
+  저장 세션(R2 우선순위 2)을 읽으려면 worktree 경로가 필요하기 때문이다.
+
+  ```bash
+  git worktree list --porcelain   # branch refs/heads/{브랜치명} 항목의 worktree 경로
+  ```
+
+- **R7.1** worktree는 있는데 workmux 창이 닫혀 있으면 선택 세션으로 직접 연다.
+- **R7.2** 창이 이미 열려 있고 선택 세션과 같은 세션이면 중복 창을 만들지 않고 기존
+  위치를 안내한다.
+- **R7.3** 창이 열려 있고 다른 세션이며 사용자가 대상을 명시하지 않았으면 기존 위치를
+  존중한다(R2 우선순위 2가 이미 그 값을 선택했으므로 R7.2로 귀결된다).
+- **R7.4** 창이 열려 있고 다른 세션이며 사용자가 대상을 명시했으면, `workmux open`으로
+  재구성하지 않고 `move-window-to-session` 절차를 쓴다. 살아 있는 pane과 에이전트
+  상태를 보존하기 위해서다. 이동 후 R2.4의 git config 확인을 수행한다.
+- **R7.5** 같은 브랜치의 worktree가 이미 있으면 새로 만들지 않고 기존 경로를 안내하는
+  현행 규칙을 유지한다. R4.3과 같은 규칙이며 PR 모드에도 동일하게 적용된다.
+
+### R8. 생성 후 검증
+
+- **R8.1** `tmux list-windows -a -F '#{session_name}:#{window_index}\t#{window_name}'`로
+  실제 윈도우 이름과 세션을 확인한다. `workmux list`에는 윈도우 이름 열이 없으므로
+  추측해서 안내하면 사용자가 `workmux close`에 없는 이름을 넘기게 된다.
+- **R8.2** 실제 세션이 선택 세션과 다르면 사용자에게 알리고, 잘못 만들어진 세션과 git
+  config 값을 함께 정리한다.
+- **R8.3** 결과 보고에 worktree 경로, 브랜치, 실제 세션, 실제 윈도우 이름 네 가지를
+  포함한다. PR 모드에서는 PR 번호와 head OID도 포함한다.
+
+### R9. 문서 동기화
+
+- **R9.1** `dot_agents/skills/create-worktree/SKILL.md`와
+  `dot_claude/skills/create-worktree/SKILL.md`의 본문은 Claude 전용 frontmatter를
+  제외하고 동일해야 한다.
+- **R9.2** 현존하는 workmux 버전 표기 불일치(`dot_agents:43` vs `dot_claude:46`)를
+  더 정확한 `dot_claude` 쪽 문구로 통일한다.
+- **R9.3** `dot_agents/skills/create-worktree/agents/openai.yaml`의 `default_prompt`에
+  대상 세션 또는 PR 참조 사례를 반영한다.
+- **R9.4** 홈의 적용본(`~/.claude/skills/...`, `~/.agents/skills/...`)을 직접 수정하지
+  않는다. chezmoi 원본만 고치고 `chezmoi apply`로 적용한다.
+
+## Acceptance criteria
+
+각 기준은 "검증 방법"의 관찰로 판정하며, "커버 요구사항" 열이 요구사항 전수 대응을
+보인다. 검증 유형은 **[실행]**(명령 종료 코드·출력으로 판정), **[문서]**(두 SKILL.md에
+해당 규칙이 기술되어 있는지 검토로 판정)로 표시한다.
+
+| ID | 기준 | 검증 방법 | 커버 요구사항 |
+|---|---|---|---|
+| AC-1 | 입력 계약이 `<브랜치명\|PR참조> [대상세션]`으로 문서화되고, 첫 인자 누락 시 사용자에게 묻는다 | [문서] 두 SKILL.md의 파라미터 절 | R1.1, R1.2 |
+| AC-2 | positional 3개 이상이면 사용법 안내 후 중단한다 | [문서] R1.3 서술 | R1.3 |
+| AC-3 | PR 모드 트리거 형태 3종(URL, `owner/repo#N`, 표지 있는 자연어)이 열거된다 | [문서] R1.4 서술과 예시 | R1.4 |
+| AC-4 | 표지 없는 맨 숫자를 PR로 해석하지 않는 규칙과 그 근거(번호 공간 공유)가 기술된다 | [문서] R1.5 서술 | R1.5 |
+| AC-5 | 자연어 → 2-튜플 환원 규칙과 "두 개 이상 발견 시 중단"이 기술된다 | [문서] R1.6 서술 | R1.6 |
+| AC-6 | 세션명을 접두사 보정하거나 목록에서 추측하지 않는 규칙이 기술된다 | [문서] R1.7 서술 | R1.7 |
+| AC-7 | Claude frontmatter `argument-hint`가 `<branch-name\|pr-ref> [target-session]`이다 | [실행] `grep -q 'argument-hint: <branch-name|pr-ref> \[target-session\]' dot_claude/.../SKILL.md` → exit 0 | R1.8 |
+| AC-8 | 세션 우선순위 4단계가 명시값 > 저장값 > 모드 기본값 > `1-main` 순으로 기술된다 | [문서] R2 우선순위 목록. 저장값이 모드 기본값보다 **위**임을 확인 | R2.1 |
+| AC-9 | 레거시 저장값을 정규식으로 판정하고 셸 glob을 금지하는 근거가 기술된다 | [문서] R2.2 서술에 `^[0-9]+-.+$`와 glob 반례(`1legacy-session`, `1-`) 포함 | R2.2 |
+| AC-10 | 선택 세션 확정 전 workmux 명령 금지가 기술된다 | [문서] R2.3 서술 | R2.3 |
+| AC-11 | 명시 세션이 저장값을 덮었을 때 git config를 갱신하는 규칙이 기술되고, 스모크 테스트에서 값이 실제로 선택 세션을 가리킨다 | [문서] R2.4 서술 + [실행] 스모크 테스트 후 `git -C {worktree} config --get workmux.worktree.{이름}.window-session` == `2-review` | R2.4 |
+| AC-12 | tmux 서버 부재를 세션 부재와 구분해 감지한다 | [실행] `tmux -L quality-goal-nonexistent-socket list-sessions` → exit 1 + `error connecting to` (별도 소켓이라 실서버 무영향). 두 SKILL.md에 이 구분이 기술됨 | R3.1, R3.2 |
+| AC-13 | 없는 세션은 `grep -qxF` 전체 일치로 부재 판정되며, 이 판정 실패 시 workmux를 호출하지 않는다 | [실행] `tmux list-sessions -F '#{session_name}' \| grep -qxF -- 'definitely-not-a-session'` → exit 1. + [문서] R3.5의 중단 규칙 | R3.3, R3.5 |
+| AC-14 | `has-session`의 접두사 함정이 실측 근거와 함께 금지된다 | [실행] `tmux has-session -t 2` → exit 0, `tmux has-session -t 2-rev` → exit 0, `grep -qxF -- 2-rev` → exit 1 (실측 완료). + [문서] R3.4 서술 | R3.4 |
+| AC-15 | 고정 `1-main` 검사가 선택 세션 검사로 일반화된다 | [실행] 아래 "1-main 잔존 검사" 참조 | R3.6, R6.6 |
+| AC-16 | PR 조회가 `state`, `headRefName`, `headRefOid`, `isCrossRepository`를 포함한다 | [문서] R4.1의 `gh pr view` 명령 | R4.1 |
+| AC-17 | PR base 저장소 불일치 시 중단한다 | [문서] R4.2 서술 | R4.2 |
+| AC-18 | PR head 브랜치의 worktree가 이미 있으면 생성을 건너뛰고 R7 창 처리로 넘어간다(전체 중단 아님) | [문서] R4.3 서술 + Architecture 흐름도의 분기 순서가 일치 | R4.3, R7.5 |
+| AC-19 | 동명 로컬 브랜치가 head OID와 다르면 중단한다 | [문서] R4.4 서술 | R4.4 |
+| AC-20 | `gh` 부재·미인증·조회 실패 시 추측 없이 중단한다 | [문서] R4.5 서술 | R4.5 |
+| AC-21 | 래퍼 경로에서 `refs/pull/{N}/head`로 head 브랜치를 확보하고, 확보 실패 시 래퍼를 부르지 않는다 | [문서] R4.6의 fetch 명령과 중단 규칙 + 래퍼 3단계 판별 근거가 기술됨 | R4.6 |
+| AC-22 | 짧은 이름이 마지막 `/` 뒤로 파생된다 | [문서] R5.1 서술과 예시 | R5.1 |
+| AC-23 | 브랜치 모드 이슈 번호 규칙(맨 앞 숫자 또는 `ZF-숫자`)이 유지된다 | [문서] R5.2 서술 | R5.2 |
+| AC-24 | PR head 브랜치가 이슈 번호로 시작해도 창 이름에 PR 번호가 쓰인다 | [실행] 스모크 테스트에서 창 이름이 `31-tmux-open-pr-shortcut`이고 `30-`으로 시작하지 않음 | R5.3 |
+| AC-25 | 브랜치 모드에서 이슈 번호가 없으면 `--target-name`을 생략한다 | [문서] R5.4 서술 | R5.4 |
+| AC-26 | target name 소문자 정규화가 안내에 반영된다 | [문서] R5.5 서술 | R5.5 |
+| AC-27 | PR 모드 충돌 재시도 이름이 PR 번호를 보존한다 | [문서] R5.6의 `{PR번호}-{repo명}-{짧은이름}` 서술과 브랜치 모드와의 구분 | R5.6 |
+| AC-28 | 경로 분기를 저장소 루트 기준으로 판정한다 | [문서] R6.1의 `git rev-parse --show-toplevel` 사용 | R6.1 |
+| AC-29 | git-crypt 저장소에서 `workmux add`를 쓰지 않는다 | [문서] R6.2 서술 + git-crypt 분기에 래퍼 호출만 존재 | R6.2 |
+| AC-30 | 래퍼 없는 PR 경로가 positional을 생략하고 `--pr`를 쓴다 | [실행] 스모크 테스트에서 worktree 브랜치가 `30-enhancement/tmux-open-pr-shortcut` | R6.3 |
+| AC-31 | 래퍼 있는 PR 경로가 head 브랜치 확보 → 래퍼 → `workmux open` 순서로 기술된다 | [문서] R6.4의 명령 순서 | R6.4 |
+| AC-32 | 래퍼 실패 시 창을 열지 않고, 프롬프트를 자동 우회하지 않는다 | [문서] R6.5 서술 | R6.5 |
+| AC-33 | `--parent-session` 미지원 조합의 생략 예외가 유지된다 | [문서] R6.7 서술 | R6.7 |
+| AC-34 | 생성된 worktree HEAD가 PR head OID와 일치한다 | [실행] 스모크 테스트에서 `git -C {worktree} rev-parse HEAD` == `9cfc6267ced574945814536710cf1019a37dc354` | R6.8 |
+| AC-35 | worktree 존재 판정이 세션 선택보다 먼저 수행된다 | [문서] Architecture 흐름도에서 R7.0이 R2보다 앞. `git worktree list --porcelain` 사용 | R7.0 |
+| AC-36 | 창이 닫힌 기존 worktree를 선택 세션에 직접 연다 | [문서] R7.1 서술 | R7.1 |
+| AC-37 | 같은 세션에 이미 열려 있으면 중복 창을 만들지 않는다 | [문서] R7.2 서술 | R7.2 |
+| AC-38 | 세션 미명시 시 기존 위치를 존중한다 | [문서] R7.3 서술 | R7.3 |
+| AC-39 | 다른 세션의 열린 창을 명시적으로 옮길 때만 `move-window-to-session`을 쓴다 | [문서] R7.4 서술 | R7.4 |
+| AC-40 | 생성 후 실제 세션·창 이름을 `tmux list-windows`로 확인한다 | [실행] 스모크 테스트에서 해당 명령 실행 및 결과 기록 | R8.1 |
+| AC-41 | 세션 불일치 시 잘못된 세션과 git config를 함께 정리한다 | [문서] R8.2 서술 | R8.2 |
+| AC-42 | 보고에 경로·브랜치·세션·창이름 4항목(PR 모드는 PR번호·head OID 추가)이 포함된다 | [실행] 스모크 테스트 보고에 6항목 존재 | R8.3 |
+| AC-43 | 두 SKILL.md 본문이 Claude frontmatter 외에 동일하다 | [실행] `diff dot_agents/.../SKILL.md dot_claude/.../SKILL.md` 출력이 `3a4,6`과 그 3줄만 | R9.1, R9.2 |
+| AC-44 | `openai.yaml` `default_prompt`에 세션 또는 PR 사례가 반영된다 | [실행] `grep -qE '2-review\|pull/' openai.yaml` → exit 0 | R9.3 |
+| AC-45 | chezmoi 원본만 수정되고 적용본이 원본과 일치한다 | [실행] `chezmoi apply` 후 3개 파일 각각 `cmp` → exit 0 | R9.4 |
+| AC-46 | PR 모드 신규 worktree에서 세션 미명시 시 `2-review`가 선택된다 | [실행] 스모크 테스트에서 창이 `2-review`에 열림 | R2 우선순위 3 |
+| AC-47 | 두 스킬이 frontmatter 검증을 통과한다 | [실행] 아래 "frontmatter 검증" 참조 | — (도구 위생) |
+| AC-48 | 공백 오류와 시크릿 유출이 없다 | [실행] `git diff --check` → exit 0, `pre-commit run --all-files` → 통과 | — (저장소 위생) |
+
+### 요구사항 전수 대응 확인
+
+R1.1→AC-1, R1.2→AC-1, R1.3→AC-2, R1.4→AC-3, R1.5→AC-4, R1.6→AC-5, R1.7→AC-6,
+R1.8→AC-7, R2.1→AC-8, R2.2→AC-9, R2.3→AC-10, R2.4→AC-11, R3.1→AC-12, R3.2→AC-12,
+R3.3→AC-13, R3.4→AC-14, R3.5→AC-13, R3.6→AC-15, R4.1→AC-16, R4.2→AC-17, R4.3→AC-18,
+R4.4→AC-19, R4.5→AC-20, R4.6→AC-21, R5.1→AC-22, R5.2→AC-23, R5.3→AC-24, R5.4→AC-25,
+R5.5→AC-26, R5.6→AC-27, R6.1→AC-28, R6.2→AC-29, R6.3→AC-30, R6.4→AC-31, R6.5→AC-32,
+R6.6→AC-15, R6.7→AC-33, R6.8→AC-34, R7.0→AC-35, R7.1→AC-36, R7.2→AC-37, R7.3→AC-38,
+R7.4→AC-39, R7.5→AC-18, R8.1→AC-40, R8.2→AC-41, R8.3→AC-42, R9.1→AC-43, R9.2→AC-43,
+R9.3→AC-44, R9.4→AC-45. **미대응 요구사항 없음.**
+
+### `1-main` 잔존 검사 (AC-15의 실행 정의)
+
+`--parent-session 1-main` 리터럴만 grep하면 다른 하드코딩이 통과한다(SPEC-004).
+두 SKILL.md에서 `1-main` 전체를 세고, 아래 허용 목록에 해당하는 것만 남아야 한다.
+
+```bash
+grep -n -- '1-main' dot_agents/skills/create-worktree/SKILL.md \
+                    dot_claude/skills/create-worktree/SKILL.md
+```
+
+**허용되는 잔존 용례** — 이외의 출현은 회귀로 판정한다.
+
+1. R2 우선순위 4순위를 설명하는 "전역 기본값 `1-main`" 서술
+2. 우선순위 예시 표에서 기본값 결과를 보이는 셀
+3. 유령 세션 위험이나 레거시 마이그레이션을 설명하며 예시로 드는 문장
+
+**금지되는 잔존 용례** — 하나라도 남으면 AC-15 실패.
+
+1. `--parent-session 1-main` 리터럴이 실행 명령 예시에 있는 경우
+2. `grep -qxF -- 1-main`처럼 검증 대상이 `1-main`으로 고정된 경우
+3. `git config ... window-session 1-main`처럼 기록 값이 고정된 경우
+4. "`1-main` 세션이 없으면 여기서 멈춘다"처럼 중단 조건이 `1-main`에 묶인 경우
+5. "새로 만든 것이면 `1-main`"처럼 사후 검증 기대값이 고정된 경우
+
+### frontmatter 검증 (AC-47의 실행 정의)
+
+```bash
+python3 /Users/lee-kyu-hwan/.claude/plugins/marketplaces/claude-plugins-official/plugins/skill-creator/skills/skill-creator/scripts/quick_validate.py \
+  /Users/lee-kyu-hwan/code/dotfiles/dot_claude/skills/create-worktree
+python3 /Users/lee-kyu-hwan/.claude/plugins/marketplaces/claude-plugins-official/plugins/skill-creator/skills/skill-creator/scripts/quick_validate.py \
+  /Users/lee-kyu-hwan/code/dotfiles/dot_agents/skills/create-worktree
+```
+
+실측 기준선(변경 전, 2026-08-27):
+
+- `dot_agents` → `Skill is valid!`, exit 0
+- `dot_claude` → `Unexpected key(s) in SKILL.md frontmatter: argument-hint, user-invocable.`, **exit 0**
+
+`quick_validate.py`는 Claude 전용 키를 허용 목록에 두지 않으므로 `dot_claude`에서 이
+안내가 나오지만 종료 코드는 0이다. 따라서 **판정 기준은 종료 코드 0 + `dot_claude`의
+메시지가 위 Claude 전용 키 안내에서 늘어나지 않을 것**이다. 새로운 종류의 경고가
+추가되면 실패로 본다.
+
+## Architecture
+
+스킬은 실행 가능한 코드가 아니라 **에이전트가 읽고 따르는 절차 문서**다. 따라서
+"아키텍처"는 문서가 기술하는 결정 흐름과 그 흐름이 호출하는 외부 도구 경계를 뜻한다.
+
+### 결정 흐름
+
+worktree 존재 판정(R7.0)이 세션 선택(R2)보다 **앞선다** — 저장 세션을 읽으려면 worktree
+경로가 필요하기 때문이다. 그리고 PR 모드의 기존 worktree는 중단이 아니라 창 처리로
+분기한다(R4.3).
+
+```
+1. 입력 파싱 (R1)
+     ├─ positional 3개 이상 → 사용법 안내 후 중단
+     ├─ PR 참조 판정 (R1.4 / R1.5)
+     └─ 자연어면 2-튜플 환원 (R1.6)
+          ↓
+2. PR 모드일 때: PR 해석 (R4.1, R4.2, R4.5)
+     ├─ PR번호·head브랜치·headRefOid·isCrossRepository 조회
+     └─ base 저장소 불일치 → 중단
+          ↓
+3. worktree 존재 판정 (R7.0)
+     git worktree list --porcelain → 경로 확보 (없으면 null)
+          ↓
+4. 세션 선택 (R2)
+     명시값 > 유효 저장값 > 모드 기본값(PR→2-review) > 1-main
+          ↓
+5. 세션 검증 (R3)
+     list-sessions 종료 코드 → grep -qxF 전체 일치 → 없으면 중단
+          ↓
+6. 이름 파생 (R5)
+     짧은 이름 → 창 이름 (PR 모드면 {PR번호}-, 아니면 {이슈번호}- 또는 생략)
+          ↓
+7. 분기
+     ├─ [worktree 있음] (R4.3 → R7.1~R7.4)
+     │     ├─ 창 닫힘 → 선택 세션으로 workmux open
+     │     ├─ 창 열림 & 같은 세션 → 안내만
+     │     └─ 창 열림 & 다른 세션 & 명시됨 → move-window-to-session
+     │
+     └─ [worktree 없음] → 브랜치 안전 검사 (R4.4) → 생성 (R6)
+           ├─ 래퍼 있음: R4.6 fetch → 래퍼 → workmux open
+           └─ 래퍼 없음: workmux add --pr (positional 생략)
+          ↓
+8. 생성 후 검증 (R6.8, R8)
+     worktree HEAD == headRefOid → tmux list-windows 대조 → git config 확인(R2.4)
+```
+
+### 구성 요소와 책임 경계
+
+| 구성 요소 | 책임 | 이번 변경 |
+|---|---|---|
+| `dot_claude/.../SKILL.md` | Claude Code가 읽는 절차 + Claude 전용 frontmatter | 본문 확장, `argument-hint` 갱신 |
+| `dot_agents/.../SKILL.md` | Codex·공용 에이전트가 읽는 절차 | 본문을 Claude 본문과 동일하게 확장 |
+| `dot_agents/.../agents/openai.yaml` | Codex UI 메타데이터 | `default_prompt` 예시 갱신 |
+| `workmux` (0.1.248) | worktree 생성, tmux 창 구성, `--pr` 체크아웃 | 호출만. 변경 없음 |
+| 대상 저장소의 `scripts/create-worktree.sh` | git-crypt worktree 생성·키 링크·의존성 설치 | 호출만. 변경 없음. 3단계 판별의 전제를 스킬이 R4.6으로 보장 |
+| `gh` | PR 메타데이터 조회 (읽기 전용) | 신규 의존 |
+| `git fetch origin refs/pull/N/head` | PR head 커밋 확보 | 신규 의존 (래퍼 경로) |
+| `move-window-to-session` 스킬 | 열린 창 이동 + 메타데이터 동기화 | 호출만. 변경 없음 |
+| `~/.config/workmux/config.yaml` | pane 레이아웃, `base_branch: auto` | 변경 없음 |
+
+### 결정: 두 원본의 동기화 방식
+
+두 SKILL.md 본문을 동일하게 유지해야 하는데(R9.1), 자동 동기화 장치를 도입할지 수동
+유지할지가 선택지였다.
+
+- **대안 A — 심볼릭 링크**: `dot_agents` 본문을 `dot_claude`로 링크. chezmoi가
+  `symlink_` 접두사를 지원하지만, Claude 전용 frontmatter가 파일 앞에 있어야 하므로
+  파일 전체를 링크할 수 없다. 탈락.
+- **대안 B — 생성 스크립트**: 공통 본문에서 두 파일을 만드는 스크립트를 둔다. 이번
+  변경 범위(#35 변경 대상 3개 파일)를 넘어서고, chezmoi 흐름에 새 빌드 단계를 넣는다.
+  탈락.
+- **대안 C — 수동 유지 + 검증(채택)**: 두 파일을 각각 수정하고 `diff`로 frontmatter
+  외 동일함을 검증한다(AC-43). 기존 관행과 같고 추가 장치가 없다.
+
+## Interfaces and data flow
+
+### 스킬 입력 계약
+
+```
+<브랜치명|PR참조> [대상세션]
+```
+
+| 입력 | 모드 | 대상 세션 | 창 이름 |
+|---|---|---|---|
+| `1290-bug/partner-robots-yeti-disallow` | 브랜치 | `1-main` (기본) | `1290-partner-robots-yeti-disallow` |
+| `1290-bug/... 2-review` | 브랜치 | `2-review` (명시) | `1290-partner-robots-yeti-disallow` |
+| `fix/login-bug` | 브랜치 | `1-main` | `--target-name` 생략 |
+| `https://github.com/owner/repo/pull/1247` | PR | `2-review` (모드 기본) | `1247-{PR head 짧은이름}` |
+| `zambaguni/zambaguni-front#1313` | PR | `2-review` | `1313-snap-board-grid-windowing` |
+| `https://github.com/o/r/pull/1247 3-personal` | PR | `3-personal` (명시) | `1247-...` |
+| 위 PR + 저장값 `3-personal`, 세션 미명시 | PR | `3-personal` (저장값 우선, R2.1) | `1247-...` |
+| 위 PR + 저장값 `3-personal`, `2-review` 명시 | PR | `2-review` (명시 우선) + git config 갱신(R2.4) | `1247-...` |
+| `1313` (표지 없는 맨 숫자) | 브랜치 또는 확인 요청 (R1.5) | — | — |
+| "PR 1313을 2-review에 열어줘" | PR (표지 있음) | `2-review` | `1313-...` |
+
+### 외부 명령 계약
+
+**PR 메타데이터 조회 (읽기 전용)**
+
+```bash
+gh pr view {번호} --repo {owner}/{repo} \
+  --json number,state,headRefName,headRefOid,headRepositoryOwner,isCrossRepository,url
+```
+
+**PR head 브랜치 확보 (래퍼 경로, R4.6)**
+
+```bash
+git fetch origin "refs/pull/{PR번호}/head:{head브랜치명}"
+git rev-parse --verify "refs/heads/{head브랜치명}"   # == headRefOid 확인
+```
+
+**래퍼 없는 저장소 — PR 모드**
+
+```bash
+workmux add --pr {PR참조} \
+  --target-name {PR번호}-{짧은이름} \
+  --parent-session {선택세션}
+```
+
+positional 브랜치명을 **생략**한다.
+
+**래퍼 있는 저장소 — PR 모드**
+
+```bash
+./scripts/create-worktree.sh {head브랜치명}
+workmux open {디렉토리명} \
+  --target-name {PR번호}-{짧은이름} \
+  --parent-session {선택세션}
+```
+
+**생성 후 검증**
+
+```bash
+git -C {worktree경로} rev-parse HEAD                  # == headRefOid (R6.8)
+git -C {worktree경로} rev-parse --abbrev-ref HEAD     # == head브랜치명
+tmux list-windows -a -F '#{session_name}:#{window_index}\t#{window_name}'
+git -C {worktree경로} config --get workmux.worktree.{이름}.window-session
+```
+
+**브랜치 모드** — 현행과 동일하되 `--parent-session`이 선택 세션 변수를 쓴다.
+
+### 상태 저장소
+
+| 위치 | 내용 | 읽기 | 쓰기 |
+|---|---|---|---|
+| `workmux.worktree.{이름}.window-session` (git config) | 창이 속한 세션 | R2 우선순위 2 | 세 경우만: R2.2 레거시 갱신, R2.4 명시값 덮어쓰기, R8.2 불일치 정리. workmux 자신도 `--parent-session`을 받으면 이 값을 쓴다 |
+| tmux 서버 | 세션·윈도우 목록 | R3 검증, R8.1 대조 | 없음 (세션 자동 생성 금지) |
+| `git worktree list` | worktree 경로·브랜치 | R7.0 | 없음 |
+| `~/.local/state/workmux/agents/*.json` | 에이전트 상태 | — | `move-window-to-session`이 담당. 이 스킬은 직접 건드리지 않음 |
+
+## Failure behavior
+
+| 실패 | 감지 | 사용자에게 보이는 동작 |
+|---|---|---|
+| positional 3개 이상 | 인자 개수 | 사용법 안내 후 중단 |
+| 자연어에서 브랜치·PR 참조 2개 이상 | R1.6 환원 | 중단하고 사용자에게 확인 |
+| 자연어에서 세션명 2개 이상 | R1.6 환원 | 중단하고 사용자에게 확인 |
+| 표지 없는 맨 숫자 | R1.5 판정 | 브랜치로 해석하거나 사용자에게 확인. PR로 단정 금지 |
+| `gh` 없음·미인증·PR 조회 실패 | 종료 코드 | 그 사실을 보고하고 중단. PR 정보 추측 금지 |
+| PR base 저장소 ≠ 현재 저장소 | `gh` 응답 대조 | 중단. worktree 생성 안 함 |
+| **PR head 브랜치 fetch 실패** | `git fetch` 종료 코드 | **중단. 래퍼를 부르지 않는다.** 부르면 빈 브랜치 worktree가 생긴다 |
+| **확보된 OID ≠ `headRefOid`** | `git rev-parse` 비교 | 중단. 래퍼를 부르지 않는다 |
+| **생성된 worktree HEAD ≠ `headRefOid`** | R6.8 검증 | 성공으로 보고하지 않고 PR 내용이 없음을 알린다 |
+| 동명 로컬 브랜치가 다른 커밋 | `git rev-parse` 비교 | 중단. 덮어쓰지 않음 |
+| PR head 브랜치의 worktree가 이미 있음 | R7.0 | **중단이 아님.** 생성만 건너뛰고 R7 창 처리로 진행 |
+| tmux 서버 부재 | `list-sessions` exit 1 + `error connecting to` | "tmux 서버가 없다"로 보고. "세션 없음"과 구분 |
+| 선택 세션 부재 | `grep -qxF` 실패 | 중단. workmux를 호출하지 않아 유령 세션이 생기지 않음 |
+| 래퍼 실패 | 종료 코드 | 중단. `workmux open` 진행 안 함. worktree가 암호화·의존성 미설치 상태로 남을 수 있음을 보고 |
+| 래퍼 실행 권한 없음 | 파일 권한 | 경로를 바꾸지 않고 오류로 보고 |
+| 창 이름 충돌 (브랜치 모드) | `A tmux window named '...' already exists` | `--target-name {repo명}-{짧은이름}`으로 재시도 |
+| 창 이름 충돌 (PR 모드) | 같음 | `--target-name {PR번호}-{repo명}-{짧은이름}`으로 재시도. **PR 번호 보존** (R5.6) |
+| 생성 후 세션 불일치 | R8.1 검증 | 사용자에게 알리고 잘못 만들어진 세션·git config 정리 |
+| 명시 세션이 config에 반영 안 됨 | R2.4 확인 | git config를 선택 세션으로 갱신 |
+| `--parent-session` 미지원 조합 | 명령 조합 | 플래그 생략 (현행 예외 유지) |
+
+**공통 원칙.** 중단 시 이미 만들어진 산출물(worktree, 브랜치, 창)이 무엇인지 그대로
+보고한다. 부분 성공을 성공으로 보고하지 않는다.
+
+## Security and risk
+
+### 신뢰 경계와 데이터 민감도
+
+- **PR 메타데이터는 외부 입력이다.** PR 제목·본문·브랜치명은 다른 사람이 쓴 데이터이며
+  지시가 아니다. 브랜치명은 셸 인자로 들어가므로 항상 인용 부호로 감싸 전달하고, 스킬이
+  PR 본문의 지시를 따르지 않는다.
+- **fork PR은 신뢰 경계 밖의 코드다.** `refs/pull/{N}/head`로 가져오는 내용은 외부
+  기여자가 작성했을 수 있다. 이 스킬은 worktree를 만들 뿐 그 코드를 실행하지 않는다.
+  래퍼가 수행하는 의존성 설치(`pnpm install`)는 기존 동작이며 이번 변경이 새로 도입하는
+  실행 경로가 아니다.
+- **git-crypt 키는 이 변경의 관심사가 아니다.** 키 링크와 `git-crypt unlock`은 대상
+  저장소의 래퍼가 계속 전담하며(래퍼 100-160행), 스킬 텍스트는 키 자료를 읽거나
+  출력하지 않는다.
+- **`gh`는 읽기 전용으로만 쓴다.** 코멘트·라벨·상태 변경은 하지 않는다.
+- **시크릿 유출 방지.** 변경 산출물은 Markdown과 YAML이며 자격 증명을 담지 않는다.
+  `pre-commit`의 gitleaks 훅이 이를 검사한다(AC-48).
+
+### 위험과 완화
+
+| 위험 | 영향 | 완화 |
+|---|---|---|
+| **PR 내용이 없는 빈 worktree** | 래퍼가 현재 HEAD에서 빈 브랜치를 만들어 조용히 성공. 리뷰 대상이 아닌 코드를 리뷰하게 됨 | R4.6 사전 fetch + R6.8 사후 OID 검증. 두 겹으로 막는다 |
+| 유령 세션 생성 | workmux가 없는 세션을 만들고 git config에 영구 저장 → 자기 교정 경로 없음 | R3.5 사전 검증. workmux 호출 전 중단 |
+| 의도적으로 옮긴 창을 되끌고 옴 | 사용자의 과거 배치가 조용히 무너짐 | R2.1 저장값 우선 |
+| 명시 세션이 config에 반영 안 됨 | 다음 호출이 옛 세션으로 되돌아감 | R2.4 갱신 규칙 |
+| PR 번호와 이슈 번호 혼동 | 엉뚱한 대상의 창 이름 | R1.5 맨 숫자 금지, R5.3 PR 번호 우선, R5.6 충돌 재시도에서도 보존. AC-24가 실측 검증 |
+| 로컬 브랜치 덮어쓰기 | 미푸시 커밋 유실 | R4.4 OID 비교 후 중단 |
+| 열린 창 재구성으로 에이전트 상태 유실 | 돌고 있는 작업 손실 | R7.4 `move-window-to-session` 사용 |
+| 두 원본 drift | Claude와 Codex가 다르게 동작 | R9.1 + AC-43 `diff` 검증 |
+| 스모크 테스트의 부작용 | 실제 worktree·tmux 창 생성 | 자신의 dotfiles 저장소 PR #31 사용. 정리 절차를 Test strategy에 포함 |
+
+### 롤백
+
+변경 산출물은 chezmoi 소스의 Markdown·YAML 3개 파일이다. 롤백은
+`git revert` 또는 `git checkout -- {경로}` 후 `chezmoi apply`이며 데이터 마이그레이션이
+없다. 스모크 테스트로 만들어진 worktree·창·로컬 브랜치는 Test strategy의 정리 절차로
+제거한다.
+
+### 비적용 항목
+
+이 작업은 standard 등급이며 다음은 해당 사항이 없다.
+
+- **인증·인가·테넌시**: 권한 경계를 다루지 않는다. `gh`는 사용자 자신의 기존 자격
+  증명을 그대로 쓰며 이 변경이 권한을 넓히지 않는다.
+- **DB 스키마·마이그레이션·백필**: 영속 스키마가 없다.
+- **공개 API 호환성·멱등성·동시성**: 외부에 노출되는 계약이 없다. 스킬은 단일 사용자가
+  대화형으로 호출한다.
+- **프로덕션 변경**: 프로덕션 시스템을 건드리지 않는다.
+
+## Test strategy
+
+이 저장소에는 테스트 스위트·타입 체크·빌드가 없다(`package.json`, `Makefile`,
+`justfile`, `.github/workflows` 부재 실측). 검증은 세 층으로 한다.
+
+### 1층 — 부작용 없는 실행 검사
+
+| 검사 | 명령 | 커버 |
+|---|---|---|
+| frontmatter | `quick_validate.py` 2회 (위 "frontmatter 검증" 기준선 대조) | AC-47 |
+| `argument-hint` | `grep -q 'argument-hint: <branch-name\|pr-ref> \[target-session\]'` | AC-7 |
+| 두 본문 동일성 | `diff` → `3a4,6`과 그 3줄만 | AC-43 |
+| `1-main` 잔존 | 위 "1-main 잔존 검사"의 허용/금지 목록 대조 | AC-15 |
+| `openai.yaml` | `grep -qE '2-review\|pull/'` | AC-44 |
+| tmux 서버 부재 감지 | `tmux -L quality-goal-nonexistent-socket list-sessions` → exit 1 + `error connecting to` | AC-12 |
+| 없는 세션 판정 | `tmux list-sessions -F '#{session_name}' \| grep -qxF -- 'definitely-not-a-session'` → exit 1 | AC-13 |
+| 접두사 함정 재현 | `tmux has-session -t 2` → 0, `-t 2-rev` → 0, `grep -qxF 2-rev` → 1 | AC-14 |
+| chezmoi 일치 | `chezmoi diff` → `chezmoi apply` → 3개 파일 `cmp` | AC-45 |
+| 공백·시크릿 | `git diff --check`, `pre-commit run --all-files` | AC-48 |
+
+위 tmux 검사 3종은 모두 **읽기 전용이거나 별도 소켓**을 쓰므로 실제 세션 배치를
+바꾸지 않는다. 세 명령의 예상 종료 코드는 2026-08-27에 실측으로 확인했다.
+
+### 2층 — 문서 검토
+
+`[문서]`로 표시된 기준은 절차 서술이므로, 해당 규칙이 두 SKILL.md에 명시적으로
+기술되어 있는지를 검토로 판정한다. 각 기준의 확인 대상은 수용 기준 표의 "검증 방법"
+열에 특정해 두었다.
+
+**이 층의 한계.** 문서 존재 검사는 "규칙이 올바르게 적혀 있음"만 보이고 "그 규칙을
+따랐을 때 실제로 옳은 결과가 나옴"은 보이지 않는다. 그래서 가장 위험한 세 가지(유령
+세션 방지, tmux 서버 부재 구분, 접두사 함정)는 1층의 실행 검사로 끌어올렸고, PR 번호
+파생과 worktree 내용은 3층 실측으로 옮겼다. 남은 `[문서]` 기준은 실행 검증에 실제
+worktree 생성이 필요한 것들이며, 이 한계를 보고서에 기록한다.
+
+### 3층 — 실제 스모크 테스트
+
+**대상**: `lee-kyu-hwan/dotfiles` PR #31.
+
+**가용성 실측 (2026-08-27)**: `state=OPEN`, head 브랜치
+`30-enhancement/tmux-open-pr-shortcut`가 원격에 존재(`9cfc6267...`),
+`refs/pull/31/head`도 같은 OID로 해석됨. 리뷰 시점의 "이미 머지되어 head 브랜치가
+삭제되었을 수 있다"는 우려는 실측으로 반증되었다.
+
+**선정 근거**: PR 번호(31)와 head 브랜치의 이슈 번호(30)가 달라 R5.3을 판별한다.
+dotfiles는 git-crypt가 아니고 래퍼도 없으므로 `workmux add --pr` 경로를 탄다.
+
+**대체 계획**: 실행 시점에 PR #31이 닫혀 head 브랜치가 사라졌으면, 같은 조건(PR 번호
+≠ head 브랜치 접두사 숫자)을 만족하는 다른 열린 PR로 교체한다. PR #32는 head가
+`feat/codex-playwright-e2e-profile`로 숫자 접두사가 없어 AC-24를 판별하지 못하므로
+대체 대상이 아니다. 조건을 만족하는 PR이 없으면 AC-24·AC-30·AC-34·AC-40·AC-42·AC-46·AC-11을
+문서 검토로 강등하고 그 사실을 보고서에 한계로 명시한다. 이 강등은 임의 판단이 아니라
+"조건을 만족하는 PR 부재"가 관찰되었을 때만 발동한다.
+
+| 단계 | 관찰 | 커버 |
+|---|---|---|
+| 세션 미명시로 PR 모드 실행 | 창이 `2-review`에 열림 | AC-46 |
+| 창 이름 | `31-tmux-open-pr-shortcut` (`30-`으로 시작하지 않음) | AC-24 |
+| worktree 브랜치 | `git -C {wt} rev-parse --abbrev-ref HEAD` == `30-enhancement/tmux-open-pr-shortcut` | AC-30 |
+| worktree HEAD | `git -C {wt} rev-parse HEAD` == `9cfc6267ced574945814536710cf1019a37dc354` | AC-34 |
+| 실제 창 위치 | `tmux list-windows -a` 출력 기록 | AC-40 |
+| git config | `workmux.worktree.{이름}.window-session` == `2-review` | AC-11 |
+| 결과 보고 | 경로·브랜치·세션·창이름·PR번호·head OID 6항목 | AC-42 |
+
+**정리 절차** (검증 후 반드시 수행):
+
+```bash
+workmux remove {worktree명}          # worktree + 창 제거
+git branch -D 30-enhancement/tmux-open-pr-shortcut   # fetch로 만들어진 로컬 브랜치
+git worktree list                    # 잔여물 없음 확인
+tmux list-windows -a                 # 잔여 창 없음 확인
+```
+
+**git-crypt 경로(AC-31)는 스모크 테스트하지 않는다.** `zambaguni-front` worktree 생성은
+의존성 설치로 개당 1~2GB를 쓰고 업무 저장소에 부작용을 남긴다. 문서 검토로 판정하고
+이 제약을 보고서에 한계로 기록한다. 다만 R4.6의 근거가 되는 래퍼의 3단계 판별 로직은
+`zambaguni-front/scripts/create-worktree.sh:82-98`을 직접 읽어 확인했다.
+
+## Decisions
+
+### D1. 세션 우선순위에서 저장값이 모드 기본값보다 우선한다
+
+이슈 #35는 "명시값 > 모드 기본값 > 저장 세션 > 1-main"을 권장했다. 이를 뒤집어
+"명시값 > 저장 세션 > 모드 기본값 > 1-main"으로 채택했다.
+
+근거: 저장값은 사용자가 `move-window-to-session`으로 **직접 창을 옮긴 행동의 기록**이고,
+모드 기본값은 단순 관습이다. 관습이 기록을 덮으면 현행 "예외 1"이 막으려던 실패 —
+의도적으로 옮긴 창을 조용히 되끌고 오는 것 — 가 `2-review` 이름으로 재발한다. 사용자가
+2026-08-27 확인에서 이 순서를 선택했다. 신규 worktree에는 저장값이 없으므로 PR 모드
+기본값 `2-review`가 정상 동작한다(AC-46이 실측).
+
+### D2. PR 참조는 표지가 있을 때만 인식한다
+
+표지 없는 맨 숫자(`1313`)를 PR로 해석하지 않는다. GitHub는 이슈와 PR이 번호 공간을
+공유하므로 맨 숫자를 PR로 단정하면 이슈 번호를 PR 번호로 오해해 엉뚱한 브랜치를
+체크아웃할 수 있다. 전체 URL, `owner/repo#N`, 또는 숫자 앞뒤에 PR 표지가 있는 자연어만
+PR 모드로 간다. 자연어 케이스에서 "표지"가 판정 기준이라는 점이 R1.5의 맨 숫자 금지와
+모순되지 않는 이유다 — 금지 대상은 **표지 없는** 맨 숫자다.
+
+### D3. PR 모드에서 positional 브랜치명을 생략한다
+
+`workmux add --help` 실측: "`[BRANCH_NAME]` ... When used with `--pr`, this becomes the
+custom local branch name". positional을 주면 PR head 브랜치 대신 그 이름으로 로컬
+브랜치가 생기므로, PR head를 그대로 쓰려면 생략해야 한다.
+
+### D4. 두 원본은 수동 유지하고 `diff`로 검증한다
+
+심볼릭 링크는 Claude 전용 frontmatter 때문에 불가능하고, 생성 스크립트는 이번 변경
+범위를 넘어선다. Architecture 절의 대안 비교 참조.
+
+### D5. workmux 버전 표기 불일치를 `dot_claude` 쪽으로 통일한다
+
+이슈 #35는 두 원본이 frontmatter만 다르다고 전제했으나 실측에서 `dot_agents:43`
+"0.1.233 실측"과 `dot_claude:46` "0.1.233 확인·0.1.248 재확인"이 다르다. 후자가 현재
+설치된 버전(0.1.248)까지 재확인한 더 정확한 서술이므로 그쪽으로 통일한다.
+
+### D6. 래퍼는 고치지 않고 스킬이 전제를 보장한다
+
+래퍼의 3단계 판별 중 "둘 다 없으면 현재 HEAD에서 새 브랜치"는 브랜치 모드에서는 올바른
+동작이다(새 기능 브랜치를 만드는 정상 경로). 문제는 PR 모드에서 head 브랜치가 `origin`에
+없을 때(fork PR)뿐이다.
+
+- **대안 A — 래퍼에 `--pr` 지원 추가**: 다른 저장소(zambaguni-front)를 고쳐야 하고,
+  이 작업의 변경 범위(#35가 지정한 3개 파일) 밖이다. 탈락.
+- **대안 B — 스킬이 호출 전 fetch로 전제를 보장(채택)**: `refs/pull/{N}/head`를 로컬
+  브랜치로 가져오면 래퍼의 2번 경로(로컬 브랜치 존재)로 확정된다. 래퍼를 건드리지 않고,
+  같은 저장소 PR과 fork PR을 동일하게 처리한다.
+- **대안 C — PR 모드에서 git-crypt 저장소를 미지원**: #28의 요구를 포기하게 되므로 탈락.
+
+사후 검증(R6.8)을 함께 두어 전제 보장이 실패했을 때도 조용한 성공이 되지 않게 한다.
+
+### D7. 기존 worktree는 중단이 아니라 창 처리로 분기한다
+
+이슈 #28은 "PR head 브랜치가 이미 다른 worktree에서 사용 중이면 ... 중단한다"고 썼다.
+그 의도는 **중복 worktree나 별칭 브랜치를 만들지 말라**는 것이지, 창을 열지 말라는 것이
+아니다. 문자 그대로 전체 중단으로 읽으면 PR 리뷰용 창을 두 번째부터 영영 열 수 없어
+Goal 2와 R7 전체가 무의미해진다. 따라서 "생성 단계만 건너뛰고 R7 창 처리로 진행"으로
+확정했다(R4.3). 흐름도의 분기 순서도 이에 맞췄다.
+
+### D8. 스모크 테스트 대상은 dotfiles PR #31이다
+
+PR 번호(31)와 head 브랜치 이슈 번호(30)가 달라 R5.3을 판별하는 가용 케이스다. 2026-08-27
+실측으로 `state=OPEN`이고 head 브랜치가 원격에 살아 있음을 확인했다. PR #32는 head
+브랜치에 숫자 접두사가 없어 이 구분을 검증하지 못하므로 대체 대상이 아니다. 실행
+시점에 #31이 닫혔을 경우의 대체 계획은 Test strategy 3층에 기술했다.
+
+### D9. git-crypt 경로는 문서 검토 + 래퍼 소스 확인으로 검증한다
+
+실제 검증은 업무 저장소에 1~2GB 규모 부작용을 남긴다. 대신 R4.6의 근거가 되는 래퍼의
+브랜치 판별 로직을 소스에서 직접 읽어 확인했고(`scripts/create-worktree.sh:82-98`), 그
+실측을 Problem and context에 기록했다. 이 한계를 보고서에 명시한다.
+
+### 미해결 사항
+
+없다. 모든 중대 결정이 위에 해소되어 있다.


### PR DESCRIPTION
## 무엇

quality-goal 스킬을 #28·#35(create-worktree PR 세션 확장)에 실전 적용한 1·2차 실행의 산출물을 기록한다. 두 실행 모두 Spec 리뷰 라운드 한도를 소진하고 `NEEDS_REDESIGN`으로 종결했고, **소스 파일은 한 줄도 바뀌지 않았다** — 미달 Spec이 구현으로 넘어가는 것을 게이트가 막았다.

## 왜 실패 기록을 남기는가

증거 기반이기 때문이다. 오늘 새로 올린 이슈 **#45~#51의 근거가 이 보고서들에 있다.**

| 이슈 | 이 보고서의 근거 |
|---|---|
| #43 | 양쪽 실행에서 `terminal state is immutable` 재현 (exit 3) |
| #44 | 1차의 "프로세스 관찰" 절 — 라운드 2 리뷰어가 SPEC-005~010을 검증 불가 |
| #50 | 2차 `report.md:178-182` — `required_sections`를 리뷰어가 확정 못 하고 오케스트레이터가 template과 직접 비교 |
| #51 | 2차 `spec.md:94-117` — 증거를 `feat-quality-goal-skill` worktree에 걸고 88점을 받았으나 그 worktree 제거로 증거가 죽음 |

## 두 실행이 잡은 진짜 결함

1차 라운드 1의 **SPEC-001은 실제 버그**다. `zambaguni-front`의 `scripts/create-worktree.sh:82-98`이 브랜치가 로컬·origin 어디에도 없으면 현재 HEAD에서 빈 브랜치를 만든다. **fork PR의 head는 origin에 없으므로 PR 내용이 전혀 없는 worktree가 조용히 생긴다.** 이슈 #28 설계에 없던 구멍이었다.

## 점수 궤적 — 반복이 낭비가 아니었다

| 실행 | 라운드 1 | 라운드 2 | 블로커 | Critical/High |
|---|---|---|---|---|
| 1차 | 75 | 82 | 3건 → 0건 | 3건 → 2건 |
| 2차 | 80 | **88** (통과선 초과) | 0건 → 0건 | 0건 → 0건 |

2차는 1차의 High 2건을 Spec 초안에 선반영한 결과다. 게이트는 `verdict_not_pass`와 `check_failed:acceptance_criteria_objective`로 실패했고 그것을 고칠 라운드가 남지 않아 종결했다 — 이 실측이 #51-C(점수 임계값 재검토)의 근거이기도 하다.

3차 실행 산출물은 진행 중이라 제외했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)