### PR TITLE
fix(quality-goal): spec 리뷰 라운드 한도를 2에서 3으로 올린다 (v3.0.0)

### DIFF
--- a/dot_claude/skills/quality-goal/SKILL.md
+++ b/dot_claude/skills/quality-goal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quality-goal
-version: 2.0.0
+version: 3.0.0
 description: Use when the user explicitly requests a quality-gated, documented software change workflow.
 argument-hint: '[--mode=auto|light|standard|strict] <goal>'
 disable-model-invocation: true
@@ -111,7 +111,7 @@ artifact's SHA-256 approval digest via approve-plan.
 |---|---|
 | INTAKE | Parse, run select-resume, preflight Git and Codex, initialize or load state, and capture the baseline |
 | CLASSIFIED | Load routing-rules.md and print the selected mode with concrete evidence |
-| SPEC_REVIEW | Standard and strict only: render templates/spec.md under brainstorming-policy.md, review, validate, gate, with at most 2 review rounds |
+| SPEC_REVIEW | Standard and strict only: render templates/spec.md under brainstorming-policy.md, review, validate, gate, with at most 3 review rounds |
 | SPEC_PASSED | Confirm the passing Spec is registered with set-artifact using its absolute path, then transition to PLAN_REVIEW |
 | PLAN_REVIEW | Standard and strict only: render templates/plan.md, map every acceptance criterion, discover exact commands, review, validate, gate, with at most 2 review rounds |
 | PLAN_PASSED | Confirm the passing Plan is registered with set-artifact using its absolute path, then transition to AWAITING_PLAN_APPROVAL |
@@ -134,7 +134,7 @@ quality_state.py classify, and show the mode and evidence before continuing.
 
 For standard and strict, inspect repository conventions and use the adapted
 brainstorming policy in brainstorming-policy.md. Draft Spec from
-templates/spec.md. The Spec review has at most 2 rounds. Strict retains the
+templates/spec.md. The Spec review has at most 3 rounds. Strict retains the
 template's strict-only blocks; a
 non-strict artifact removes those blocks and records any inapplicable
 requirements with a reason. Immediately after drafting, register the Spec with
@@ -142,7 +142,7 @@ set-artifact --kind spec using its absolute path, before the first reviewer
 round, so record-review's artifact-digest cross-check engages on every round.
 Launch a fresh quality-reviewer round using the Spec rubric, validate the
 result, and run its deterministic gate. Revise only within the Spec limit of
-at most 2 rounds; after each revision, re-register the Spec with
+at most 3 rounds; after each revision, re-register the Spec with
 set-artifact --kind spec using its absolute path so the digest stays current.
 A failed limit or recurring material finding is NEEDS_REDESIGN. On a pass,
 confirm the current registration and transition through SPEC_PASSED.

--- a/dot_claude/skills/quality-goal/references/spec-rubric.md
+++ b/dot_claude/skills/quality-goal/references/spec-rubric.md
@@ -30,5 +30,5 @@ Unsupported opinion without repository or requirement evidence cannot block the 
 
 - Round 1 is a full review of the Spec against every rubric item and required section.
 - Later rounds verify open findings and regressions introduced by revisions. A new blocker after Round 1 must be Critical or High and include `new_blocker_evidence` showing that it was newly introduced or could not reasonably have been identified earlier.
-- After round 2 without a passing gate, stop and record `NEEDS_REDESIGN`.
+- After round 3 without a passing gate, stop and record `NEEDS_REDESIGN`.
 - If the same blocking finding ID recurs twice, stop and record `NEEDS_REDESIGN`, even if the round limit has not otherwise been reached.

--- a/dot_claude/skills/quality-goal/scripts/quality_state.py
+++ b/dot_claude/skills/quality-goal/scripts/quality_state.py
@@ -66,7 +66,7 @@ ALLOWED_TRANSITIONS = {
 }
 
 TERMINAL_STATES = {"COMPLETED", "BLOCKED", "NEEDS_REDESIGN", "CANCELLED"}
-ROUND_LIMITS = {"spec": 2, "plan": 2, "code": 3}
+ROUND_LIMITS = {"spec": 3, "plan": 2, "code": 3}
 
 _REQUESTED_MODES = {"auto", "light", "standard", "strict"}
 _CLASSIFIED_MODES = {"light", "standard", "strict"}

--- a/dot_claude/skills/quality-goal/tests/test_content_contracts.py
+++ b/dot_claude/skills/quality-goal/tests/test_content_contracts.py
@@ -228,7 +228,10 @@ class SpecRubricContentTests(unittest.TestCase):
                 self.assertIn(term, lower)
         self.assertIn("`SPEC-`", text)
         self.assertRegex(lower, r"(?:later rounds|rounds after round 1).{0,220}(?:open findings|regressions)")
-        self.assertRegex(lower, r"stop.{0,100}round 2|after round 2.{0,100}stop")
+        self.assertEqual(
+            ["3"],
+            re.findall(r"after round (\d+) without a passing gate", lower),
+        )
         self.assertRegex(lower, r"needs_redesign")
 
     def test_rubric_pass_gate_keys_match_required_checks_exactly(self):
@@ -279,7 +282,10 @@ class PlanRubricContentTests(unittest.TestCase):
                 self.assertIn(term, lower)
         self.assertRegex(lower, r"every acceptance criterion.{0,180}(?:maps|map).{0,120}(?:task|verification)")
         self.assertRegex(lower, r"placeholders_absent.{0,120}placeholder text is absent")
-        self.assertRegex(lower, r"stop.{0,100}round 2|after round 2.{0,100}stop")
+        self.assertEqual(
+            ["2"],
+            re.findall(r"after round (\d+) without a passing gate", lower),
+        )
         self.assertRegex(lower, r"needs_redesign")
 
 
@@ -318,7 +324,10 @@ class CodeRubricContentTests(unittest.TestCase):
                 self.assertIn(term, lower)
         self.assertIn("`CODE-`", text)
         self.assertRegex(lower, r"(?:reviewer|review).{0,80}(?:never waivable|cannot waive)")
-        self.assertRegex(lower, r"stop.{0,100}round 3|after round 3.{0,100}stop")
+        self.assertEqual(
+            ["3"],
+            re.findall(r"after round (\d+) without a passing gate", lower),
+        )
         self.assertRegex(lower, r"needs_redesign")
 
 
@@ -720,7 +729,7 @@ class QualityGoalSkillContentTests(unittest.TestCase):
         frontmatter, _ = parse_yaml_frontmatter(self.read_skill())
         expected = {
             "name": "quality-goal",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "description": "Use when the user explicitly requests a quality-gated, documented software change workflow.",
             "argument-hint": "[--mode=auto|light|standard|strict] <goal>",
             "disable-model-invocation": "true",
@@ -914,7 +923,7 @@ class QualityGoalSkillContentTests(unittest.TestCase):
     def test_review_round_limits_and_reviewer_isolation_contract(self):
         _, body = parse_yaml_frontmatter(self.read_skill())
         lower = body.casefold()
-        for stage, limit in (("spec", 2), ("plan", 2), ("code", 3)):
+        for stage, limit in (("spec", 3), ("plan", 2), ("code", 3)):
             with self.subTest(stage=stage):
                 self.assertRegex(
                     lower,

--- a/dot_claude/skills/quality-goal/tests/test_quality_state.py
+++ b/dot_claude/skills/quality-goal/tests/test_quality_state.py
@@ -153,7 +153,7 @@ class ConstantTests(unittest.TestCase):
             quality_state.TERMINAL_STATES,
         )
         self.assertEqual(
-            {"spec": 2, "plan": 2, "code": 3},
+            {"spec": 3, "plan": 2, "code": 3},
             quality_state.ROUND_LIMITS,
         )
 
@@ -1011,27 +1011,45 @@ class RecordReviewTests(unittest.TestCase):
 
 
 class RoundLimitTests(unittest.TestCase):
-    def test_spec_and_plan_round_three_are_rejected_after_two_recorded_rounds(self):
+    def test_plan_round_three_is_rejected_after_two_recorded_rounds(self):
         with tempfile.TemporaryDirectory() as directory:
-            for artifact, stage in (("spec", "SPEC_REVIEW"), ("plan", "PLAN_REVIEW")):
-                with self.subTest(artifact=artifact):
-                    state = state_at(stage)
-                    for round_number in (1, 2):
-                        review_path = write_json(
-                            directory,
-                            f"{artifact}-{round_number}.json",
-                            valid_review(artifact=artifact, round_number=round_number),
-                        )
-                        quality_state.record_review(state, review_path, VALID_DIGEST)
+            state = state_at("PLAN_REVIEW")
+            for round_number in (1, 2):
+                review_path = write_json(
+                    directory,
+                    f"plan-{round_number}.json",
+                    valid_review(artifact="plan", round_number=round_number),
+                )
+                quality_state.record_review(state, review_path, VALID_DIGEST)
 
-                    round_three = write_json(
-                        directory,
-                        f"{artifact}-3.json",
-                        valid_review(artifact=artifact, round_number=3),
-                    )
-                    with self.assertRaises(StateError):
-                        quality_state.record_review(state, round_three, VALID_DIGEST)
-                    self.assertEqual(2, state["rounds"][artifact])
+            round_three = write_json(
+                directory,
+                "plan-3.json",
+                valid_review(artifact="plan", round_number=3),
+            )
+            with self.assertRaises(StateError):
+                quality_state.record_review(state, round_three, VALID_DIGEST)
+            self.assertEqual(2, state["rounds"]["plan"])
+
+    def test_spec_round_four_is_rejected_after_three_recorded_rounds(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state = state_at("SPEC_REVIEW")
+            for round_number in (1, 2, 3):
+                review_path = write_json(
+                    directory,
+                    f"spec-{round_number}.json",
+                    valid_review(artifact="spec", round_number=round_number),
+                )
+                quality_state.record_review(state, review_path, VALID_DIGEST)
+
+            round_four = write_json(
+                directory,
+                "spec-4.json",
+                valid_review(artifact="spec", round_number=4),
+            )
+            with self.assertRaises(StateError):
+                quality_state.record_review(state, round_four, VALID_DIGEST)
+            self.assertEqual(3, state["rounds"]["spec"])
 
     def test_code_round_four_is_rejected_after_three_recorded_rounds(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -1054,16 +1072,28 @@ class RoundLimitTests(unittest.TestCase):
             self.assertEqual(3, state["rounds"]["code"])
 
     def test_nonpassing_final_spec_round_enters_needs_redesign(self):
+        """Rounds 1-2 are REVISE with no blockers so neither the recurring-
+        blocker branch nor a premature limit fires before round 3, the
+        actual final spec round under the 3-round limit."""
         with tempfile.TemporaryDirectory() as directory:
             state = state_at("SPEC_REVIEW")
-            first = write_json(directory, "spec-1.json", valid_review(artifact="spec"))
-            quality_state.record_review(state, first, VALID_DIGEST)
+            for round_number in (1, 2):
+                review_path = write_json(
+                    directory,
+                    f"spec-{round_number}.json",
+                    valid_review(
+                        artifact="spec",
+                        round_number=round_number,
+                        verdict="REVISE",
+                    ),
+                )
+                quality_state.record_review(state, review_path, VALID_DIGEST)
             final = write_json(
                 directory,
-                "spec-2.json",
+                "spec-3.json",
                 valid_review(
                     artifact="spec",
-                    round_number=2,
+                    round_number=3,
                     verdict="REVISE",
                     blockers=["SPEC-LIMIT-001"],
                 ),


### PR DESCRIPTION
Closes #53

## 근거 — 실전 4회 연속 spec 2/2 소진

spec 리뷰가 실전에서 4회 연속으로 최대 2라운드를 전부 소진했다. plan은 한도 도달조차 못 했고 code는 소진 0회다. spec의 한도 2는 예외적 안전망이 아니라 상시 제약이다.

더 결정적인 것은 **소진된 라운드 중 3개가 점수 통과선(85)을 넘고도 게이트에 실패했다**는 점이다.

| 실행 | 라운드 1 | 라운드 2 | 종결 |
|---|---|---|---|
| `…-create-worktree-pr-session` | 75점 / 블로커 3건 | 82점 / High 2건 | `NEEDS_REDESIGN` |
| `…-create-worktree-pr-session-2` | 80점 / 블로커 0 · Critical·High 0 | **88점** / 블로커 0 · Critical·High 0 | `NEEDS_REDESIGN` |
| `…-quality-goal-review-loop` | 87점 / 블로커 1건 | 86점 / 블로커 1건 | `NEEDS_REDESIGN` |

정확한 인과는 "한도 때문에만 실패했다"가 아니다. 각 최종 라운드의 게이트는 `verdict_not_pass`·`blockers_present`·`critical_or_high_finding`·`check_failed:acceptance_criteria_objective` 같은 실질 사유로 실패했다. 문제는 **그것을 고칠 라운드가 남아 있지 않았다**는 것이다. `NEEDS_REDESIGN`은 30분 이상의 실행을 통째로 폐기한다.

## 변경

`quality_state.py`의 `ROUND_LIMITS["spec"]`를 2 → 3. **`plan`(2)과 `code`(3)는 그대로 둔다** — 실측 근거가 없다.

## 함께 동기화한 것

- `spec-rubric.md`의 라운드 문구. **`plan-rubric.md:33`과 바이트 동일한 문장이라** `replace_all`을 쓰지 않고 파일별로 개별 편집했다
- `SKILL.md`의 spec 라운드 서술 3곳. plan·code 서술은 손대지 않았다

## 상수만 바꾸면 깨지는 기존 테스트 3개를 고쳤다

- `ConstantTests` — 기대 dict를 spec 3으로 동기화
- spec/plan 라운드 상한 테스트를 **분리**했다. 기존 테스트는 spec·plan을 한 `subTest` 루프로 묶어 둘 다 라운드 3에서 거부됨을 단정했는데, 한도가 갈라지면서 더 이상 성립하지 않는다. plan은 라운드 3 거부(기존 code round-4 테스트와 같은 이름 패턴), spec은 라운드 4 거부로 분리했다
- `NEEDS_REDESIGN` 진입 테스트를 라운드 3으로 재앵커했다. **라운드 1·2를 blocker 없는 REVISE로 두고 라운드 3만 blocker를 넣었다** — blocker ID를 라운드마다 다르게 만드는 대안도 성립하지만(4개 시나리오 실측), 이 형태가 자동 전이 조건(`verdict != PASS or blockers`)을 그대로 쓰면서 recurring-blocker 분기(`:588-591`)를 우회하는 최소 변경이다. 후자를 그대로 두면 라운드 2에서 recurring 분기가 먼저 발동해 `RECURRING_BLOCKING_FINDING`이 기록되고 단정이 깨진다.

## 루브릭 라운드 단언을 개수·값 고정 형태로 교체

`test_content_contracts.py`의 세 루브릭 라운드 단언이 `assertRegex(lower, r"stop.{0,100}round N|after round N.{0,100}stop")`이었다. **좌변은 세 루브릭 어디에서도 매치되지 않는다**(실측 전부 `False`) — 순수한 잠재 오탐 여지였다. `re.findall(r"after round (\d+) without a passing gate", lower) == ["3"]`/`["2"]`/`["3"]`로 바꿔 개수와 값을 동시에 고정했다.

넓은 패턴 `after round (\d+)`는 각 루브릭의 "A new blocker after Round 1…" 문장이 먼저 잡혀 `["1","3"]` 형태가 되므로 그대로 쓸 수 없었다 — 실측으로 확인 후 `without a passing gate`로 좁혔다.

## 변이 검증 4종

- `ROUND_LIMITS` spec 되돌림 → 탐지
- `spec-rubric.md`만 되돌림 (`SKILL.md`·코드는 3 유지) → 탐지
- `SKILL.md` 세 문장 중 1곳만 되돌림 → **통과.** 결함이 아니다 — `SKILL.md` 계약 테스트는 원래부터 "증거가 어딘가에 있으면 통과"하는 느슨한 스타일이고(세 문장 전체를 되돌리면 최초 red 단계에서 확인했듯 정상적으로 깨진다), `#53`이 요청한 것은 **세 루브릭 파일**의 단언 강화뿐이며 `SKILL.md` 자체의 문장별 개별 고정은 범위 밖이다. 필요하면 별건으로 다룰 것을 제안한다
- 루브릭에 `round 2` 문장을 **치환 없이 추가** → 탐지 (개수 고정이 정확히 이 시나리오를 막는다)

## 하지 않은 것

- **조건부 계속 진행 로직을 넣지 않았다.** "라운드 3은 진전이 있을 때만" 류의 판단 분기는 검토 후 기각했다 — 그 로직이 들어갈 자리가 `record_review`이고 거기가 `#43`의 자동 전이 결함이 있는 함수다. 그 조건이 막으려는 "정체된 실행"은 실측 4회 모두 개선 궤적이어서 관측된 적이 없다
- **4 이상으로 올리지 않았다.** 3이 필요했던 실측만 존재한다
- 요구사항 래칫 대응(수렴 규칙·추상화 이탈 감지)은 별개 주제다
- `record_review`의 자동 전이 블록(`#43`)은 상수 값만 참조하며 코드는 base revision과 **바이트 동일**하다

## 검증

```bash
PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover \
  -s dot_claude/skills/quality-goal/tests -p 'test_*.py'
```

**201개 통과** (기준선 200 + 1: spec/plan 라운드 상한 테스트 분리로 순증 1건).

## SemVer

**3.0.0** — 라운드 한도는 상태 머신 계약이며, `#54`가 이미 2.0.0을 쓰고 병합됐으므로 그 위에 새 MAJOR로 올린다.

## 관련

- `#54` — 병합 완료. `ROUND_LIMITS` spec의 값 자체는 그 PR에서 건드리지 않았다
- `#43` — `record-review`의 자동 터미널 전이. 범위 밖

🤖 Generated with [Claude Code](https://claude.com/claude-code)
