### PR TITLE
feat(create-worktree): PR 링크로 2-review 세션에 PR 번호 창을 연다

### DIFF
--- a/docs/development/2026-08-27-create-worktree-pr-session-3/plan.md
+++ b/docs/development/2026-08-27-create-worktree-pr-session-3/plan.md
@@ -1,0 +1,1021 @@
+# Quality Goal Implementation Plan
+
+- Task ID: 20260827T120102Z-28-35-create-worktree-스킬-3차-실행-pr-링크-입력-a16ed82b
+- Mode: standard
+- Status: PLAN_REVIEW (round 2)
+- Created: 2026-08-28
+- Updated: 2026-08-28
+- Source goal: #28 #35 create-worktree 스킬 3차 실행 — PR 링크 입력 시 2-review 세션에 PR 번호 윈도우를 생성하고 대상 세션을 직접 지정하도록 확장한다. SPEC-009(AC-9 판별력)과 SPEC-010(--pr 정규화)를 선반영하고, 휘발성 식별자를 증거에서 제거한다
+
+## Spec link
+
+- 경로: `docs/development/2026-08-27-create-worktree-pr-session-3/spec.md`
+- SHA-256: `5c742d283a2e042b97f81239c5dd7e836a3b1b9bb7c9c822e7476a5c597408f9`
+- 게이트: 라운드 2에서 90점 PASS, 블로커 0, Critical/High 0
+- 이 Plan은 위 digest의 Spec만을 근거로 한다. Spec이 바뀌면 이 Plan을 무효로 본다.
+
+### Spec 잔여 권고 사항의 처리
+
+Spec 게이트 통과 후에도 Medium 1건·Low 4건이 남았다. 통과 시점 digest를 깨지 않기 위해
+Spec 본문은 수정하지 않았고, **이 Plan이 각각의 해소 방침을 확정한다.** 구현은 Spec이
+아니라 아래 확정안을 따른다.
+
+| ID | 심각도 | 내용 | 이 Plan의 확정 |
+|---|---|---|---|
+| SPEC-018 | Medium | R8.2("실제 세션 ≠ 선택 세션이면 정리")가 R2.6 3행("창이 열려 있고 옮기지 않으면 실제 세션으로 갱신")과 충돌 | **분기별로 나눈다** — ① 생성·오픈 분기: R8.2 그대로 적용 ② 이동 분기(R7.5): 이동 후 최종 위치가 선택 세션과 다르면 **보고하고 config에 잘못된 값을 쓰지 않는다** ③ 옮기지 않는 분기(R7.3·R7.4): 불일치가 정상이므로 R8.2를 적용하지 않고 R2.6이 관장한다. 세 갈래를 SKILL.md 사후 검증 절에 모두 적는다 |
+| SPEC-019 | Low | AC-9b의 "실행된 `git config` 명령 기록"에 캡처 방법이 없다 | **아래 "스모크 실행 하네스"의 명령 로그**를 캡처 수단으로 확정. 로그가 비었거나 하네스를 우회한 흔적이 있으면 통과가 아니라 **"검증 불가"**로 보고 |
+| SPEC-020 | Low | AC-56 정규식이 줄 끝 `PR`을 놓친다 | 앵커 추가 — `'pull request\|(^\|[^a-z])PR([^a-z]\|$)'` |
+| SPEC-021 | Low | Spec 헤더가 "round 1"로 남아 있다 | **수정하지 않는다.** 통과 시점 digest 보존. 보고서에 알려진 표기 오류로 기록 |
+| SPEC-022 | Low | R7.5가 `move-window-to-session`의 `{worktree명}`을 handle과 무조건 등치. 그 스킬은 PATH basename으로 정의 | **분기 규칙까지 확정한다** — handle과 경로를 함께 넘기고, 이동 후 `workmux.worktree.{handle}.window-session`을 읽어 대상 세션과 다르면(그 스킬이 basename 키에 썼다는 뜻) **스킬이 handle 키를 직접 갱신하고 그 사실을 보고한다.** 갱신도 실패하면 중단한다. 이 분기는 스모크로 덮이지 않는다(아래 한계 참조) |
+
+**SPEC-022의 검증 한계.** 이 저장소의 기본 명명에서는 PR #31 worktree의 handle과 PATH
+basename이 같아 분기가 발동하지 않는다. 스모크로 확인할 수 없으므로 문서 검토로만
+판정하고 보고서에 잔여 격차로 기록한다. 억지로 조건을 만들려면 `--name`으로 handle을
+바꾼 worktree를 옮겨야 하는데, 그것은 T8 픽스처와 T9~T12 상태 전이를 뒤섞어 다른 기준의
+판정을 흐린다.
+
+## Global constraints
+
+### 변경 허용 경로 (이 셋 외 어떤 파일도 수정하지 않는다)
+
+1. `dot_claude/skills/create-worktree/SKILL.md`
+2. `dot_agents/skills/create-worktree/SKILL.md`
+3. `dot_agents/skills/create-worktree/agents/openai.yaml`
+
+### 보존 대상 (baseline의 initial dirty path — 바이트 단위 보존)
+
+- `docs/development/2026-08-27-create-worktree-pr-session/`
+- `docs/development/2026-08-27-create-worktree-pr-session-2/`
+
+이번 실행 산출물인 `-3/` 디렉터리는 오케스트레이터만 쓴다. Codex는 수정하지 않는다.
+
+### 저장소 관례
+
+- **홈의 적용본을 직접 수정하지 않는다.** 소스만 고치고 chezmoi가 생성한다(CLAUDE.md).
+- 두 SKILL.md 본문은 Claude 전용 frontmatter 3줄을 제외하고 동일해야 한다.
+
+### 안전 제약
+
+- **커밋·푸시·머지 금지.**
+- **`chezmoi apply`를 인자 없이 실행하지 않는다.** `dot_claude/skills/quality-goal`이
+  chezmoi 소스에 있어(실측) 전체 apply는 다른 세션이 실행 중인 quality-goal 배포본
+  **23개 파일**을 덮는다. 반드시 경로를 한정한다.
+- 다른 세션의 worktree·창(`workmux list`에 이미 있는 항목)을 건드리지 않는다.
+- Codex 호출에 `--skip-git-repo-check`, `--full-auto`, `--yolo`를 쓰지 않는다.
+
+### 구현 규칙
+
+- **test-first**: 검증 명령을 먼저 실행해 실패를 기록(T1) → 최소 변경(T2~T4) → 같은
+  명령으로 통과 기록(T5).
+- Spec의 요구사항 번호를 SKILL.md 본문에 노출하지 않는다. 절 제목과 서술로 옮긴다.
+- Spec R9.6의 보존 규칙 18개는 문구가 바뀌어도 규칙 자체가 남아야 한다.
+
+## 스모크 실행 하네스 (PLAN-001·PLAN-002 해소의 핵심)
+
+### 문제
+
+라운드 1 Plan은 스킬이 **파생해야 할 값**(대상 세션, 창 이름, `--pr` 인자 형태)을
+오케스트레이터가 직접 타이핑한 뒤 그 값을 검증했다. 그러면 SKILL.md가 틀리게 적혀 있어도
+통과한다 — Spec D19가 AC-9b를 만든 이유와 정확히 같은 결함이다.
+
+### 원칙
+
+1. **입력에 정답을 넣지 않는다.** 각 스모크 단계의 호출 프롬프트에는 그 단계가 검증하려는
+   값을 넣지 않는다. 세션 선택을 검증하는 단계에는 세션명을 주지 않고, 창 이름 파생을
+   검증하는 단계에는 이름을 주지 않는다.
+2. **배포본이 절차를 결정한다.** 호출 주체는 `~/.claude/skills/create-worktree/SKILL.md`
+   를 읽고 스스로 명령을 만든다.
+3. **실제 실행된 명령줄을 기계적으로 남긴다.** 자기 보고가 아니라 로그로 남긴다.
+
+### 하네스 구성 (T7 직후, T8 시작 전에 준비)
+
+```bash
+HARNESS=/tmp/qg-harness
+mkdir -p "$HARNESS/shim"
+LOG="$HARNESS/cmd.log"; : > "$LOG"
+
+# workmux·git·tmux 실행을 argv 그대로 기록하는 shim
+# tmux를 포함하는 이유(PLAN-013): 창 이동은 tmux move-window·display-message로 일어나므로
+# tmux를 빼면 T11의 "이동 경로를 탔다"는 증거를 만들 수 없다.
+for real in /opt/homebrew/bin/workmux /opt/homebrew/bin/git /opt/homebrew/bin/tmux; do
+  name=$(basename "$real")
+  cat > "$HARNESS/shim/$name" <<EOF
+#!/bin/sh
+printf '%s' "$name" >> "$LOG"
+for a in "\$@"; do printf ' %s' "\$a" >> "$LOG"; done
+printf '\n' >> "$LOG"
+exec "$real" "\$@"
+EOF
+  chmod +x "$HARNESS/shim/$name"
+done
+
+# 모든 셸 명령을 이 스크립트로 통과시킨다
+cat > "$HARNESS/run.sh" <<EOF
+#!/bin/bash
+export PATH="$HARNESS/shim:\$PATH"
+eval "\$@"
+EOF
+chmod +x "$HARNESS/run.sh"
+```
+
+`workmux`와 `git`의 실경로는 실측했다(`/opt/homebrew/bin/workmux`,
+`/opt/homebrew/bin/git`). shim은 argv를 로그에 붙인 뒤 실물을 `exec`하므로 동작을 바꾸지
+않는다.
+
+### 호출 방식 (PLAN-018)
+
+각 스모크 단계는 **Agent 도구로 `general-purpose` 하위 에이전트 하나**를 띄워 수행한다
+(Bash 권한이 있어야 하므로 읽기 전용 에이전트는 쓰지 않는다). 오케스트레이터가 그
+에이전트에게 주는 것은 (a) 그 단계의 입력, (b) 하네스 사용 지시뿐이다. 하네스 지시는
+검증 대상 값과 무관하므로 정답을 흘리지 않는다.
+
+프롬프트 형식은 다음과 같고, `{단계별 입력}`만 단계마다 달라진다. 각 단계의 실제 문구는
+해당 태스크에 그대로 적어 두었다.
+
+> 모든 셸 명령을 `/tmp/qg-harness/run.sh "<명령>"` 형태로 실행해라. 명령에 작은따옴표가
+> 들어가면 바깥은 큰따옴표로 감싼다.
+> `~/.claude/skills/create-worktree/SKILL.md`의 절차를 따라라.
+> 작업: {단계별 입력}
+
+### 단계별 로그 분리 (PLAN-012)
+
+`cmd.log`는 누적되므로 "그 단계의 호출"을 기계적으로 판정하려면 경계를 나눠야 한다.
+**각 단계 시작 직전에 로그를 그 단계 파일로 옮기고 비운다.**
+
+```bash
+newphase() {            # 사용: newphase T9
+  mv "$LOG" "/tmp/qg-harness/cmd-$1-prev.log" 2>/dev/null || :
+  : > "$LOG"
+  echo "### phase $1" >> "$LOG"
+}
+```
+
+단계가 끝나면 `cp "$LOG" "/tmp/qg-harness/cmd-<단계>.log"`로 보존한다. 이후 모든
+per-phase grep은 그 단계 파일만 읽는다.
+
+### 판정과 폴백
+
+**우회 판정은 단계마다 기대 명령이 다르다.** `add`/`open`은 생성 단계에서만 나온다 —
+T10·T11·T12는 올바르게 동작해도 `add`/`open`을 부르지 않으므로, 그것을 기준으로 삼으면
+정상 실행이 "검증 불가"로 오판된다(PLAN-012).
+
+| 단계 | 로그에 반드시 있어야 하는 것 | 없으면 |
+|---|---|---|
+| T8 B부 | `workmux list` ≥1 **그리고** `git config` ≥1 | 검증 불가 |
+| T9 | `workmux add` ≥1 | 검증 불가 |
+| T10 | `workmux list` ≥1 (기존 창 판정을 했다는 증거) | 검증 불가 |
+| T11 | `workmux list` ≥1 **그리고** `tmux move-window` 또는 `git config ... window-session` ≥1 | 검증 불가 |
+| T12 | `workmux list` ≥1 **그리고** `git config ... window-session` ≥1 | 검증 불가 |
+
+- 하네스 구성 자체가 실패하면(shim 생성 불가 등) 실행 기준을 문서 검토로 강등하고 사유를
+  보고서에 남긴다(Spec 폴백 b).
+- **관찰 가능한 종국 상태도 함께 증거로 쓴다.** 세션·창 이름·브랜치·HEAD는 로그와 독립적
+  으로 확인되며, 입력에 그 값을 주지 않았으므로 스킬이 파생한 결과다.
+
+### 잔여 한계 (PLAN-017 — 명시적으로 기록한다)
+
+- 음성 단언(`$SLUG`·`$W` 조회 0건)은 **하네스를 완전히 지켰을 때만** 성립한다. 에이전트가
+  일부 명령을 `run.sh` 밖에서 실행하면 그 호출은 로그에 남지 않는다. 위 표는 **전면**
+  우회만 잡고 **부분** 우회는 잡지 못한다. 따라서 음성 단언은 "그 단계의 명령 시퀀스가
+  로그에 온전히 있다는 전제 아래"로만 해석하고, 보고서에 그 전제를 명시한다.
+- **인용 부호 주의**: 절차의 명령에는 작은따옴표가 들어간다(`-F '#{window_id} …'`).
+  래퍼에 넘길 때는 **큰따옴표로 감싼다** — `run.sh "tmux list-panes -a -F '#{window_id}'"`.
+  이 안내가 없으면 에이전트가 래퍼를 버리기 쉽다.
+
+### 하네스 정리 (T13)
+
+```bash
+rm -rf /tmp/qg-harness
+```
+
+## File map
+
+| 파일 | 책임 | 이번 변경 |
+|---|---|---|
+| `dot_claude/skills/create-worktree/SKILL.md` | Claude Code가 읽는 절차 + Claude 전용 frontmatter | 본문 전면 확장, `argument-hint`·`description` 갱신 |
+| `dot_agents/skills/create-worktree/SKILL.md` | Codex·공용 에이전트가 읽는 절차 | **동일 본문**, `description` 갱신. Claude 전용 3줄 없음 |
+| `dot_agents/skills/create-worktree/agents/openai.yaml` | Codex UI 메타데이터 | `default_prompt`에 세션 또는 PR 사례 추가 |
+| `~/.claude/skills/create-worktree/`, `~/.agents/skills/create-worktree/` | 위의 적용본 | 직접 수정 금지. 경로 한정 `chezmoi apply`가 생성 |
+| `dot_claude/skills/move-window-to-session/SKILL.md` | 창 이동 절차 | **읽기만.** 입력 계약(21행)과 `{worktree명}` 정의(104행)·config 쓰기(114행) |
+| `dot_claude/skills/remove-worktree/SKILL.md` | worktree 제거 | **읽기만.** `remove`가 브랜치까지 지움(26행), `-k`로 보존(36행) |
+| `dot_config/workmux/config.yaml` | pane 레이아웃 | **읽기만.** |
+| `/Users/lee-kyu-hwan/code/zambaguni-front/scripts/create-worktree.sh` | git-crypt 래퍼 | **읽기만. 이 저장소 밖의 절대경로다.** Codex 샌드박스에서 읽히지 않을 수 있으며, 그때는 Spec이 인용한 82–98행 서술을 근거로 쓴다 |
+
+## Task dependencies
+
+```
+T1 (기준선 캡처, red)
+  ↓
+T2 (dot_claude SKILL.md 재작성 — 정본) → T3 (dot_agents 복제) → T4 (openai.yaml)
+  ↓
+T5 (1층 결정적 검사, green)  →  T6 (2층 문서 검토)
+  ↓
+T7 (경로 한정 chezmoi apply + 무영향 검증)   ← 스모크는 배포본을 실행하므로 선행 필수
+  ↓
+T7.5 (스모크 하네스 준비)
+  ↓
+T8 (0차: A부 환경 전제 + B부 산출물)  ← T9와 같은 브랜치. 완전 정리 후 진행
+  ↓
+T9 (1차: 신규 생성, 입력은 PR URL만)
+  ↓
+T10 (2차: 같은 세션 재호출)   ← T9의 창이 살아 있어야 성립
+  ↓
+T11 (3차: 다른 세션 명시 이동)
+  ↓
+T12 (4차: 레거시 값 + 세션 미명시)
+  ↓
+T13 (정리·하네스 제거·최종 확인)
+```
+
+**셸 연속성 규칙 (PLAN-004).** T9~T12의 `$WT`·`$H`·`$WID` 같은 값은 셸을 넘어 유지되지
+않는다. **각 단계는 시작할 때 `workmux list --json`에서 다시 파생한다.** 아래 공통 프리앰블을
+매 단계 앞에 붙인다.
+
+```bash
+BR=30-enhancement/tmux-open-pr-shortcut
+WT=$(workmux list --json | python3 -c "import json,sys;r=[w['path'] for w in json.load(sys.stdin) if w['branch']=='$BR'];print(r[0] if r else '')")
+H=$(workmux list --json  | python3 -c "import json,sys;r=[w['handle'] for w in json.load(sys.stdin) if w['branch']=='$BR'];print(r[0] if r else '')")
+[ -n "$WT" ] || { echo "FAIL: worktree 없음"; exit 1; }
+[ -n "$H" ]  || { echo "FAIL: handle 없음"; exit 1; }
+wids() { tmux list-panes -a -F '#{window_id} #{pane_current_path}' \
+  | awk -v wt="$WT" '$2==wt||index($2,wt"/")==1{print $1}' | sort -u; }
+```
+
+**빈 값 방어 (PLAN-004).** 창 개수는 `wids | grep -c .`로 센다 — `wc -l`은 빈 문자열에도
+1을 준다. 비교 전에 `[ -n ... ]`로 비어 있지 않음을 먼저 단언한다.
+
+**적용 범위 (PLAN-014).** 이 프리앰블은 **T9~T13 전부**에 적용한다. T13도 `$H`를 쓰며,
+정의되지 않은 `$H`로 `workmux remove "" -k`를 실행하면 파괴적 명령이 빈 인자로 나가고
+`git config --get-regexp "^workmux\.worktree\.\."`가 모든 키에 매칭되어 잔여물 검사가
+거짓 실패를 낸다.
+
+### `workmux remove`의 확인 프롬프트 처리 (PLAN-016)
+
+`workmux remove`는 **기본적으로 확인 프롬프트를 띄우고**, 이 저장소의 `remove-worktree`
+스킬은 그것을 `-f`로 우회하지 말라고 명시한다(`remove-worktree/SKILL.md:29-30`).
+비대화형 Bash 호출에서 프롬프트가 뜨면 명령이 정지한다.
+
+**처리 방침**: 정리 단계의 `workmux remove`는 자동 실행하지 않는다. 오케스트레이터가
+명령을 만들어 **사용자에게 제시하고, 사용자가 `! workmux remove …` 형태로 직접 실행**한다.
+`-f`를 쓰지 않으므로 스킬의 금지 규칙을 지키고, 미커밋 변경 경고도 사용자가 본다.
+
+제시할 명령을 만들 때는 `$H`가 비어 있지 않음을 먼저 확인한다. 정지·타임아웃이 발생하면
+아래 롤백 트리거 표의 해당 행을 따른다.
+
+## Tasks
+
+### T1. 기준선 캡처 (red 기록)
+
+```bash
+cd /Users/lee-kyu-hwan/code/dotfiles
+B=.claude/quality-state/20260827T120102Z-28-35-create-worktree-스킬-3차-실행-pr-링크-입력-a16ed82b/baseline
+mkdir -p "$B"
+QV=/Users/lee-kyu-hwan/.claude/plugins/marketplaces/claude-plugins-official/plugins/skill-creator/skills/skill-creator/scripts/quick_validate.py
+
+# 1) argument-hint (실패 기대)
+grep -q 'argument-hint: <branch-name|pr-ref> \[target-session\]' \
+  dot_claude/skills/create-worktree/SKILL.md; echo "argument-hint: $?" | tee "$B/red.txt"
+
+# 2) description (양쪽 실패 기대)
+for f in dot_agents/skills/create-worktree/SKILL.md dot_claude/skills/create-worktree/SKILL.md; do
+  sed -n '3p' "$f" | grep -qiE 'pull request|(^|[^a-z])PR([^a-z]|$)'; echo "desc-PR $f: $?" | tee -a "$B/red.txt"
+  sed -n '3p' "$f" | grep -qi 'session'; echo "desc-session $f: $?" | tee -a "$B/red.txt"
+done
+
+# 3) openai.yaml (실패 기대)
+grep -qE '2-review|pull/' dot_agents/skills/create-worktree/agents/openai.yaml
+echo "openai: $?" | tee -a "$B/red.txt"
+
+# 4) 두 본문 diff
+diff dot_agents/skills/create-worktree/SKILL.md \
+     dot_claude/skills/create-worktree/SKILL.md > "$B/diff-before.txt"; echo "diff: $?" | tee -a "$B/red.txt"
+
+# 5) 1-main 잔존
+grep -c -- '1-main' dot_agents/skills/create-worktree/SKILL.md \
+                    dot_claude/skills/create-worktree/SKILL.md | tee -a "$B/red.txt"
+
+# 6) quick_validate 기준선 (PLAN-009 — T5가 대조할 좌변)
+python3 "$QV" dot_claude/skills/create-worktree > "$B/qv-claude-before.txt" 2>&1; echo "qv-claude: $?" | tee -a "$B/red.txt"
+python3 "$QV" dot_agents/skills/create-worktree > "$B/qv-agents-before.txt" 2>&1; echo "qv-agents: $?" | tee -a "$B/red.txt"
+```
+
+**기대(red)**: 1·2·3번 exit 1, 4번은 frontmatter 3줄 + 버전 문구 1줄, 5번은 `1-main`
+다수, 6번은 둘 다 exit 0이되 `dot_claude`에 Claude 전용 키 안내가 있다.
+
+**실패 처리**: 1·2·3번이 이미 exit 0이면 소스가 예상과 다르므로 중단·보고.
+
+> **workmux 키 기준선은 여기서 잡지 않는다(PLAN-010).** 정리 검증의 기준점은 T8이 잡는
+> `$HARNESS/wm-keys-before.txt` 하나이며, T8·T13이 모두 그것과 대조한다. 기준선을 둘
+> 두면 어느 쪽이 권위인지 모호해진다.
+
+---
+
+### T2. `dot_claude/skills/create-worktree/SKILL.md` 재작성 (정본)
+
+**frontmatter**
+
+```yaml
+---
+name: create-worktree
+description: <아래 제약을 만족하는 한 줄>
+argument-hint: <branch-name|pr-ref> [target-session]
+user-invocable: true
+allowed-tools: Bash
+---
+```
+
+`description` 제약: 한 줄, 양쪽 파일 문자열까지 동일, `pull request` 또는 단어 경계의
+`PR` 포함, `session` 포함. 예: `Use when creating a git worktree for a branch or a pull
+request (PR) review, optionally opening it in a named tmux session`.
+
+**본문에 옮길 절과 Spec 대응**
+
+| SKILL.md 절 | Spec 근거 | 핵심 |
+|---|---|---|
+| 파라미터 | R1.1–R1.7 | 입력 계약, PR 트리거 3종, 표지 없는 맨 숫자 금지, 자연어 2-튜플 환원, 추측 금지, 3개 이상 중단 |
+| 워크트리 식별자 | R2.0 | `handle` 정의, 브랜치·창 이름 유추 금지 근거, 기본 설정에서만 basename과 일치, 4개 하위 키 |
+| 세션 선택 | R2.1–R2.6 | 4단계 우선순위, 레거시 정규식, **영속 변경 명령 열거 + 읽기 전용·dry-run 예외**, 명시값 덮어쓰기, 사라진 세션 복구, **갱신 대상 3행 표** |
+| 세션 검증 | R3.1–R3.6 | **서버 부재와 세션 부재 구분**, `grep -qxF`, **`has-session` 금지 근거**, **자동 생성 금지** |
+| PR 해석 | R4.0–R4.8 | 저장소 확정, 조회 필드, 불일치 중단, 기존 worktree는 생성만 건너뜀, OID 비교, head 확보, 상태 4요소, **`--pr` 정규화** |
+| 이름 파생 | R5.1–R5.6 | 짧은 이름, 이슈 번호, PR 번호 우선, 생략, 소문자, 모드별 충돌 재시도 |
+| 생성·오픈 경로 | R6.1–R6.10 | 루트 기준 분기, git-crypt add 금지, positional·`--name` 생략, 래퍼 순서, 실패 중단, 세션 변수화, 미지원 조합, HEAD 검증, 경로·handle 확보와 폴백, git-crypt 필터만 있는 경우 |
+| 기존 worktree 처리 | R7.0–R7.6 | 존재·경로 판정, 창 탐지 4단계와 저장값 부재·스테일 처리, 분기 4종, `move-window-to-session` 호출 |
+| 사후 검증 | R8.1–R8.3 | 실제 창 확인, **분기별 불일치 규칙(아래)**, 보고 항목 |
+| 주의사항 | R9.6의 14–16 | 에이전트 자동 실행 안 함, 개발 서버 분리, 레이아웃 위치 |
+
+**SPEC-018 확정 — 사후 검증 절에 세 갈래를 모두 적는다.**
+
+> 실제 창 위치를 확인한 뒤의 처리는 이번 호출이 무엇을 했는지에 따라 다르다.
+> - **창을 새로 만들거나 열었으면**: 실제 세션이 선택 세션과 다르면 잘못 만들어진
+>   세션과 git config를 함께 정리한다.
+> - **창을 옮겼으면**: 최종 위치가 선택 세션과 다르면 이동이 완결되지 않은 것이다.
+>   그 사실을 보고하고, config에 잘못된 값을 쓰지 않는다.
+> - **창을 옮기지 않았으면**: 실제 세션이 선택 세션과 다른 것이 정상이다. 정리하지
+>   않는다. 이때의 `window-session` 갱신은 "세션 선택"의 갱신 대상 표가 관장한다.
+
+**SPEC-022 확정 — 이동 절에 분기 규칙까지 적는다.**
+
+> `move-window-to-session`에 handle과 worktree 경로를 함께 넘긴다. 그 스킬은
+> `workmux list`의 PATH basename에서 이름을 파생하므로, 기본 명명이 아니면 handle과
+> 어긋날 수 있다. 이동이 끝나면 `workmux.worktree.{handle}.window-session`을 읽는다.
+> - 대상 세션과 같으면 정상이다.
+> - 다르면 그 스킬이 basename 키에 쓴 것이다. **handle 키를 직접 대상 세션으로 갱신하고
+>   그 사실을 보고한다.** 갱신도 실패하면 중단한다.
+
+**`1-main` 사용 제한**: Spec의 허용 3용례만. 금지 5용례는 0건.
+
+**검증(태스크 직후)**
+
+```bash
+grep -q 'argument-hint: <branch-name|pr-ref> \[target-session\]' dot_claude/skills/create-worktree/SKILL.md && echo OK-hint
+sed -n '3p' dot_claude/skills/create-worktree/SKILL.md | grep -qiE 'pull request|(^|[^a-z])PR([^a-z]|$)' && echo OK-desc-PR
+sed -n '3p' dot_claude/skills/create-worktree/SKILL.md | grep -qi 'session' && echo OK-desc-session
+```
+
+세 줄이 모두 출력되어야 한다.
+
+---
+
+### T3. `dot_agents/skills/create-worktree/SKILL.md` 동기화
+
+T2의 본문을 그대로 복제, frontmatter는 `name`·`description` 2줄만.
+
+```bash
+diff dot_agents/skills/create-worktree/SKILL.md \
+     dot_claude/skills/create-worktree/SKILL.md
+```
+
+**기대**: `3a4,6`과 뒤따르는 `>` 3줄만. 다른 hunk가 있으면 실패. **인자 순서를 바꾸지
+않는다** — 바꾸면 정상 상태가 `4,6d3`으로 나와 기대값과 어긋난다.
+
+---
+
+### T4. `dot_agents/skills/create-worktree/agents/openai.yaml`
+
+```yaml
+interface:
+  display_name: "Create Worktree"
+  short_description: "브랜치 또는 PR용 Git worktree 생성 및 Workmux 윈도우 구성"
+  default_prompt: "Use $create-worktree to open https://github.com/owner/repo/pull/1247 in the 2-review session."
+```
+
+```bash
+grep -qE '2-review|pull/' dot_agents/skills/create-worktree/agents/openai.yaml && echo OK
+```
+
+---
+
+### T5. 1층 결정적 검사 (green 기록)
+
+```bash
+cd /Users/lee-kyu-hwan/code/dotfiles
+B=.claude/quality-state/20260827T120102Z-28-35-create-worktree-스킬-3차-실행-pr-링크-입력-a16ed82b/baseline
+QV=/Users/lee-kyu-hwan/.claude/plugins/marketplaces/claude-plugins-official/plugins/skill-creator/skills/skill-creator/scripts/quick_validate.py
+
+# AC-59 — T1이 잡은 기준선과 대조 (PLAN-009)
+python3 "$QV" dot_claude/skills/create-worktree > /tmp/qv-claude-after.txt 2>&1; echo "qv-claude: $?"
+python3 "$QV" dot_agents/skills/create-worktree > /tmp/qv-agents-after.txt 2>&1; echo "qv-agents: $?"
+diff "$B/qv-claude-before.txt" /tmp/qv-claude-after.txt; echo "qv-claude diff: $?"
+diff "$B/qv-agents-before.txt" /tmp/qv-agents-after.txt; echo "qv-agents diff: $?"
+
+# AC-7
+grep -q 'argument-hint: <branch-name|pr-ref> \[target-session\]' dot_claude/skills/create-worktree/SKILL.md; echo "AC-7: $?"
+
+# AC-56 (SPEC-020 확정 정규식)
+for f in dot_agents/skills/create-worktree/SKILL.md dot_claude/skills/create-worktree/SKILL.md; do
+  sed -n '3p' "$f" | grep -qiE 'pull request|(^|[^a-z])PR([^a-z]|$)' || echo "FAIL PR: $f"
+  sed -n '3p' "$f" | grep -qi 'session' || echo "FAIL session: $f"
+done
+[ "$(sed -n '3p' dot_agents/skills/create-worktree/SKILL.md)" \
+  = "$(sed -n '3p' dot_claude/skills/create-worktree/SKILL.md)" ] || echo "FAIL desc 불일치"
+
+# AC-53 / AC-54 / AC-18
+diff dot_agents/skills/create-worktree/SKILL.md dot_claude/skills/create-worktree/SKILL.md
+grep -qE '2-review|pull/' dot_agents/skills/create-worktree/agents/openai.yaml; echo "AC-54: $?"
+grep -n -- '1-main' dot_agents/skills/create-worktree/SKILL.md dot_claude/skills/create-worktree/SKILL.md
+
+# AC-15/16/17 실행 절반 — 부작용 없는 tmux 프로브
+tmux -L quality-goal-nonexistent-socket list-sessions; echo "server-absent: $?"          # 1
+tmux list-sessions -F '#{session_name}' | grep -qxF -- 'definitely-not-a-session'; echo "no-session: $?"  # 1
+tmux has-session -t 2; echo "prefix-2: $?"                                               # 0
+tmux has-session -t 2-rev; echo "prefix-2-rev: $?"                                       # 0
+tmux list-sessions -F '#{session_name}' | grep -qxF -- '2-rev'; echo "grep-2-rev: $?"     # 1
+
+# AC-60
+git diff --check; echo "whitespace: $?"
+pre-commit run --all-files; echo "gitleaks: $?"
+```
+
+**기대**: `qv-*-after`가 기준선과 **동일**(경고 증가 없음), AC-7·53·54·56 통과, tmux 프로브
+5개 종료 코드가 주석과 일치, AC-60 둘 다 통과.
+
+**실패 처리**: 어떤 항목이든 어긋나면 T2~T4로 돌아가 고치고 T5 전체를 다시 실행한다.
+
+---
+
+### T6. 2층 문서 검토
+
+Spec이 `[문서]`로 표시한 기준을 두 SKILL.md에서 확인한다.
+
+| 확인 항목 | 대상 AC | 근거 위치 기록 |
+|---|---|---|
+| 입력 계약·PR 트리거·맨 숫자 금지·자연어 환원·추측 금지·3개 이상 중단 | AC-1~6 | |
+| handle 정의·유추 금지 근거·4개 키 네임스페이스 | AC-8 | |
+| 우선순위 4단계(저장값 > 모드 기본값) | AC-10 | |
+| 레거시 정규식 판정과 glob 반례 | AC-11 | |
+| 영속 변경 명령 열거 + 읽기 전용·dry-run 예외 | AC-12 | |
+| 갱신 대상 3행 표 | AC-12b(문서) | |
+| 사라진 세션 복구 4단계 | AC-14 | |
+| **tmux 서버 부재와 세션 부재 구분 서술** | AC-15(문서) | **PLAN-006** |
+| **선택 세션 부재 시 자동 생성 금지 서술** | AC-16(문서) | **PLAN-006** |
+| **`has-session` 접두사 함정 근거 서술** | AC-17(문서) | **PLAN-006** |
+| `1-main` 허용 3용례만, 금지 5용례 0건 | AC-18 | T5의 grep 출력과 대조 |
+| 저장소 확정·조회 필드·불일치 중단·기존 worktree 분기·OID 비교·gh 실패 중단·head 확보 | AC-19~25 | |
+| CLOSED·MERGED 4요소 | AC-26 | |
+| `--pr {PR번호}` 표기 | AC-27(문서) | |
+| 짧은 이름·이슈 번호·생략·소문자·충돌 재시도 | AC-28·29·31·32·33 | |
+| 루트 기준 분기·git-crypt add 금지·래퍼 순서·실패 중단·미지원 조합 | AC-34·35·37·38·39 | |
+| 경로·handle 확보와 폴백 | AC-41(문서) | |
+| git-crypt 필터만 있는 경우 | AC-42 | |
+| 흐름에서 worktree 판정이 세션 선택보다 앞 | AC-43 | |
+| 창 탐지 4단계와 파생 이름 금지 근거 | AC-44(문서) | |
+| 매칭 0건·2건 이상·공백·`cd`·저장값 부재·스테일 | AC-45 | |
+| 창 닫힘 시 직접 열기 | AC-46 | |
+| 미명시 시 존중(경로 1·2) | AC-48(문서) | |
+| 이동 호출 형식 + **SPEC-022 분기 규칙** | AC-49(문서) | |
+| **사후 검증 세 갈래**(생성·이동·미이동) | AC-51 | **SPEC-018 확정** |
+| 보존 규칙 18개 | AC-57 | 18개 개별 |
+
+**판정**: 각 항목이 두 파일 모두에 있어야 한다. AC-57은 18개를 개별로 세어 누락 0건.
+
+---
+
+### T7. 경로 한정 `chezmoi apply` + 무영향 검증
+
+```bash
+cd /Users/lee-kyu-hwan/code/dotfiles
+
+# PLAN-003 — 실패할 수 있는 무영향 검사. 배포된 quality-goal 23개 파일 전체의
+# 해시와 mtime을 apply 전후로 비교한다. cmp 한 파일로는 판별력이 없다.
+find ~/.claude/skills/quality-goal -type f -exec shasum -a 256 {} \; | sort > /tmp/qg-before.sha
+find ~/.claude/skills/quality-goal -type f -exec stat -f '%m %N' {} \; | sort > /tmp/qg-before.mtime
+wc -l < /tmp/qg-before.sha    # 23 기대
+
+chezmoi diff ~/.claude/skills/create-worktree ~/.agents/skills/create-worktree
+
+chezmoi apply ~/.claude/skills/create-worktree ~/.agents/skills/create-worktree
+echo "apply: $?"
+
+# AC-55 — 소스 ↔ 적용본
+cmp dot_claude/skills/create-worktree/SKILL.md ~/.claude/skills/create-worktree/SKILL.md; echo "cmp claude: $?"
+cmp dot_agents/skills/create-worktree/SKILL.md ~/.agents/skills/create-worktree/SKILL.md; echo "cmp agents: $?"
+cmp dot_agents/skills/create-worktree/agents/openai.yaml ~/.agents/skills/create-worktree/agents/openai.yaml; echo "cmp openai: $?"
+
+# quality-goal 무영향 (해시·mtime 둘 다)
+find ~/.claude/skills/quality-goal -type f -exec shasum -a 256 {} \; | sort > /tmp/qg-after.sha
+find ~/.claude/skills/quality-goal -type f -exec stat -f '%m %N' {} \; | sort > /tmp/qg-after.mtime
+diff /tmp/qg-before.sha /tmp/qg-after.sha;     echo "qg 해시 동일: $?"
+diff /tmp/qg-before.mtime /tmp/qg-after.mtime; echo "qg mtime 동일: $?"
+```
+
+**기대**: `cmp` 3개 exit 0. quality-goal 해시·mtime `diff` 둘 다 exit 0. **mtime이 바뀌면
+내용이 같아도 apply가 파일을 다시 쓴 것이므로 위반으로 본다.**
+
+**실패 처리**: `chezmoi apply`가 "modified since chezmoi last wrote it" 프롬프트를 내면
+적용본이 손으로 수정된 것이다. 자동 응답하지 말고 중단·보고한다.
+
+---
+
+### T7.5. 스모크 하네스 준비
+
+위 "스모크 실행 하네스"의 구성 블록을 실행하고, 로그가 비어 있는 상태로 시작하는지
+확인한다.
+
+위 "스모크 실행 하네스" 절의 구성 블록과 `newphase()` 정의를 **그대로** 실행한다(생략
+부호 없이 그 블록 전체다 — PLAN-018). 그다음 동작을 확인한다.
+
+```bash
+/tmp/qg-harness/run.sh "workmux --version"
+grep -c . /tmp/qg-harness/cmd.log        # 1 이상 (shim 동작 확인)
+grep -q '^workmux --version' /tmp/qg-harness/cmd.log && echo "shim OK"
+
+# PLAN-019: workmux list --json의 필드 이름을 여기서 실측한다.
+# 공통 프리앰블과 롤백 루프가 handle·path·branch를 파싱하므로 전제를 먼저 굳힌다.
+workmux list --json | python3 -c "
+import json,sys
+rows=json.load(sys.stdin)
+need={'handle','path','branch','is_open','is_main'}
+missing=need - set(rows[0].keys()) if rows else need
+print('필드 누락:', missing or '없음')
+"
+```
+
+**기대**: `cmd.log`에 `workmux --version`이 기록되고, 필드 누락이 "없음"이다.
+2026-08-27 실측에서 `handle`·`path`·`branch`·`is_open`·`mode`·`is_main`·`project`가
+확인되었다.
+
+**실패 처리**: shim이 기록하지 않으면 스모크 실행 기준을 문서 검토로 강등한다. 필드가
+누락되면 공통 프리앰블의 파싱을 실제 필드명으로 고친 뒤 진행하고, 고칠 수 없으면 T9~T12를
+문서 검토로 강등한다(T8의 폴백 b와 같은 처리 — PLAN-019).
+
+---
+
+### T8. 스모크 0차 — AC-9(환경 전제) + AC-9b(산출물)
+
+**전제 확인 (읽기 전용)**
+
+```bash
+PRN=31; BR=30-enhancement/tmux-open-pr-shortcut
+OID=9cfc6267ced574945814536710cf1019a37dc354
+gh pr view $PRN --repo lee-kyu-hwan/dotfiles --json state,headRefName,headRefOid
+git ls-remote origin "refs/pull/$PRN/head"
+git worktree list --porcelain | grep -F "refs/heads/$BR" && echo "FAIL: worktree 이미 존재"
+git rev-parse --verify "$BR" 2>/dev/null    # 없거나 $OID와 같아야 한다
+workmux add --pr $PRN --dry-run
+```
+
+2026-08-28 실측: PR #31 OPEN, worktree 없음, 동명 로컬 브랜치가 존재하나 OID가 `$OID`와
+**동일**해 R4.4에 걸리지 않는다. 어긋나면 대체 PR로 교체하거나 폴백(b).
+
+**키 기준선 (유일한 권위 — PLAN-010)**
+
+```bash
+HARNESS=/tmp/qg-harness
+F=pr31-fixture-handle; W=pr31-fixture-window; SLUG=30-enhancement-tmux-open-pr-shortcut
+git config --get-regexp '^workmux\.worktree\.' > "$HARNESS/wm-keys-before.txt" || : > "$HARNESS/wm-keys-before.txt"
+for k in "$SLUG" "$W" "$F"; do
+  git config --get "workmux.worktree.$k.window-session" && echo "FAIL 잔여 키: $k"
+done
+```
+
+셋 다 exit 1이어야 한다. 하나라도 값이 있으면 이름을 바꾸거나 폴백(b).
+
+**A부 — 환경 전제 (AC-9)**
+
+```bash
+workmux add --pr $PRN --name "$F" --target-name "$W" --parent-session 2-review
+git config --get "workmux.worktree.$F.window-session";    echo "F: $?"     # 0 + 값
+git config --get "workmux.worktree.$SLUG.window-session"; echo "SLUG: $?"  # 1
+git config --get "workmux.worktree.$W.window-session";    echo "W: $?"     # 1
+```
+
+**픽스처 경로 확보 (PLAN-018)** — B부 프롬프트에 넣을 값이다. 추측하지 않고 읽는다.
+
+```bash
+FWT=$(workmux list --json | python3 -c \
+  "import json,sys;r=[w['path'] for w in json.load(sys.stdin) if w['handle']=='$F'];print(r[0] if r else '')")
+[ -n "$FWT" ] || { echo "FAIL: 픽스처 경로 확보 실패"; exit 1; }
+```
+
+**B부 — 산출물 (AC-9b) · 하네스 경유**
+
+`newphase T8B`로 로그를 분리한 뒤, Agent 도구로 `general-purpose` 에이전트를 띄운다.
+주는 것은 다음뿐이다. **키 이름을 주지 않는다.**
+
+> 모든 셸 명령을 `/tmp/qg-harness/run.sh "<명령>"` 형태로 실행해라. 명령에 작은따옴표가
+> 들어가면 바깥은 큰따옴표로 감싼다.
+> `~/.claude/skills/create-worktree/SKILL.md`의 "워크트리 식별자"와 "기존 worktree 처리"
+> 절차를 따라, 아래 worktree의 handle과 창 위치를 판정하고 결과만 보고해라.
+> worktree 경로: {위에서 확보한 `$FWT` 값}
+
+에이전트 종료 후 로그를 판정한다.
+
+```bash
+LOG=/tmp/qg-harness/cmd.log
+grep -E '^git config' "$LOG"                      # 실행된 config 명령 전수
+grep -cE "workmux\.worktree\.$F\." "$LOG"         # 1 이상 기대
+grep -cE "workmux\.worktree\.$SLUG\." "$LOG"      # 0 기대
+grep -cE "workmux\.worktree\.$W\." "$LOG"         # 0 기대
+grep -cE '^workmux list' "$LOG"                   # 1 이상 (handle을 조회했다는 증거)
+```
+
+**판정**: `$F` 기준 조회가 있고 `$SLUG`·`$W` 기준 조회가 0건이며 `workmux list` 호출이
+있어야 한다. **`git config` 줄이 하나도 없거나 `workmux list` 호출이 없으면 하네스를
+우회한 것이므로 "검증 불가"로 기록한다**(SPEC-019 확정). 통과로 적지 않는다.
+
+**정리 (T9 시작 전 필수) — 브랜치 보존 (PLAN-005)**
+
+```bash
+workmux remove "$F" -k          # -k: 로컬 브랜치를 남긴다. 이 브랜치는 사전 존재했다
+git worktree list | grep -F "$F" && echo "FAIL 잔여 worktree"
+workmux list --json | grep -F "\"$F\"" && echo "FAIL 잔여 handle"
+git config --get-regexp "^workmux\.worktree\.$F\."; echo "키 잔여: $?"   # 1 기대
+diff <(git config --get-regexp '^workmux\.worktree\.' || :) "$HARNESS/wm-keys-before.txt"; echo "키 원복: $?"
+git rev-parse --verify "$BR" >/dev/null 2>&1 || git branch "$BR" "$OID"   # 만약을 위한 복구
+```
+
+`-k`를 쓰는 이유: `workmux remove`는 기본적으로 **로컬 브랜치까지 지운다**
+(`remove-worktree/SKILL.md:26`). `$BR`은 T8 이전부터 있던 사용자 브랜치이므로 지우면 안
+된다. `-k`가 그것을 보존한다(같은 파일 36행).
+
+**폴백(b)**: 픽스처 생성 실패, 전제 위반, 잔여 키 미해소, 하네스 미동작 중 하나라도
+발생하면 AC-9·AC-9b를 문서 검토로 강등하고 사유를 보고서에 기록한다.
+
+---
+
+### T9. 스모크 1차 — 신규 생성 (입력은 PR URL만)
+
+**하위 에이전트에게 주는 입력** — 세션명도, 창 이름도, `--pr` 인자 형태도 주지 않는다.
+
+> 모든 셸 명령을 `/tmp/qg-harness/run.sh '<명령>'` 형태로 실행해라.
+> `~/.claude/skills/create-worktree/SKILL.md`의 절차를 따라 다음을 처리해라.
+> https://github.com/lee-kyu-hwan/dotfiles/pull/31
+
+에이전트 종료 후 오케스트레이터가 관찰한다(공통 프리앰블 먼저 실행).
+
+```bash
+grep -E '^workmux add' /tmp/qg-harness/cmd.log         # 실제 호출된 명령줄
+git -C "$WT" rev-parse --abbrev-ref HEAD               # == $BR
+git -C "$WT" rev-parse HEAD                            # == $OID
+tmux list-windows -a -F '#{session_name}:#{window_index} #{window_id} #{window_name}'
+git config --get "workmux.worktree.$H.target-window"
+wids | grep -c .                                        # 1 기대
+```
+
+| 관찰 | 기대 | AC | 왜 조작 불가인가 |
+|---|---|---|---|
+| 창이 열린 세션 | `2-review` | AC-58 | 입력에 세션명을 주지 않았다 |
+| 로그의 `--pr` 인자 | 숫자 `31`만 | AC-27 | 입력은 URL이었다. 숫자면 스킬이 정규화한 것 |
+| 창 이름 | `31-`로 시작, `30-`이 아님 | AC-30 | 입력에 이름을 주지 않았다 |
+| 로그에 positional·`--name` 없음 | 없음 | AC-36 | 로그가 실제 argv다 |
+| worktree 브랜치 | `$BR` | AC-36 | |
+| worktree HEAD | `$OID` | AC-40 | |
+| handle·경로 | `workmux list --json`에서 읽음 | AC-41 | |
+| `target-window` 값 | 실제 창 이름과 일치 | AC-44(b) | |
+| 고유 `window_id` | 정확히 1 | AC-44(a) | `grep -c .`로 셈 |
+| 창 위치 기록 | `tmux list-windows -a` 출력 보존 | AC-50 | |
+| 보고 7항목 | 경로·handle·브랜치·세션·창이름·PR번호·head OID | AC-52 | |
+
+**실패 처리**: HEAD가 `$OID`와 다르면 PR 내용이 없는 worktree이므로 성공으로 보고하지
+않고 즉시 정리·보고한다. 로그에 `workmux add`가 없으면 "검증 불가".
+
+---
+
+### T10. 스모크 2차 — 같은 세션 재호출 (중복 창 금지)
+
+공통 프리앰블 실행 후:
+
+```bash
+BEFORE=$(wids); [ -n "$BEFORE" ] || { echo "FAIL: 창 없음"; exit 1; }
+echo "$BEFORE" | grep -c .    # 1 기대
+```
+
+**에이전트 입력** — 이번에는 세션이 검증 대상이 아니라 *입력*이므로 준다. 창 이름은 주지
+않는다.
+
+> 모든 셸 명령을 `/tmp/qg-harness/run.sh '<명령>'` 형태로 실행해라.
+> `~/.claude/skills/create-worktree/SKILL.md`의 절차를 따라라.
+> https://github.com/lee-kyu-hwan/dotfiles/pull/31 을 2-review 세션에 열어줘
+
+```bash
+AFTER=$(wids); [ -n "$AFTER" ] || { echo "FAIL: 창 사라짐"; exit 1; }
+echo "$AFTER" | grep -c .                      # 1 기대 (증가 없음)
+[ "$BEFORE" = "$AFTER" ] && echo "AC-47 OK: window_id 동일"
+```
+
+**기대**: 고유 `window_id`가 1개로 유지되고 값이 재호출 전과 같다. 빈 값이면 비교 전에
+중단하므로 공허한 통과가 생기지 않는다(PLAN-004).
+
+---
+
+### T11. 스모크 3차 — 다른 세션 명시 이동
+
+**전제 확인 (PLAN-015 — 실행 전 필수)**
+
+```bash
+newphase T11
+TARGET=3-personal
+# (a) 대상 세션이 실재하는가. 스킬은 세션을 만들지 않으므로(AC-16) 없으면 진행 불가
+tmux list-sessions -F '#{session_name}' | grep -qxF -- "$TARGET" \
+  || { echo "SKIP: $TARGET 없음"; exit 1; }
+# (b) 원본 세션의 마지막 창을 옮기면 세션이 소멸하고, detach-on-destroy=on +
+#     .zshrc의 exec tmux 때문에 사용자의 터미널 창이 닫힌다
+#     (move-window-to-session/SKILL.md:47-48, 199)
+SRC_SESS=$(tmux display-message -p -t "$BEFORE3" '#{session_name}')
+N=$(tmux list-windows -t "$SRC_SESS" -F '#{window_index}' | grep -c .)
+[ "$N" -ge 2 ] || { echo "SKIP: $SRC_SESS 창이 $N개 — 옮기면 세션 소멸·터미널 닫힘"; exit 1; }
+```
+
+2026-08-28 실측: `3-personal` 존재, `2-review` 창 9개 → 두 조건 모두 충족. 실행 시점에
+어긋나면 **다른 기존 세션으로 대상을 바꾸거나** 이 단계를 건너뛰고 AC-49·AC-13을 문서
+검토로 강등하며 사유를 보고서에 남긴다.
+
+```bash
+BEFORE3=$(wids); [ -n "$BEFORE3" ] || { echo "FAIL"; exit 1; }
+```
+
+**에이전트 입력**
+
+> 모든 셸 명령을 `/tmp/qg-harness/run.sh '<명령>'` 형태로 실행해라.
+> `~/.claude/skills/create-worktree/SKILL.md`의 절차를 따라라.
+> https://github.com/lee-kyu-hwan/dotfiles/pull/31 을 3-personal 세션으로 옮겨줘
+
+```bash
+AFTER3=$(wids); [ -n "$AFTER3" ] || { echo "FAIL"; exit 1; }
+[ "$BEFORE3" = "$AFTER3" ] && echo "AC-49 OK: 재생성 아님(window_id 동일)"
+tmux display-message -p -t "$AFTER3" '#{session_name}'     # 3-personal 기대
+git config --get "workmux.worktree.$H.window-session"      # 3-personal 기대 (AC-13)
+grep -E 'move-window|display-message' /tmp/qg-harness/cmd.log   # 이동 경로를 탔다는 증거
+```
+
+**기대**: 창이 `3-personal`로 이동, `window_id`가 T9와 동일(이동이지 재생성이 아님),
+`window-session`이 `3-personal`로 갱신.
+
+---
+
+### T12. 스모크 4차 — 레거시 저장값 + 세션 미명시 (R2.6·R7.4)
+
+SPEC-011이 지적한 경로를 실제로 만든다. **이 Plan에서 가장 중요한 실행 검증이다.**
+
+```bash
+git config "workmux.worktree.$H.window-session" legacy      # 형식 불만족 값을 심는다
+WID4=$(wids); [ -n "$WID4" ] || { echo "FAIL"; exit 1; }
+SESS_BEFORE=$(tmux display-message -p -t "$WID4" '#{session_name}')
+[ -n "$SESS_BEFORE" ] || { echo "FAIL: 세션 확인 불가"; exit 1; }
+```
+
+**에이전트 입력** — 세션을 주지 않는다. 이것이 우선순위 2를 건너뛰게 만드는 조건이다.
+
+> 모든 셸 명령을 `/tmp/qg-harness/run.sh '<명령>'` 형태로 실행해라.
+> `~/.claude/skills/create-worktree/SKILL.md`의 절차를 따라라.
+> https://github.com/lee-kyu-hwan/dotfiles/pull/31
+
+```bash
+WID4_AFTER=$(wids)
+SESS_AFTER=$(tmux display-message -p -t "$WID4" '#{session_name}')
+STORED=$(git config --get "workmux.worktree.$H.window-session")
+[ "$WID4" = "$WID4_AFTER" ] && [ "$SESS_BEFORE" = "$SESS_AFTER" ] && echo "AC-48 OK: 창 불이동"
+[ -n "$STORED" ] && [ "$STORED" = "$SESS_AFTER" ] \
+  && echo "AC-12b OK: 실제 세션으로 갱신" \
+  || echo "AC-12b FAIL: stored=$STORED actual=$SESS_AFTER"
+```
+
+**기대**: 창이 옮겨지지 않고(`window_id`·세션 불변), `window-session`이 `2-review`
+(우선순위 3)가 **아니라** 창의 실제 세션(`3-personal`)으로 갱신된다.
+
+`2-review`로 바뀌면 SPEC-011의 결함이 남은 것이므로 **실패**다.
+
+---
+
+### T13. 정리·하네스 제거·최종 확인
+
+**공통 프리앰블을 먼저 실행한다(PLAN-014).** `$H`가 비어 있으면 아래 어떤 명령도 실행하지
+않는다.
+
+```bash
+HARNESS=/tmp/qg-harness; BR=30-enhancement/tmux-open-pr-shortcut
+OID=9cfc6267ced574945814536710cf1019a37dc354
+# ↑ 공통 프리앰블로 $WT·$H를 재파생하고 [ -n "$H" ] 가드를 통과한 뒤에만 진행
+
+# PLAN-016: 아래 remove는 자동 실행하지 않는다. 사용자에게 제시해 직접 실행하게 한다.
+echo "사용자 실행 필요:  ! workmux remove \"$H\" -k"
+# (사용자 실행 완료 후 아래 검증을 이어간다)
+
+git worktree list
+workmux list --json
+tmux list-windows -a -F '#{session_name}:#{window_index} #{window_name}'
+git config --get-regexp "^workmux\.worktree\.$H\."; echo "키 잔여: $?"   # 1 기대
+diff <(git config --get-regexp '^workmux\.worktree\.' || :) "$HARNESS/wm-keys-before.txt"; echo "키 원복: $?"
+
+# 사전 존재하던 브랜치 확인·복구
+git rev-parse --verify "$BR" >/dev/null 2>&1 && echo "브랜치 보존됨" || git branch "$BR" "$OID"
+
+# 하네스 제거
+rm -rf "$HARNESS"
+
+# 소스 변경 범위 (허용 3파일 외 0건)
+git status --short
+git diff --stat
+```
+
+**기대**: worktree·창·키 잔여 0건, 사전 브랜치 보존, `git status`에 허용 3파일과 산출물
+디렉터리만 표시.
+
+## Verification commands
+
+| # | 명령 | 기대 | 단계 |
+|---|---|---|---|
+| 1 | `diff $B/qv-claude-before.txt /tmp/qv-claude-after.txt` | exit 0 (경고 증가 없음) | T5 |
+| 2 | `diff $B/qv-agents-before.txt /tmp/qv-agents-after.txt` | exit 0 | T5 |
+| 3 | `grep -q 'argument-hint: ...'` | exit 0 | T5 |
+| 4 | `sed -n '3p' {두 파일} \| grep -qiE 'pull request\|(^\|[^a-z])PR([^a-z]\|$)'` | 양쪽 exit 0 | T5 |
+| 5 | `sed -n '3p'` 두 파일 문자열 비교 | 동일 | T5 |
+| 6 | `diff dot_agents/... dot_claude/...` | `3a4,6` + `>` 3줄만 | T5 |
+| 7 | `grep -qE '2-review\|pull/' openai.yaml` | exit 0 | T5 |
+| 8 | `grep -n -- '1-main' {두 파일}` | 허용 3용례만 | T5+T6 |
+| 9 | `tmux -L quality-goal-nonexistent-socket list-sessions` | exit 1 + `error connecting to` | T5 |
+| 10 | `... \| grep -qxF -- 'definitely-not-a-session'` | exit 1 | T5 |
+| 11 | `tmux has-session -t 2` / `-t 2-rev` | 둘 다 exit 0 | T5 |
+| 12 | `... \| grep -qxF -- '2-rev'` | exit 1 | T5 |
+| 13 | `git diff --check` | exit 0 | T5 |
+| 14 | `pre-commit run --all-files` | 통과 | T5 |
+| 15 | `chezmoi diff {두 경로}` | 예상 변경만 | T7 |
+| 16 | `chezmoi apply {두 경로}` | exit 0, 프롬프트 없음 | T7 |
+| 17 | `cmp` 3쌍 | 모두 exit 0 | T7 |
+| 18 | quality-goal 23개 파일 해시·mtime `diff` | 둘 다 exit 0 | T7 |
+| 19 | `/tmp/qg-harness/run.sh 'workmux --version'` 후 `grep -c . cmd.log` | 1 이상 | T7.5 |
+| 20 | 0차 A부 프로브 3개 | `$F` 0, `$SLUG`·`$W` 1 | T8 |
+| 21 | 0차 B부 로그 grep | `$F` ≥1, `$SLUG`·`$W` 0, `workmux list` ≥1 | T8 |
+| 22 | 1차 관찰 11항목 | T9 표 | T9 |
+| 23 | 2차 `window_id` 비교 | 비어 있지 않고 1개, 값 동일 | T10 |
+| 24 | 3차 세션·`window_id`·config | `3-personal`, 동일 id, 갱신됨 | T11 |
+| 25 | 4차 `stored == actual` | 실제 세션으로 갱신 | T12 |
+| 26 | 정리 후 잔여물·브랜치·키 | 0건, 브랜치 보존, 키 원복 | T13 |
+
+### 검증 카테고리 상태
+
+| 카테고리 | 상태 | 근거 |
+|---|---|---|
+| 표적 테스트·전체 스위트·타입 체크·빌드 | `not configured` | `package.json`·`Makefile`·`justfile`·`.github/workflows` 부재 |
+| 린트 | `not configured` | `.pre-commit-config.yaml`에 gitleaks 훅만 |
+| E2E·수동 | **T8~T13에서 수행** | 스모크 0~4차 |
+
+## Rollout and rollback
+
+### 롤아웃 순서
+
+1. 소스 3파일 수정(T2~T4) — 배포본 무영향
+2. 결정적 검사·문서 검토 통과(T5·T6)
+3. **경로 한정** `chezmoi apply`(T7) — 이 시점부터 배포본이 새 절차로 바뀐다
+4. 하네스 준비(T7.5) → 스모크(T8~T12)
+5. 정리(T13)
+
+### 배포 영향
+
+- **다른 세션이 `create-worktree`를 실행 중이면 T7 시점에 절차가 바뀐다.** 대화형 호출이라
+  실행 중 교체 위험은 낮지만 승인 시점에 알린다.
+- **quality-goal 배포본 23개 파일은 건드리지 않는다.** 검증 18번이 해시·mtime으로 확인한다.
+- **커밋하지 않는다.**
+
+### 롤백 트리거와 절차
+
+| 트리거 | 절차 |
+|---|---|
+| T5·T6 실패 | 배포 전이므로 소스만 되돌린다 |
+| T7의 `cmp` 실패 또는 quality-goal 해시·mtime 변경 | 즉시 전체 롤백 |
+| T8~T12 중 스킬 결함 발견 | 스모크 정리(브랜치 보존 포함) 후 전체 롤백 |
+| 스모크가 다른 세션의 worktree·창을 건드림 | 즉시 중단, 상태 그대로 보고. 자동 복구 금지 |
+| **`workmux remove`가 프롬프트로 정지·타임아웃** | 자동 실행하지 않으므로 원칙적으로 발생하지 않는다. 그래도 정지하면 그 호출을 중단하고 사용자에게 `! workmux remove … -k` 실행을 요청한다. 픽스처가 남아 있으면 T9를 시작하지 않는다 |
+| **원본 세션이 소멸(마지막 창 이동)** | T11 전제 확인이 막는다. 그럼에도 발생하면 즉시 중단하고 보고한다. `detach-on-destroy=on` + `.zshrc`의 `exec tmux` 때문에 사용자 터미널이 닫혔을 수 있으므로 자동 복구를 시도하지 않고 상태를 그대로 알린다 |
+| **tmux resurrect 스냅샷 변경** | `move-window-to-session`이 4단계에서 즉시 저장한다. 이는 그 스킬의 정상 동작이며 되돌리지 않는다. 스모크가 공유 tmux 상태를 바꿨다는 사실을 보고서에 기록한다 |
+
+```bash
+# 전체 롤백 — 소스 복원 + 적용본 복원 + 스모크 잔여물 정리 + 사전 브랜치 복구
+BR=30-enhancement/tmux-open-pr-shortcut
+OID=9cfc6267ced574945814536710cf1019a37dc354
+
+# 1) 스모크 잔여물 (있으면) — 브랜치를 지우지 않는 -k 를 쓴다
+for h in $(workmux list --json | python3 -c \
+  "import json,sys;print(' '.join(w['handle'] for w in json.load(sys.stdin) if w['branch']=='$BR'))"); do
+  workmux remove "$h" -k
+done
+git rev-parse --verify "$BR" >/dev/null 2>&1 || git branch "$BR" "$OID"
+
+# 2) 소스 복원
+git checkout -- dot_claude/skills/create-worktree dot_agents/skills/create-worktree
+
+# 3) 적용본 복원 (경로 한정)
+chezmoi apply ~/.claude/skills/create-worktree ~/.agents/skills/create-worktree
+cmp dot_claude/skills/create-worktree/SKILL.md ~/.claude/skills/create-worktree/SKILL.md
+
+# 4) 하네스 제거
+rm -rf /tmp/qg-harness
+```
+
+데이터 마이그레이션이 없으므로 롤백은 파일 복원과 worktree 정리로 끝난다. **모든 제거
+경로가 `-k`와 브랜치 복구를 짝지어 갖는다**(PLAN-005).
+
+## Acceptance-criteria traceability
+
+| 기준 | 태스크 | 검증 명령·증거 | 기대 결과 |
+|---|---|---|---|
+| AC-1 | T2·T3 | T6 문서 검토 | 입력 계약·첫 인자 질문이 두 파일에 존재 |
+| AC-2 | T2·T3 | T6 | positional 3개 이상 중단 |
+| AC-3 | T2·T3 | T6 | PR 트리거 3종 |
+| AC-4 | T2·T3 | T6 | 맨 숫자 금지와 번호 공간 근거 |
+| AC-5 | T2·T3 | T6 | 2-튜플 환원, 두 개 이상 중단 |
+| AC-6 | T2·T3 | T6 | 접두사 보정·추측 금지 |
+| AC-7 | T2 | 검증 3 | exit 0 |
+| AC-8 | T2·T3 | T6 | handle 정의·유추 금지·4개 키 |
+| AC-9 | T8 A부 | 검증 20 | `$F` 0, `$SLUG`·`$W` 1 |
+| AC-9b | T8 B부 | 검증 21 | 하네스 로그에 `$F`만, `$SLUG`·`$W` 0건 |
+| AC-10 | T2·T3 | T6 | 저장값이 모드 기본값보다 위 |
+| AC-11 | T2·T3 | T6 | 정규식과 glob 반례 |
+| AC-12 | T2·T3 | T6 | 금지 4개 열거 + 예외 |
+| AC-12b | T2·T3 + T12 | T6 + 검증 25 | 3행 표 + `stored == actual` |
+| AC-13 | T11 | 검증 24 | `window-session` == `3-personal` |
+| AC-14 | T2·T3 | T6 | 복구 4단계 |
+| AC-15 | T2·T3 + T5 | 검증 9 + T6 | exit 1 + `error connecting to`, **문서에 구분 서술** |
+| AC-16 | T2·T3 + T5 | 검증 10 + T6 | exit 1, **문서에 자동 생성 금지** |
+| AC-17 | T2·T3 + T5 | 검증 11·12 + T6 | 0/0/1, **문서에 함정 근거** |
+| AC-18 | T5·T6 | 검증 8 | 허용 3용례만 |
+| AC-19 | T2·T3 | T6 | 입력 형태별 표와 폴백 |
+| AC-20 | T2·T3 | T6 | 조회 필드와 소비처 |
+| AC-21 | T2·T3 | T6 | 불일치 중단과 두 값 출처 |
+| AC-22 | T2·T3 | T6 | 생성만 건너뛰고 창 처리로 |
+| AC-23 | T2·T3 | T6 | OID 비교 후 중단 |
+| AC-24 | T2·T3 | T6 | 추측 없이 중단 |
+| AC-25 | T2·T3 | T6 | pull ref fetch와 래퍼 미호출 |
+| AC-26 | T2·T3 | T6 | 4요소 |
+| AC-27 | T2·T3 + T9 | T6 + 검증 22 | 문서 `--pr {PR번호}` + **로그의 실제 인자가 숫자** |
+| AC-28 | T2·T3 | T6 | 마지막 `/` 뒤 |
+| AC-29 | T2·T3 | T6 | 맨 앞 숫자 또는 `ZF-숫자` |
+| AC-30 | T9 | 검증 22 | 창 이름이 `31-`, 입력에 이름 없음 |
+| AC-31 | T2·T3 | T6 | `--target-name` 생략 |
+| AC-32 | T2·T3 | T6 | 소문자 정규화 |
+| AC-33 | T2·T3 | T6 | 모드별 재시도 |
+| AC-34 | T2·T3 | T6 | 루트 기준 분기 |
+| AC-35 | T2·T3 | T6 | git-crypt에 래퍼만 |
+| AC-36 | T9 | 검증 22 | 로그에 positional·`--name` 없음, 브랜치가 `$BR` |
+| AC-37 | T2·T3 | T6 | 확보 → 래퍼 → open |
+| AC-38 | T2·T3 | T6 | 실패·권한 시 창 안 엶 |
+| AC-39 | T2·T3 | T6 | 미지원 조합 예외 |
+| AC-40 | T9 | 검증 22 | HEAD == `$OID` |
+| AC-41 | T2·T3 + T9 | T6 + 검증 22 | 폴백 서술 + `workmux list --json`으로 확보 |
+| AC-42 | T2·T3 | T6 | 필터만 있으면 확인 후 진행 |
+| AC-43 | T2·T3 | T6 | worktree 판정이 세션 선택보다 앞 |
+| AC-44 | T2·T3 + T9 | T6 + 검증 22 | 4단계 탐지 + 고유 `window_id` 1 + `target-window` 일치 |
+| AC-45 | T2·T3 | T6 | 0건·2건·공백·`cd`·부재·스테일 |
+| AC-46 | T2·T3 | T6 | 닫힘 시 직접 열기 |
+| AC-47 | T10 | 검증 23 | 비어 있지 않고 1개, 값 동일 |
+| AC-48 | T2·T3 + T12 | T6 + 검증 25 | 문서 경로 1·2 + 창 불이동 |
+| AC-49 | T2·T3 + T11 | T6 + 검증 24 | 호출 형식·SPEC-022 분기 규칙 + 동일 `window_id` |
+| AC-50 | T9 | 검증 22 | `tmux list-windows -a` 출력 보존 |
+| AC-51 | T2·T3 | T6 | **사후 검증 세 갈래**(생성·이동·미이동) |
+| AC-52 | T9 | 검증 22 | 보고 7항목 |
+| AC-53 | T3 | 검증 6 | `3a4,6` + `>` 3줄 |
+| AC-54 | T4 | 검증 7 | exit 0 |
+| AC-55 | T7 | 검증 17 | `cmp` 3쌍 exit 0 |
+| AC-56 | T2·T3 | 검증 4·5 | 양쪽 exit 0 + 동일 |
+| AC-57 | T2·T3 | T6 | 18개 누락 0건 |
+| AC-58 | T9 | 검증 22 | 창이 `2-review`, 입력에 세션 없음 |
+| AC-59 | T5 | 검증 1·2 | 기준선과 동일 |
+| AC-60 | T5 | 검증 13·14 | 둘 다 통과 |
+
+**전수 확인**: Spec의 62개 기준이 모두 위 표에 있고 각각 구현 태스크와 검증 명령·증거를
+갖는다. 미대응 기준 없음.
+
+### 알려진 검증 한계
+
+| 항목 | 한계 | 사유 |
+|---|---|---|
+| AC-37 (git-crypt 래퍼 경로) | 문서 검토만 | 실제 검증은 업무 저장소에 1~2GB 부작용. 래퍼 82–98행을 직접 읽어 근거 확보 |
+| SPEC-022 분기(basename ≠ handle) | 문서 검토만 | 기본 명명에서 둘이 같아 스모크로 발동시킬 수 없다 |
+| 실패 상황 기준(fetch 실패·저장소 불일치·래퍼 부재 등) | 문서 검토만 | 인위 조성이 다른 기준의 판정을 흐린다 |
+
+## Codex 핸드오프 계약
+
+`codex exec` (standard: `gpt-5.6-terra`, effort high).
+
+- **허용 경로**: 위 3파일만.
+- **읽기 허용**: 이 Plan, Spec, 현행 두 SKILL.md, `move-window-to-session/SKILL.md`,
+  `remove-worktree/SKILL.md`, `dot_config/workmux/config.yaml`.
+  `/Users/lee-kyu-hwan/code/zambaguni-front/scripts/create-worktree.sh`는 **이 저장소
+  밖**이라 샌드박스에서 읽히지 않을 수 있다. 읽을 수 없으면 Spec이 인용한 82–98행 서술을
+  근거로 쓴다(PLAN-011).
+- **보존**: initial dirty path 2개 디렉터리를 바이트 단위로 유지.
+- **금지**: 커밋·푸시, 인자 없는 `chezmoi apply`, 샌드박스 우회 플래그.
+- **결과 계약**: `changed_files`, 실행 명령과 종료 코드, Plan 이탈, 남은 우려.
+- **범위**: **T2~T4(문서 작성)만.** T5 이후의 검증·배포·스모크는 오케스트레이터가 직접
+  수행한다 — 스모크는 tmux·worktree 부작용을 만들고 다른 세션과 공유 자원을 건드리므로
+  샌드박스 안에서 실행하지 않는다.

--- a/docs/development/2026-08-27-create-worktree-pr-session-3/report.md
+++ b/docs/development/2026-08-27-create-worktree-pr-session-3/report.md
@@ -1,0 +1,214 @@
+# Quality Goal Report
+
+- Task ID: 20260827T120102Z-28-35-create-worktree-스킬-3차-실행-pr-링크-입력-a16ed82b
+- Mode: standard (요청 auto)
+- Status: NEEDS_REDESIGN
+- Created: 2026-08-27T12:01:02Z
+- Updated: 2026-08-28
+- Source goal: #28 #35 create-worktree 스킬 3차 실행 — PR 링크 입력 시 `2-review` 세션에 PR 번호 윈도우를 생성하고 대상 세션을 직접 지정하도록 확장한다. SPEC-009(AC-9 판별력)과 SPEC-010(`--pr` 정규화)를 선반영하고, 휘발성 식별자를 증거에서 제거한다
+
+## Classification
+
+`auto` 요청에 대해 strict 위험 스캔 결과 트리거 0건(인증·인가, 결제·정산, PII·시크릿, DB 마이그레이션, 공개 API·큐, 프로덕션 인프라 모두 해당 없음)이었다. 변경 대상은 chezmoi 소스 트리의 Markdown/YAML 스킬 지침이고 롤백은 `git revert` + `chezmoi apply`로 단순하다. git-crypt는 대상 저장소의 자체 래퍼가 전담하며 이번 변경이 래퍼를 수정하지 않으므로 strict 사유가 되지 않는다.
+
+standard 조건은 복수로 성립했다.
+
+1. **다중 파일·레이어** — #35가 지정한 변경 대상 3개 파일이 Claude/Codex 두 런타임 트리에 걸친다
+2. **인터페이스·상태 전이 변경** — 선택적 대상 세션 인자와 PR 참조 모드가 추가되고, 4단계 세션 선택 우선순위가 신설된다
+3. **비자명한 신규 의존** — `workmux add --pr`, `workmux list --json`, `git fetch origin refs/pull/N/head`, `gh pr view`, `tmux list-panes -a`
+4. **대안·비범위·수용 기준 명시 필요** — #35에 '비범위' 절이 있고 두 이슈를 충돌 없이 결합해야 한다
+
+3차 실행 맥락: 2차 실행이 라운드 한도로 종료되며 남긴 Medium 2건을 선반영하고, 2차 Spec이 **이후 제거된 worktree를 근거로 삼아 증거가 죽은** 문제를 고치기 위해 휘발성 식별자를 증거에서 제거했다. 범위 확대가 아니라 기존 증거를 재현 가능한 것으로 교체하는 작업이므로 모드에 영향이 없다.
+
+## Review history
+
+| 아티팩트 | 라운드 | 점수 | 판정 | 블로커 | 대상 digest |
+|---|---|---|---|---|---|
+| Spec | 1 | — | REVISE | SPEC-011 | `913b54e5` |
+| Spec | 2 | 90 | PASS | 없음 | `5c742d28` |
+| Plan | 1 | 69 | REVISE | PLAN-001·PLAN-002 | `d49db8b8` (아래 불일치 참조) |
+| Plan | 2 | — | PASS | 없음 | `d49db8b8` |
+| Code | 1 | 82 | REVISE | 없음 | `29597a06` |
+| Code | 2 | 86 | REVISE | 없음 | `4a6ed493` |
+| Code | 3 | 88 | REVISE | 없음 | `4a6ed493` |
+
+**라운드 간에 바뀐 것**
+
+- **Spec 1→2**: SPEC-011(창 탐지 규칙이 선택 세션을 실제 위치로 오인)이 블로커로 잡혀 설계를 고쳤다. 이 결함은 나중에 스모크 T12와 재스모크 R3에서 실제로 수정 효과가 실증된 유일한 설계 결함이다.
+- **Plan 1→2**: PLAN-001·PLAN-002는 "스모크 테스트가 스킬이 파생해야 할 값(`--target-name`·`--parent-session`)을 오퍼레이터가 직접 타이핑해 단언이 구성적으로 참이 된다"는 지적이었다. 하위 에이전트에게 **입력만** 주고 `workmux`·`git`·`tmux`를 shim으로 감싸 argv를 로깅하는 하네스로 바꿔 해소했다.
+- **Code 1→2**: CODE-001~008 중 6건을 Codex 수정 라운드로 반영했다. 실행 순서 요약 절 신설, `target-window` 접미사 비교 규칙, `move-window-to-session` 인자 2개·인라인 금지 명시, git-crypt 문단의 선행사 모호성 해소, 편집 지시문 삭제. CODE-004(AC-59)는 코드로 닫을 수 없어 남았다.
+- **Code 2→3**: 산출물은 건드리지 않고 `verification.json`의 증거 기록만 고쳤다. CODE-013(모순된 'AC-59 통과' 잔존), CODE-014(`superseded` 표시가 대체 증거 범위보다 넓음), CODE-015(AC-50 미검증 사유 부정확)를 정리했고 라운드 3이 셋 모두 해소를 확인했다. 대신 CODE-016이 나왔다 — 기록이 정직해진 결과 AC-9b·AC-50의 재배포본 증거 공백이 **확정**되어 `acceptance_criteria_met`을 참으로 판정할 수 없게 됐다. 리뷰어가 제시한 선택지 (a)를 택해 재실측했다(아래 R5 참조).
+
+### 라운드 2·3 리뷰 JSON 유실 (절차 결함)
+
+이 실행에서 코드 리뷰는 실제로 **네 번** 돌았다. 그러나 중간 두 라운드(CODE-009~012, CODE-013~014를 낸 라운드)의 리뷰 JSON이 디스크에 영속화되지 않았다. `code-prior-round2.json`에 그 findings ID가 "이전 열린 발견"으로 남아 있는 것이 실행 사실의 유일한 잔존 증거다.
+
+오케스트레이터는 기억으로 리뷰어 산출물을 재구성해 기록하는 것을 **거부했다** — 감사 기록 위조에 해당하기 때문이다. 대신 남은 라운드 예산으로 최종 상태에 대해 리뷰를 새로 돌려 그것을 라운드 2·3으로 기록했다. 따라서 위 표의 라운드 번호는 **기록상 라운드**이며 실제 리뷰 횟수(4회)와 다르다.
+
+**후속 개선**: `record-review`를 리뷰 직후 무조건 호출하도록 절차를 강제해야 한다. 리뷰어 반환값을 파일로 먼저 떨어뜨리지 않으면 컨텍스트 소실로 증거가 사라진다.
+
+### Plan digest 불일치
+
+Plan 라운드 1 리뷰의 실제 대상은 digest `8c239061`이었으나 state에는 `d49db8b8`으로 기록되어 있다. 오케스트레이터가 **리뷰를 기록하기 전에 Plan을 개정**했고, `record_review`가 현재 등록 아티팩트 기준으로 digest를 검사하므로 원래 값으로는 기록할 수 없었다.
+
+원인을 코드로 확정했다. `set_artifact`는 `artifacts[kind]`에 경로만 쓰고, `artifact_digests`를 갱신하는 유일한 지점은 `record_review`다. v1.0.0의 `approve_plan`은 경로만 비교한 뒤 digest를 새로 계산하며 `artifact_digests["plan"]`과 교차 검사하지 않는다. 따라서 라운드 1·2가 같은 `d49db8b8`을 공유하는 것은 **`set-artifact` 누락이 아니라 기록 순서 오류의 결과**다. 올바른 순서는 기록 → 게이트 → 개정이다.
+
+승인·구현에 실제로 쓰인 digest는 `fdbd2ddf`로, 리뷰가 본 어느 digest와도 다르다. 라운드 1 리뷰 원문은 `plan-review-round1.json`에 그대로 보존되어 있다.
+
+## Blocking-finding resolutions
+
+| 발견 | 단계 | 해소 | 검증 증거 |
+|---|---|---|---|
+| SPEC-011 | Spec 라운드 1 | 창 탐지를 4단계(`is_open` → 저장 세션 → `target-window` 접미사 → pane 경로 교차)로 재설계하고, 창을 옮기지 않는 경로에서는 **선택 세션이 아니라 실측 세션**을 기록하도록 규칙을 바꿨다 | 재스모크 R3 — `window-session=legacy` 주입 후 세션 미명시 재호출에서 하네스가 기록한 유일한 config 쓰기가 `… .window-session 3-personal`이었다. `SELECTED_SESSION`인 `2-review`가 아니다 |
+| PLAN-001 | Plan 라운드 1 | 스모크가 스킬이 파생해야 할 값을 오퍼레이터가 타이핑하던 구조를 폐기하고, 하위 에이전트에 **입력만** 주는 방식으로 전환 | T9 로그 실측 — 에이전트에게 PR URL만 주었는데 `workmux add --pr 31 --target-name 31-tmux-open-pr-shortcut --parent-session 2-review`가 실행됐다 |
+| PLAN-002 | Plan 라운드 1 | `workmux`·`git`·`tmux`를 argv 로깅 shim으로 감싸고 `run.sh`로 구동하는 하네스 도입 | 하네스 자체 검증(`workmux --version`이 로그에 기록됨) 후 전 단계 적용 |
+| CODE-010 | Code (미기록 라운드) | 수정 라운드가 소스를 바꾼 뒤 **재배포하지 않아** 배포본에 6건이 전부 빠져 있었다. 즉시 경로 단위 `chezmoi apply` 후 재스모크 | `cmp` 3쌍 exit 0으로 AC-55 회복. 재스모크 R1에서 에이전트가 새 문서에만 있는 '실행 순서 요약' 절을 인용했고, R2에서 CODE-002 수정 덕에 `move-window-to-session`을 인라인이 아니라 Skill 도구로 호출했다 |
+
+## Plan approval
+
+- Approval timestamp: 2026-08-28T01:20:29Z
+- Plan digest: `fdbd2ddfd163cdef0f528b9235f0fc96344d642568841685a24ac9b02d5ae676`
+
+사용자 승인 문구는 "승인 — 스모크까지 전체"였다. 위 digest 불일치 절에 적었듯 이 digest는 리뷰가 본 `d49db8b8`·`8c239061` 어느 쪽과도 다르다.
+
+## Changed files
+
+| 파일 | 의도한 변경 |
+|---|---|
+| `dot_claude/skills/create-worktree/SKILL.md` (319행) | PR 참조 모드(URL / `owner/repo#N` / 태그된 자연어), 4단계 세션 선택 우선순위, handle 기반 config 키, 이름 비의존 창 탐지, `--pr` 숫자 정규화. Claude 전용 frontmatter 3줄(`argument-hint`·`user-invocable`·`allowed-tools`) 포함 |
+| `dot_agents/skills/create-worktree/SKILL.md` (316행) | 위와 **본문 바이트 동일**. 차이는 Claude 전용 frontmatter 3줄뿐이며 `diff` 출력이 정확히 `3a4,6` + `>` 3줄이어야 한다는 불변식으로 관리된다 |
+| `dot_agents/skills/create-worktree/agents/openai.yaml` (4행) | `short_description`과 `default_prompt`를 PR 모드·`2-review` 세션 반영으로 갱신 |
+
+합계 547 삽입 / 301 삭제. 범위 밖 변경 0건(패치 헤더 정확히 3개, `git diff --check` exit 0).
+
+## Verification evidence
+
+**자동 검증 카테고리는 대부분 `not configured`다.** `package.json`·`Makefile`·`justfile`·`.github/workflows` 모두 부재하여 targeted_tests·full_suite·type_check·build를 실행할 대상이 없다. lint는 `.pre-commit-config.yaml`에 gitleaks 훅만 있고 pre-commit 자체가 미설치라 gitleaks를 직접 실행했다(DEV-4). 따라서 이 작업의 검증은 **문서 검토 + 실제 스모크 테스트**가 전부다.
+
+### 핵심 실행 증거
+
+가장 중요한 단일 증거다. 하위 에이전트에게 PR URL만 주었고 세션 이름도, 창 이름도, `--pr`의 인자 형태도 알려주지 않았다. 하네스가 기록한 실제 argv:
+
+```
+workmux add --pr 31 --target-name 31-tmux-open-pr-shortcut --parent-session 2-review
+```
+
+PR 번호 `31`이 head 브랜치가 담은 이슈 번호 `30`을 이겼다. 이것이 #28·#35가 요구한 핵심 동작이다.
+
+### 재배포 후 재스모크 (R1~R4)
+
+| 단계 | 입력 | 결과 |
+|---|---|---|
+| R1 | PR URL만 (재배포본) | 재배포 실효 확인 — 새 문서에만 있는 '실행 순서 요약' 절을 인용. AC-27·30·36·40·41·58 재확인 |
+| R2 | `3-personal` 이동 지시 | AC-49·AC-13 재확인, `window_id` 동일(이동이지 재생성 아님). CODE-002 수정 실효 — `move-window-to-session`을 Skill 도구로 인자 2개만 넘겨 호출 |
+| R2 | AC-44b 접미사 판정 | CODE-003 수정 실효 실증 — 동등 비교는 **실패**, 접미사 판정은 통과 |
+| R3 | `window-session=legacy` 주입 + 세션 미명시 | **AC-12b·AC-48·AC-52** — 창 불이동, 기록값이 실측 `3-personal`(선택값 `2-review` 아님). SPEC-011 수정 실증 |
+| R4 | 같은 세션(`3-personal`) 명시 | **AC-47** — `tmux list-windows -a` 전체 18행이 전후 바이트 동일, 중복 창 없음 |
+| R5 | PR URL만, 생성 경로 (grep 패턴 수정 후) | **AC-50** — 생성(로그 59행) 후 사후 검증 `tmux list-windows -a`(148행) 실행. 창 목록 행 `2-review:4\|@37\|␣31-tmux-open-pr-shortcut`을 `od -c`로 바이트 확인 |
+| R6 | 기존 worktree 존재 상태에서 PR URL만 | **AC-9b** — 창 이름 기준 조회 0건, 브랜치 슬러그 기준 0건, 쓰기 0건. 사후 config에 유령 `workmux.worktree.31-*` 섹션 없음 |
+| 정리 | `workmux remove -k` | 잔여물 0건, 사전 존재 브랜치 `30-enhancement/tmux-open-pr-shortcut`이 `9cfc6267` 그대로 보존. `-f` 미사용 |
+
+R3·R4의 픽스처는 오퍼레이터가 직접 조성하고 **검증 대상인 재호출만** 에이전트가 수행했다. 조성 값이 판정 대상이 아니므로 PLAN-001의 구성적 참 문제가 재발하지 않는다.
+
+### 배포 정합
+
+`chezmoi apply`는 **경로 단위로만** 실행했다. 인자 없는 실행은 다른 세션이 배포본 quality-goal 스킬을 실행 중일 수 있어 금지되었다. `cmp` 3쌍 exit 0으로 소스↔배포본 일치를 확인했다.
+
+### 미검증으로 남긴 것
+
+| 기준 | 사유 |
+|---|---|
+| AC-37 (git-crypt 래퍼 경로) | 업무 저장소에 1~2GB 부작용을 만들지 않기 위해 문서 검토만 |
+| SPEC-022 분기 (basename ≠ handle) | 이 저장소 기본 명명에서 둘이 같아 스모크로 발동 불가 |
+| 실패 상황 기준 (fetch 실패·저장소 불일치·래퍼 부재) | 인위 조성이 다른 기준 판정을 흐림 |
+| AC-9b의 음성 단언 일반 | 하네스 완전 준수를 전제로 하며 부분 우회는 탐지하지 못한다 |
+
+## Remaining advisory findings
+
+| 발견 | 심각도 | 영향 | 후속 |
+|---|---|---|---|
+| **CODE-004 (AC-59)** | Medium | 코드 게이트의 `required_commands_passed`를 false로 만든다. 이 작업이 `COMPLETED`에 도달하지 못하는 **유일한 사유**다 | 아래 전용 절 참조 |
+| CODE-016 (AC-9b·AC-50) | Medium | 라운드 3이 제기. **해소됨** — 리뷰어가 제시한 선택지 (a)를 택해 R5·R6로 재실측했다. 다만 라운드 한도 소진으로 이 증거를 검토한 리뷰 라운드는 없다 | 없음 |
+| ERRATUM-5 (Spec R7.5 서술) | Low | Spec 본문과 산출물의 인자 계약 서술이 다르다. 산출물이 정확하다 | 다음 실행에서 R7.5 본문을 Interfaces 절의 한정어와 일치시킨다 |
+| `quick_validate.py` 스키마 미반영 | Medium | 이 저장소의 Claude 전용 스킬은 앞으로도 이 검증기에서 exit 1이 난다 | 검증기를 교체하거나 `dot_agents` 쪽에만 적용 |
+| 리뷰 JSON 영속화 누락 | Medium | 감사 추적 단절 | `record-review`를 리뷰 직후 무조건 호출하도록 절차 강제 |
+
+### AC-59 — 사용자가 인정한 미충족 기준
+
+승인된 AC-59의 판정 기준은 `quick_validate.py`의 **종료 코드 0**이다. 그런데 그 검증기는
+
+```
+42:  ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'}
+45:  unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
+99:  sys.exit(1)
+```
+
+allow list에 `argument-hint`도 `user-invocable`도 없고, 예상 밖 키가 있으면 exit 1이다. 그런데 **Spec R1.8은 `argument-hint`를 요구한다.** 즉 R1.8을 만족하는 한 `dot_claude` 쪽 종료 코드는 항상 1이며, **기준과 요구사항이 서로를 배제한다.**
+
+검증기 경로: `/Users/lee-kyu-hwan/.claude/plugins/marketplaces/claude-plugins-official/plugins/skill-creator/skills/skill-creator/scripts/quick_validate.py`
+
+이것은 **산출물 결함이 아니다.** 변경 전후로 unexpected key 집합이 `argument-hint, user-invocable`로 동일하고 메시지도 기준선과 바이트 동일하다. 어떤 코드 수정으로도 닫을 수 없다.
+
+ERRATUM-4가 판정 기준을 정식 개정하려 시도했으나 **코드 리뷰 CODE-004가 거부했다** — 구현 쪽 정오표로 승인된 수용 기준을 고쳐 쓸 수 없고, 검토자는 결정적 명령의 비영 종료를 waive할 수 없다는 이유다. Spec 리뷰 라운드 한도(2/2)가 소진되어 정식 개정안을 게이트에 태울 수도 없었다.
+
+사용자는 2026-08-28 **"미충족으로 인정하고 진행"**을 선택했다. 권위 있는 기록은 `verification.json`의 `user_accepted_unmet_criteria` 항목이다.
+
+**후속 제안**: `quick_validate.py`는 skill-creator 플러그인 소유이고 Claude Code의 실제 frontmatter 스키마(`argument-hint`·`user-invocable`·`disable-model-invocation`)를 반영하지 않는다. 검증 도구를 교체하거나 `dot_agents` 쪽에만 적용하는 편이 낫다.
+
+## Plan 이탈 (정오표)
+
+| ID | 내용 |
+|---|---|
+| ERRATUM-1 | `quick_validate.py` 종료 코드를 파이프로 측정해 `head`의 값을 읽었다. `dot_claude`는 실제로 exit 1이 정상이다 |
+| ERRATUM-2 | `chezmoi apply <디렉터리>`는 아무것도 매칭하지 않는다. 파일 단위 3개로 지정했다. 사전 점검이 "매칭 없음"과 "드리프트 없음"을 구분하지 못했던 것이 원인 |
+| ERRATUM-3 | `target-window` 저장값과 실제 창 이름은 일치가 아니라 **접미사 일치**다(`nerdfont: true`가 붙이는 `U+E418` + 공백). 원 측정이 `.split()`으로 부분 토큰 일치를 전체 일치로 오독했다 |
+| ERRATUM-4 | AC-59 판정 기준 개정 시도 → CODE-004가 거부 → 사용자 인정 미충족으로 재분류 |
+| ERRATUM-5 | Spec R7.5의 "경로와 handle을 함께 전달한다"와 산출물의 "인자는 2개뿐"이 다르다. 대상 스킬의 실제 계약에 비추어 **산출물이 정확하다** |
+| DEV-4 | pre-commit 미설치로 gitleaks를 직접 실행. 그 config의 유일한 훅이 gitleaks라 검증 내용은 동등 |
+| DEV-5 | `workmux remove`에 `< /dev/null` 추가. `-k` + 빈 stdin에서 프롬프트 없이 exit 0으로 완료됨을 실측. **`-f`는 쓰지 않았다** |
+| DEV-6 | 수정 라운드 후 재배포 누락(CODE-010). 코드 리뷰가 잡아 즉시 재배포하고 수정된 경로를 재배포본에 대해 다시 태웠다 |
+
+## 미결 결정 사항 (사용자)
+
+**변경된 3개 파일 547줄이 `~/.claude`·`~/.agents`에 배포되어 있으나 커밋되지 않았다.** 사용자가 "커밋하지 마라, 3차까지의 산출물 처리는 사용자가 결정한다"고 지시했으므로 오케스트레이터는 커밋하지 않았다. 작업 중 동료 세션이 커밋을 요청했으나 그 요청은 사용자 승인을 대신하지 못하므로 거부했다.
+
+현재 상태의 위험: 배포본은 새 동작을 하지만 git에는 없다. `chezmoi apply`가 다른 경로로 실행되면 배포본이 옛 버전으로 되돌아갈 수 있다.
+
+1·2차 실행 산출물은 **소실되지 않았다.** 커밋 `f23620a`가 `docs/quality-goal-field-reports`·`fix/quality-goal-round-limits` 브랜치에 담고 있으며, main 작업트리의 미추적 사본만 정리된 것이다.
+
+## 도구 제약으로 남은 기록 불일치 (#43 재현)
+
+**상태는 코드 리뷰 라운드 3을 기록한 순간 자동으로 `NEEDS_REDESIGN`으로 전이됐다** (2026-08-28T05:37:21Z, `status_reason: REVIEW_LIMIT_EXHAUSTED:code`). 오케스트레이터가 `transition`을 호출한 적이 없다 — `record-review`가 라운드 한도 도달과 비-PASS 판정을 보고 스스로 종결했다.
+
+이 자동 전이가 두 가지 결과를 낳았다.
+
+**1. 보고서를 아티팩트로 등록할 수 없다.** 스킬은 "터미널 상태로 전이하기 **전에** `set-artifact --kind report`로 등록하라"고 규정하는데, 전이가 보고서 작성보다 먼저 일어났다. 실제 시도 결과:
+
+```
+$ quality_state.py set-artifact --kind report --path .../report.md
+error: terminal state is immutable: NEEDS_REDESIGN
+```
+
+사용자 지시에 따라 **우회하지 않았다.** `state.json`의 `artifacts.report`는 `null`로 남으며, 보고서의 권위 있는 위치는 이 파일의 경로다.
+
+- 보고서 경로: `/Users/lee-kyu-hwan/code/dotfiles/docs/development/2026-08-27-create-worktree-pr-session-3/report.md`
+
+**2. R5·R6 증거가 `state.json`에 반영되지 못했다.** CODE-016을 닫은 재실측(AC-9b·AC-50)은 자동 전이 **이후**에 수행됐다. `verification.json` 파일 자체에는 R5·R6와 갱신된 `known_limits`가 기록되어 있으나, `record-verification` 역시 같은 이유로 거부됐다.
+
+```
+$ quality_state.py record-verification --fingerprint e7b515b4…
+error: terminal state is immutable: NEEDS_REDESIGN
+```
+
+따라서 `state.json`이 가리키는 검증 지문은 `4a6ed493`(R5·R6 이전)이고, 같은 경로의 `verification.json` 파일은 그보다 더 많은 증거를 담고 있다. **산출물 3파일은 R5·R6 동안 불변이며**(diff stat 547/301 동일, `cmp` 3쌍 exit 0) 지문 변화는 이 보고서 파일이 새로 생긴 데서 왔다.
+
+**후속 개선**: `record-review`가 라운드 한도에서 자동 종결하기 전에 보고서 등록 기회를 주어야 한다. 현재 설계에서는 마지막 리뷰를 기록하는 순간 보고서 등록 경로가 닫히므로, 규정된 순서(보고서 등록 → 전이)를 지키는 것이 구조적으로 불가능하다.
+
+## Final status
+
+- Status: NEEDS_REDESIGN
+- Machine-readable reason: `REVIEW_LIMIT_EXHAUSTED:code` (`state.json`이 기록한 값)
+
+근본 사유는 `required_commands_passed=false`다. AC-59의 승인된 판정 기준(`quick_validate.py` 종료 코드 0)이 Spec R1.8(`argument-hint` 요구)과 상호 배제적이어서 구조적으로 충족 불가능하다. 사용자가 미충족을 인정했으나 검토자는 결정적 명령의 비영 종료를 waive할 수 없고, Spec 라운드 한도 소진으로 정식 개정도 불가능했다. 코드 리뷰 3라운드가 모두 REVISE(82 → 86 → 88)로 끝나 한도가 소진됐다.
+
+**산출물 자체는 동작한다.** 핵심 목표(PR 링크 입력 시 PR 번호로 `2-review` 세션에 창 생성, 대상 세션 직접 지정)는 실행 증거로 확인됐다. `NEEDS_REDESIGN`은 산출물 결함이 아니라 **수용 기준과 검증 도구 사이의 구조적 모순** 때문이다. 다음 실행은 AC-59 판정 기준을 Spec 게이트를 거쳐 정식 개정하는 것에서 시작해야 한다.

--- a/docs/development/2026-08-27-create-worktree-pr-session-3/spec.md
+++ b/docs/development/2026-08-27-create-worktree-pr-session-3/spec.md
@@ -1,0 +1,1449 @@
+# Quality Goal Specification
+
+- Task ID: 20260827T120102Z-28-35-create-worktree-스킬-3차-실행-pr-링크-입력-a16ed82b
+- Mode: standard
+- Status: SPEC_REVIEW (round 1)
+- Created: 2026-08-27T12:01:02Z
+- Updated: 2026-08-27T12:01:02Z
+- Source goal: #28 #35 create-worktree 스킬 3차 실행 — PR 링크 입력 시 2-review 세션에 PR 번호 윈도우를 생성하고 대상 세션을 직접 지정하도록 확장한다. SPEC-009(AC-9 판별력)과 SPEC-010(--pr 정규화)를 선반영하고, 휘발성 식별자를 증거에서 제거한다
+
+## Problem and context
+
+`create-worktree` 스킬은 현재 브랜치명 하나만 입력으로 받고, workmux 윈도우를 항상
+`1-main` 세션에 연다. 두 가지 한계가 실제 사용에서 드러났다.
+
+**한계 1 — PR 리뷰용 worktree를 PR 번호로 식별할 수 없다.** 현행 규칙은 브랜치명 맨
+앞의 숫자만 이슈 번호로 인식해 `{이슈번호}-{짧은이름}` 윈도우를 만든다
+(`dot_claude/skills/create-worktree/SKILL.md:145-147`). PR head 브랜치명에는 보통 PR
+번호가 아니라 원 이슈 번호가 들어 있어, PR을 리뷰할 때 창을 PR 번호로 찾을 수 없다.
+
+**한계 2 — 대상 세션을 지정할 수 없어 불필요한 이동이 발생한다.** 이슈 #35가 기록한
+실제 사례에서 사용자가 `2-review`를 명시했음에도 현행 스킬은 `1-main`에 창을 연 뒤
+`move-window-to-session` 전체 절차를 밟아야 했다. 처음부터
+`--parent-session 2-review`를 쓰면 전부 불필요한 작업이다.
+
+**선행 실행의 결과.** 같은 목표의 quality-goal 실행이 두 번 있었다.
+
+| 실행 | 산출물 | 점수 | 블로커 | Critical/High | 종료 |
+|---|---|---|---|---|---|
+| 1차 | `docs/development/2026-08-27-create-worktree-pr-session/` | 75 → 82 | 3 → 0 | 3 → 2 | NEEDS_REDESIGN |
+| 2차 | `docs/development/2026-08-27-create-worktree-pr-session-2/` | 80 → 88 | 0 → 0 | 0 → 0 | NEEDS_REDESIGN |
+
+2차는 점수(88 ≥ 85)와 심각도(Critical/High 0) 기준을 모두 충족했고, 게이트 실패 사유는
+`verdict_not_pass`와 `check_failed:acceptance_criteria_objective` 두 가지였다. 남은
+Medium 2건은 SPEC-009(AC-9의 판별력)와 SPEC-010(`--pr` 인자 정규화)이다. 이 Spec은 2차
+개정본을 기반으로 그 둘을 선반영한다.
+
+### 이 Spec의 증거 규율 — 휘발성 식별자 금지
+
+1차·2차 Spec은 특정 worktree(디렉터리명 `feat-quality-goal-skill`, 브랜치
+`chore/post-upgrade-skill-maintenance`)를 R2.0·R7.1·D4의 근거로 인용했다. **그
+worktree는 그 뒤 제거되어 근거가 죽었다.** 같은 실패를 반복하지 않기 위해 이 Spec은
+다음을 지킨다.
+
+- 특정 worktree 디렉터리명·브랜치명, tmux `pane_id`(`%N`)·`window_id`(`@N`)·
+  `세션:번호`를 **증거나 수용 기준의 고정 대상으로 쓰지 않는다.** 이들은 작업이 끝나면
+  사라지거나 창을 옮기면 바뀐다.
+- 증거는 **재현 가능한 명령과 그 출력 형태**, 또는 저장소에 커밋된 파일의 인용으로
+  한정한다.
+- 실행 검증이 특정 조건의 worktree를 필요로 하면, 기존 것을 찾아 쓰지 않고 **테스트가
+  직접 만들고 검증 후 제거한다**(Test strategy 0차). 만들 수 없으면 조건부 증거로
+  강등하고 잔여 격차를 기록한다.
+
+이 규율 자체가 SPEC-009 해소의 일부다 — AC-9이 "지금 존재하는 어떤 worktree"에
+의존하면 그 worktree가 사라지는 순간 다시 죽는다.
+
+### 측정된 사실 (2026-08-27 실측, 재현 가능)
+
+아래는 모두 명령 하나로 재현되며 특정 worktree의 존속에 의존하지 않는다.
+
+| 사실 | 관찰 명령 | 결과 |
+|---|---|---|
+| workmux 버전 | `workmux --version` | `workmux 0.1.248` |
+| `--pr` 플래그와 그 계약 | `workmux add --help` | `--pr <NUMBER\|URL>` — **번호 또는 URL만 받는다** |
+| `--pr`와 positional | `workmux add --help` | "`[BRANCH_NAME]` ... When used with `--pr`, this becomes the custom local branch name" |
+| `add`의 이름·세션 플래그 | `workmux add --help` | `--name`("Explicit name for the worktree directory and tmux window"), `--target-name`, `--parent-session`, `--dry-run` |
+| `workmux open`의 `--pr` 부재 | `workmux open --help` | `--pr` 없음. `--target-name`, `--parent-session`은 있음 |
+| `workmux list --json` | `workmux list --help` | `--json  Output as JSON` |
+| JSON 필드 | `workmux list --json` | 각 항목에 `handle`, `path`, `branch`, `is_open`, `mode`, `is_main`, `project` |
+| **workmux git config 키 네임스페이스** | `git config --get-regexp '^workmux\.worktree\.'` | handle 하나당 최대 4개 하위 키: `.mode`, `.target-window`, `.window-session`, `.window-token` |
+| **키는 공유 저장소 config에 있다** | 같은 명령을 메인 worktree와 각 worktree에서 실행 | **세 곳에서 출력이 완전히 동일** — worktree별로 분리되지 않는다 |
+| **`target-window` 저장값은 실제 tmux 창 이름이다** | 아래 "`target-window` 의미 확인" 절차 | 저장값이 `tmux list-windows -a` 창 이름 목록에 존재했고, 같은 worktree의 `handle`과는 **달랐다** |
+| tmux 세션 | `tmux list-sessions -F '#{session_name}'` | `1-main`, `2-review`, `3-personal`, `4-eslint`, `5-quick` |
+| dotfiles git-crypt | `git config --get filter.git-crypt.smudge` | 값 없음. 래퍼도 없음 |
+| zambaguni-front git-crypt | 같음 | `"git-crypt" smudge`. 래퍼 존재 |
+| 현재 저장소 판정 | `gh repo view --json owner,name -q '.owner.login + "/" + .name'` | `lee-kyu-hwan/dotfiles` |
+| PR #31 | `gh pr view 31 --json state,headRefName,headRefOid` | `OPEN`, `30-enhancement/tmux-open-pr-shortcut`, `9cfc6267ced574945814536710cf1019a37dc354` |
+| PR #31 원격 head / pull ref | `git ls-remote origin '...'` / `'refs/pull/31/head'` | 둘 다 `9cfc6267...` |
+| PR #32 | `gh pr view 32 --json state,headRefName` | `OPEN`, `feat/codex-playwright-e2e-profile` (숫자 접두사 없음) |
+| tmux 서버 부재 | `tmux -L quality-goal-nonexistent-socket list-sessions` | exit 1 + `error connecting to ...` |
+| 없는 세션 판정 | `... \| grep -qxF -- 'definitely-not-a-session'` | exit 1 |
+| `has-session` 접두사 함정 | `tmux has-session -t 2` / `-t 2-rev` | 둘 다 exit 0 (그런 세션 없음) |
+| 같은 조건 `grep -qxF` | `... \| grep -qxF -- '2-rev'` | exit 1 (올바름) |
+| `quick_validate.py` (dot_agents) | 아래 "frontmatter 검증" | `Skill is valid!`, exit 0 |
+| `quick_validate.py` (dot_claude) | 같음 | `Unexpected key(s) ... argument-hint, user-invocable`, **exit 0** |
+| 현재 `description` | `sed -n 3p` 두 파일 | 양쪽 동일: "Use when creating a new git worktree for a branch to work on in isolation from the main workspace" |
+
+**공유 config 사실의 의미(SPEC-009의 근거).** `git config --get-regexp
+'^workmux\.worktree\.'`는 실행 위치와 무관하게 저장소의 **모든** workmux worktree 키를
+돌려준다. 따라서 "출력의 모든 키가 테스트 대상 handle 기준이어야 한다"는 판정은 다른
+worktree가 하나라도 있으면 올바른 구현에도 실패한다. AC-9은 테스트 대상 handle로
+범위를 좁혀 판정한다.
+
+### `target-window` 의미 확인 (R7.1 3단계의 근거)
+
+특정 worktree 이름을 박지 않고, **열려 있는 worktree가 있으면 그것을 골라** 확인하는
+절차다. 대상이 없으면 이 확인은 수행되지 않으며, 그때 R7.1은 3단계를 건너뛴다(아래
+"저장값 부재·스테일 처리").
+
+```bash
+H=$(workmux list --json | python3 -c \
+  "import json,sys; r=[w for w in json.load(sys.stdin) if w['is_open'] and not w['is_main']]; print(r[0]['handle'] if r else '')")
+[ -n "$H" ] || echo "열린 worktree 없음 — 이 확인은 조건부"
+git config --get "workmux.worktree.$H.target-window"      # 저장값
+tmux list-windows -a -F '#{window_name}'                   # 이 목록에 저장값이 있는지
+```
+
+2026-08-27 실측: 저장값이 창 이름 목록에 **존재**했고, 같은 worktree의 `handle`과는
+**달랐다**. 즉 `target-window`는 workmux가 창을 만들 때 기록해 둔 실제 창 이름이며,
+handle에서 파생되지 않는다. R7.1이 이 값을 읽는 것은 유추가 아니라 저장값 조회다.
+
+### `workmux add`의 이름 파생 (dry-run 실측, 영속 변경 없음)
+
+`--dry-run`은 아무것도 만들지 않고 결과만 보여 준다. PR #31에 대해 세 조합을 실행했다.
+
+| 명령 | Worktree 디렉터리 = handle | Target (창 이름) |
+|---|---|---|
+| `workmux add --pr 31 --dry-run` | `30-enhancement-tmux-open-pr-shortcut` | `30-enhancement-tmux-open-pr-shortcut` |
+| `workmux add --pr 31 --target-name 31-tmux-open-pr-shortcut --dry-run` | `30-enhancement-tmux-open-pr-shortcut` | **`31-tmux-open-pr-shortcut`** |
+| `workmux add --pr 31 --name pr31-fixture --dry-run` | **`pr31-fixture`** (출력에 `Handle: pr31-fixture` 줄이 추가됨) | `pr31-fixture` |
+
+세 가지가 확정된다.
+
+1. **기본 handle은 브랜치 슬러그다** — 브랜치의 `/`를 `-`로 바꾼 형태. 이 저장소에는
+   `worktree_naming` 설정이 없어 기본 전략이 적용된 결과다.
+2. **`--target-name`을 주면 handle과 창 이름이 갈라진다.** 2행이 직접 사례다 — handle은
+   `30-enhancement-...`인데 창 이름은 `31-...`이다. 스킬이 PR 모드에서 반드시 쓰는
+   조합이므로(R5.3) **이 분기는 구조적으로 항상 발생한다.**
+3. **`--name`으로 handle을 브랜치 슬러그와 다르게 만들 수 있다.** 3행이 사례다. 이것이
+   AC-9의 자기 완결 픽스처를 가능하게 한다 — 기존 worktree를 찾을 필요가 없다.
+
+### 래퍼 스크립트의 브랜치 판별
+
+`zambaguni-front/scripts/create-worktree.sh:82-98` 실측. 래퍼는
+`git fetch --prune origin` 후 3단계로 판별한다.
+
+1. `refs/remotes/origin/{BRANCH}`가 있으면 → tracking 브랜치 모드
+2. `refs/heads/{BRANCH}`가 있으면 → 기존 로컬 브랜치 모드
+3. **둘 다 없으면 → 현재 HEAD 기준으로 새 브랜치 생성 (`-b`)**
+
+3번이 결정적이다. 같은 저장소 PR이면 래퍼 자신의 fetch가 `origin/{head}`를 만들어 1번이
+적용되지만, **fork PR의 head 브랜치는 `origin`에 없다.** `git fetch --prune origin`은
+`refs/pull/*/head`를 가져오지 않으므로 3번으로 떨어져 **PR 내용이 전혀 없는 빈 브랜치를
+현재 HEAD에서 만들고** 겉보기에 성공한 worktree를 남긴다. 이 실패는 조용하다.
+
+## Goals
+
+1. PR 참조를 입력하면 PR 번호로 식별되는 리뷰용 worktree 윈도우를 만든다. 창 이름은
+   PR head 브랜치의 이슈 번호가 아니라 PR 번호를 쓴다.
+2. 대상 tmux 세션을 호출 시 지정할 수 있게 하고, 지정된 세션에 처음부터 직접 창을
+   만들어 `1-main` 경유 이동을 없앤다.
+3. 세션 선택 규칙을 결정적 우선순위로 일반화하고, Claude와 Codex 두 원본이 동일하게
+   읽게 한다.
+4. worktree 식별과 창 탐지를 이름 유추가 아닌 안정 식별자로 규정해, 잘못된 git config
+   키와 중복 창 생성을 막는다.
+5. 현행 스킬의 기존 규칙을 회귀 없이 보존한다. 보존 대상은 R9.6에 열거하고 AC-57로
+   검증한다.
+6. 유령 세션, 저장소 불일치, 브랜치 충돌, PR 내용이 없는 빈 worktree, 사라진 저장
+   세션을 부작용이 생기기 전에 차단하거나 복구 경로를 제공한다.
+
+## Non-goals
+
+- tmux 세션 자동 생성. 선택 세션이 없으면 중단하거나 확인받는다(R2.5).
+- workmux session mode 전환(`--session`, `--mode session`)이나 pane 레이아웃 변경.
+- `move-window-to-session` 스킬 내부 동작·입력 계약 변경. 그 스킬이 **받아들이는 형식
+  으로** 인자를 맞춰 호출한다(R7.5).
+- `remove-worktree` 스킬 변경.
+- 대상 저장소의 `scripts/create-worktree.sh` 래퍼 수정. 3단계 판별은 그대로 두고
+  스킬이 호출 전에 전제를 보장한다.
+- workmux의 `worktree_naming` 설정 변경. handle 파생 규칙은 workmux에 맡기고 읽기만
+  한다.
+- **스킬 본문에서 `--name` 사용.** `--name`은 Test strategy 0차 픽스처를 만드는 데만
+  쓰고, 실제 생성 경로(R6.3)는 기본 명명을 그대로 따른다.
+- 개발 서버나 에이전트 자동 실행.
+- PR 리뷰 자체의 수행.
+- `review/pr-{번호}` 같은 별칭 브랜치 생성.
+- GitHub 쓰기 작업(코멘트, 라벨, 상태 변경).
+- `workmux` 자체의 기능 추가나 버그 수정.
+- 선행 실행 산출물(1차·2차 디렉터리) 수정. baseline의 initial dirty path로 기록되어
+  보존된다.
+- quality-goal 스킬 자체의 결함(#43, #44) 수정. 별도 이슈로 추적된다.
+
+## Requirements
+
+### R1. 입력 규격
+
+- **R1.1** 첫 번째 positional 인자는 브랜치명 또는 PR 참조이며 필수다. 비어 있으면
+  사용자에게 물어본다.
+- **R1.2** 두 번째 positional 인자는 정확한 tmux 세션명이며 선택이다.
+- **R1.3** 세 번째 이상의 positional 인자가 오면 추측하지 말고 사용법을 안내하고
+  중단한다. positional 형태 호출에만 적용된다(R1.6 참조).
+- **R1.4** PR 모드는 다음 형태에서만 자동 선택된다.
+  - 전체 GitHub PR URL: `https://github.com/{owner}/{repo}/pull/{번호}`
+  - `{owner}/{repo}#{번호}` 형식
+  - 자연어 문장에서 숫자 앞뒤에 PR 표지가 있는 경우 ("PR 1313", "1313번 PR",
+    "pull request 1313")
+- **R1.5** 표지 없는 맨 숫자(`1313`)는 PR 참조로 보지 않는다. GitHub는 이슈와 PR이
+  번호 공간을 공유하므로 맨 숫자를 PR로 단정하면 엉뚱한 대상을 체크아웃할 수 있다.
+  표지가 없으면 브랜치 모드로 해석하거나, 브랜치로도 해석되지 않으면 확인한다.
+- **R1.6** 자연어 호출은 `(브랜치명|PR참조, 대상세션)` 2-튜플로 환원한다.
+  - 첫 요소: 문장에서 발견된 브랜치명 또는 R1.4 형태의 PR 참조. 두 개 이상이면 중단
+    하고 확인한다.
+  - 둘째 요소: 문장에서 발견된 tmux 세션명. 두 개 이상이면 중단하고 확인한다.
+  - 환원 결과가 2-튜플을 넘지 않으므로 R1.3의 중단은 자연어 호출에서 발동하지 않는다.
+- **R1.7** 세션명을 접두사로 보정하거나 존재하는 세션 목록에서 추측하지 않는다.
+- **R1.8** Claude frontmatter의 `argument-hint`는
+  `<branch-name|pr-ref> [target-session]`로 갱신한다.
+
+### R2. worktree 식별자와 세션 선택
+
+- **R2.0 워크트리 식별자 정의.** workmux git config 키의 `{이름}` 자리는 **workmux
+  worktree handle**이며 다음으로 얻는다.
+
+  ```bash
+  workmux list --json    # 각 항목의 handle 필드
+  ```
+
+  기본 설정에서는 `handle`이 `path` 필드의 basename과 같지만 **보장되지 않는다** —
+  `worktree_naming`이나 `worktree_prefix` 설정이 바뀌면 어긋날 수 있다. 그래서
+  basename은 폴백일 뿐이고(D4 대안 C), 평상시에는 `handle`을 읽는다.
+
+  workmux는 handle 하나당 최대 네 개의 하위 키를 쓴다 — `.mode`, `.target-window`,
+  `.window-session`, `.window-token`(실측). 이 스킬이 읽고 쓰는 것은
+  `.window-session`이고, `.target-window`는 R7.1이 읽기 전용으로 참조한다.
+
+  **브랜치명이나 tmux 창 이름에서 유추하면 안 된다.**
+
+  - 브랜치 유추가 위험한 이유: handle은 브랜치 슬러그와 같을 수도(기본 명명) 다를 수도
+    (`--name` 지정, 또는 `worktree_naming` 설정) 있어 **규칙으로 예측할 수 없다.**
+    dry-run 실측이 양쪽 사례를 모두 보인다(위 표).
+  - 창 이름 유추가 위험한 이유: PR 모드는 `--target-name`을 반드시 쓰므로(R5.3) handle과
+    창 이름이 **구조적으로 항상 갈라진다.** dry-run 2행이 그 사례다.
+
+  틀린 키를 넘겨도 git은 오류 없이 새 섹션을 만들고 진짜 키는 옛 값을 유지하므로
+  (`move-window-to-session/SKILL.md:104-108`), 읽기는 빈 값을 주고 쓰기는 조용히
+  실패한다. 그 결과 R2 우선순위 2가 빈 값으로 떨어져 R2.1이 막으려던 실패가 재발한다.
+
+  `workmux list --json`을 쓸 수 없으면 worktree 절대경로의 basename을 폴백으로 쓰되,
+  `path` 필드와 대조해 확인한다. 대조할 수단조차 없으면 중단한다.
+
+세션(`SELECTED_SESSION`)은 다음 순서로 결정한다.
+
+1. 사용자가 이번 호출에서 명시한 대상 세션
+2. 기존 worktree의 `workmux.worktree.{handle}.window-session` 값이 `^[0-9]+-.+$`를
+   만족하고 **그 세션이 실제로 존재할 때** 그 값 (R2.5)
+3. 입력 모드 기본값 — PR 모드이면 `2-review`
+4. 전역 기본값 `1-main`
+
+- **R2.1** 저장값이 모드 기본값보다 우선한다. 저장값은 사용자가 직접 창을 옮긴 행동의
+  기록이고 모드 기본값은 관습이다. 관습이 기록을 덮으면 현행 "예외 1"이 막으려던
+  실패가 `2-review` 이름으로 재발한다.
+- **R2.2** 저장값이 `^[0-9]+-.+$`를 만족하지 않으면 레거시 값으로 보고 우선순위 2에서
+  제외하며, **R2.6이 정한 대상 세션으로** 갱신한다. 판정은 셸 glob(`[0-9]*-*`)이 아니라
+  정규식으로 한다 — glob의 첫 `*`는 임의 문자열이라 `1legacy-session`이나 `1-`가
+  통과한다.
+- **R2.3 영속 변경 명령의 순서 제약.** 선택 세션이 확정되기 전에는 **영속 변경을 만드는
+  workmux 명령**(`workmux add`, `open`, `remove`, `close`)을 실행하지 않는다. 읽기 전용
+  조회(`workmux list --json`)와 `--dry-run`은 예외이며, R7.0·R7.1·R6.9가 세션 선택보다
+  먼저 이들을 쓴다. 금지 대상을 열거하지 않고 "어떤 workmux 명령도"로 적으면 문서가
+  자기모순이 된다.
+- **R2.4** 명시 세션(우선순위 1)이 유효한 저장값(우선순위 2)을 덮은 경우, 창을 연 뒤
+  `workmux.worktree.{handle}.window-session`이 명시 세션을 가리키는지 확인하고 다르면
+  갱신한다. 갱신하지 않으면 다음번 세션 미명시 호출이 옛 세션으로 되돌아간다.
+- **R2.5 사라진 저장 세션의 복구.** 저장값이 형식은 유효하나 그 세션이 지금 존재하지
+  않으면(닫혔거나 이름이 바뀜) 막다른 길이 되지 않게 한다. 우선순위 2를 건너뛰고
+  다음을 수행한다.
+
+  1. 저장값이 가리키는 세션이 사라졌음을 그 값과 함께 사용자에게 알린다.
+  2. 우선순위 3·4로 결정되는 세션을 제시하고 확인받는다.
+  3. 확인되면 그 세션으로 진행하고 **R2.6이 정한 대상 세션으로** `window-session`을
+     갱신한다.
+  4. 세션을 자동 생성하지 않는다.
+
+  이 규칙이 없으면 R3.5의 무조건 중단이 매 호출마다 반복되어 자기 교정 경로가 없다.
+  스킬이 `window-session`을 직접 쓰는 것은 R2.2·R2.4·R2.5·R8.2 네 곳뿐이다.
+
+- **R2.6 `window-session` 갱신 대상.** R2.2·R2.5가 저장값을 갱신할 때, 무엇으로 쓸지는
+  **창이 실제로 어디 있는지**에 따라 갈린다. 무조건 `SELECTED_SESSION`으로 쓰면 안 된다.
+
+  | 상태 | 갱신 대상 |
+  |---|---|
+  | 창이 닫혀 있다(`is_open` 거짓) | `SELECTED_SESSION` — 그 세션에 새로 열 것이므로 일치한다 |
+  | 창이 열려 있고 그 세션으로 옮긴다(R7.5) | `SELECTED_SESSION` — 이동 후 위치와 일치한다. 실제 쓰기는 `move-window-to-session`이 수행하므로 R2.4는 확인으로 동작한다 |
+  | **창이 열려 있고 옮기지 않는다(R7.3·R7.4)** | **R7.1이 확정한 창의 실제 세션** |
+
+  세 번째 행이 핵심이다. 저장값이 레거시(R2.2)이거나 사라진 세션을 가리키면(R2.5) 우선
+  순위 2가 건너뛰어져 `SELECTED_SESSION`은 우선순위 3·4의 값(`2-review` 또는 `1-main`)이
+  된다. 그런데 사용자가 세션을 명시하지 않았으면 R7.4가 창을 옮기지 않는다. 이때
+  `SELECTED_SESSION`으로 갱신하면 **창은 세션 X에 있는데 config는 `2-review`를 가리키는**
+  어긋남이 생기고, 그것은 R2.0·R2.4가 막으려던 바로 그 상태를 스킬이 스스로 만드는
+  것이다. 다음 호출마다 같은 어긋남이 재생산되며 자기 교정 경로가 없다.
+
+  창이 열려 있는데 R7.1이 실제 세션을 확정하지 못했으면(R7.1 불일치 처리) 갱신하지
+  않는다. 잘못된 값을 쓰는 것보다 옛 값을 두고 사용자에게 알리는 편이 안전하다.
+
+### R3. tmux 세션 검증
+
+- **R3.1** `tmux list-sessions -F '#{session_name}'`을 단독 실행해 종료 코드를 먼저
+  확인한다.
+- **R3.2** exit 1과 `error connecting to ...`이면 tmux 서버 부재로 보고하고 중단한다.
+  "세션이 없다"와 구분한다.
+- **R3.3** 목록 조회 성공 후 `grep -qxF -- "$SELECTED_SESSION"`으로 전체 문자열 일치를
+  확인한다.
+- **R3.4** `has-session -t`를 쓰지 않는다. 접두사 매칭 때문에 `has-session -t 2`와
+  `-t 2-rev`가 모두 exit 0이다(실측).
+- **R3.5** 선택 세션이 없으면 자동 생성하지 않는다. 저장값에서 온 경우는 R2.5의 복구
+  경로를 타고, 사용자가 명시한 경우는 오타 가능성을 알리고 중단한다. workmux는 존재
+  하지 않는 `--parent-session` 값을 오류 없이 받아 세션을 만들고 git config에 영구
+  저장하므로, 이 검사가 유일한 안전망이다.
+- **R3.6** 현행의 "`1-main` 존재 확인"은 "선택 세션 존재 확인"으로 일반화한다.
+
+### R4. PR 참조 해석
+
+- **R4.0 저장소 판정.** PR 참조에서 `{owner}/{repo}`를, 현재 작업 대상에서 현재
+  저장소를 각각 확정한다. 둘 다 이름이 있어야 R4.2의 비교가 성립한다.
+
+  | 입력 형태 | `{owner}/{repo}` 출처 |
+  |---|---|
+  | 전체 PR URL | URL 경로의 `{owner}/{repo}` |
+  | `{owner}/{repo}#{번호}` | 문자열 그대로 |
+  | 표지 있는 자연어 (`PR 1313`) | 명시되지 않았으므로 **현재 저장소로 간주** |
+
+  현재 저장소는 다음으로 얻는다.
+
+  ```bash
+  gh repo view --json owner,name -q '.owner.login + "/" + .name'
+  ```
+
+  이 명령이 실패하면 `git remote get-url origin`을 폴백으로 쓰고 `{owner}/{repo}`를
+  파싱한다. 둘 다 실패하면 저장소를 확정할 수 없으므로 중단한다.
+- **R4.1** PR 번호, head 브랜치명, head 커밋 OID, 상태를 조회한다.
+
+  ```bash
+  gh pr view {번호} --repo {owner}/{repo} --json number,state,headRefName,headRefOid
+  ```
+
+  조회 필드는 소비되는 것만 요청한다 — `number`·`headRefName`·`headRefOid`는 이름
+  파생과 검증에, `state`는 R4.7에 쓰인다. base 저장소는 R4.0에서 이미 확정되므로 별도
+  필드가 필요 없고, fork 여부는 R4.6의 pull ref가 균일하게 처리한다.
+- **R4.2** R4.0의 `{owner}/{repo}`와 현재 저장소가 다르면 중단한다. 자연어 형태는
+  현재 저장소로 간주되므로 이 비교가 자동으로 통과한다.
+- **R4.3** PR head 브랜치의 worktree가 이미 있으면 **새 worktree를 만들지 않는다.**
+  별칭 브랜치도 만들지 않는다. 생성 단계만 건너뛰고 R7의 창 처리로 넘어간다. 전체
+  작업 중단이 아니다.
+- **R4.4** 같은 이름의 로컬 브랜치가 있는데 R4.1의 head OID와 다른 커밋을 가리키면
+  덮어쓰지 않고 중단한다.
+- **R4.5** `gh`가 없거나 인증되지 않았거나 조회가 실패하면 보고하고 중단한다. 추측
+  하지 않는다.
+- **R4.6 PR head 브랜치 확보.** worktree를 새로 만들기 전에 PR head 커밋이 로컬에서
+  `{head브랜치명}`으로 도달 가능함을 보장한다. 래퍼는 브랜치가 로컬과 `origin` 양쪽에
+  없으면 현재 HEAD에서 빈 브랜치를 만들므로(래퍼 82-98행), 이 보장 없이 래퍼를 부르면
+  PR 내용이 없는 worktree가 조용히 생긴다.
+
+  ```bash
+  # 로컬 브랜치가 이미 있으면 R4.4의 OID 비교로 판정이 끝나 있다.
+  # 없을 때만 pull ref에서 가져온다. fork PR도 이 ref로 동일하게 처리된다.
+  git fetch origin "refs/pull/{PR번호}/head:{head브랜치명}"
+  git rev-parse --verify "refs/heads/{head브랜치명}"   # == R4.1의 headRefOid
+  ```
+
+  fetch 실패나 OID 불일치면 중단하고 래퍼를 부르지 않는다. 래퍼 없는 경로는
+  `workmux add --pr`가 체크아웃을 직접 하므로 사전 fetch 대신 사후 검증(R6.8)으로 같은
+  보장을 얻는다.
+- **R4.7 PR 상태 처리.** `state`가 `OPEN`이 아니면(`CLOSED`, `MERGED`) 알리고 계속할지
+  확인한다. 자동 중단하지 않는다 — 머지된 PR을 사후에 들여다보는 것은 정당한 용도다.
+  다만 head 브랜치가 삭제되었을 수 있으므로 R4.6의 fetch 실패 가능성을 함께 안내한다.
+- **R4.8 PR 참조 정규화.** `workmux add --pr`의 계약은 `<NUMBER|URL>`이다(실측). R1.4가
+  허용하는 세 형태 중 `{owner}/{repo}#{번호}`와 표지 있는 자연어는 그대로 넘기면
+  workmux가 거부한다. **`--pr`에 넘기기 전에 R4.0·R4.1이 확정한 값으로 환원한다.**
+
+  | 조건 | `--pr`에 넘기는 값 |
+  |---|---|
+  | R4.0의 `{owner}/{repo}` == 현재 저장소 | R4.1의 `{번호}` (숫자만) |
+  | 그 외 | R4.2에서 이미 중단되므로 해당 없음 |
+
+  R4.2가 저장소 불일치를 중단시키므로 `--pr`에 도달하는 값은 항상 현재 저장소의 PR
+  번호다. 따라서 URL 형태를 넘길 필요가 없다. 원시 사용자 입력을 그대로 전달하지
+  않는다.
+
+### R5. 윈도우 이름 파생
+
+- **R5.1** 짧은 이름은 브랜치명(PR 모드에서는 PR head 브랜치명)에서 마지막 `/`까지를
+  제거한 부분이다. `392-feat/add-partner-chat-enabled` → `add-partner-chat-enabled`.
+- **R5.2** 브랜치 모드에서 이슈 번호는 브랜치명 맨 앞의 숫자 또는 `ZF-숫자`만 인식한다.
+- **R5.3** PR 모드의 윈도우 이름은 `{PR번호}-{짧은이름}`이다. PR head 브랜치가 이슈
+  번호로 시작하더라도 PR 번호를 쓴다.
+- **R5.4** 브랜치 모드에서 이슈 번호가 없으면 `--target-name`을 생략한다.
+- **R5.5** workmux가 target name을 소문자로 정규화하므로, 안내와 재사용에 쓰는 이름은
+  정규화된 소문자다.
+- **R5.6** 창 이름 충돌 시 재시도 이름은 모드별로 다르다.
+  - 브랜치 모드: `{repo명}-{짧은이름}` (현행 규칙 유지)
+  - PR 모드: `{PR번호}-{repo명}-{짧은이름}` — PR 번호를 보존한다.
+
+### R6. 생성·오픈 경로
+
+- **R6.1** 경로 분기는 저장소 루트(`git rev-parse --show-toplevel`) 기준으로
+  `scripts/create-worktree.sh` 존재 여부로 판정한다. 상대 경로로 판정하면 서브디렉터리
+  나 기존 worktree 안에서 부를 때 false가 된다.
+- **R6.2** git-crypt 저장소에서 `workmux add`를 쓰지 않는다. PR 모드도 마찬가지다.
+- **R6.3** 래퍼 없는 저장소의 PR 모드는 positional 브랜치명을 생략하고, `--pr`에는
+  R4.8이 정규화한 **PR 번호**를 넘긴다.
+
+  ```bash
+  workmux add --pr {PR번호} \
+    --target-name {PR번호}-{짧은이름} \
+    --parent-session {선택세션}
+  ```
+
+  positional을 주면 그것이 커스텀 로컬 브랜치명이 되어 PR head 브랜치가 쓰이지 않는다.
+  `--name`은 쓰지 않는다 — 기본 명명을 그대로 두어야 R6.9의 handle 확보가 실제 상황을
+  검증한다. `--target-name`과 `--parent-session`이 `--pr`와 공존 가능함은
+  `workmux add --help` 실측으로 확인했다.
+- **R6.4** 래퍼 있는 저장소의 PR 모드는 R4.6으로 head 브랜치를 확보한 뒤 실행한다.
+
+  ```bash
+  ./scripts/create-worktree.sh {head브랜치명}
+  workmux open {handle} \
+    --target-name {PR번호}-{짧은이름} \
+    --parent-session {선택세션}
+  ```
+
+- **R6.5** 래퍼가 실패하면 종료 코드를 확인해 중단하고 `workmux open`으로 넘어가지
+  않는다. 확인 프롬프트를 `-y`나 `yes |`로 우회하지 않는다. 실행 권한이 없으면 경로를
+  바꾸지 말고 오류로 보고한다.
+- **R6.6** 모든 `workmux add`/`workmux open` 예시가 고정 `1-main`이 아니라 선택 세션
+  변수를 쓴다.
+- **R6.7** `--parent-session` 미지원 조합(session mode, 샌드박스 안, `--count`,
+  `--foreach`, 여러 `--agent`, stdin)에서는 플래그를 생략한다.
+- **R6.8 PR worktree 내용 검증.** 생성 직후 worktree의 HEAD가 R4.1의 `headRefOid`와
+  같은지 확인한다. 다르면 PR 내용이 없는 worktree이므로 성공으로 보고하지 않는다.
+- **R6.9 경로·handle 확보.** 생성 후 worktree 경로와 handle을 명령 출력에서 얻는다.
+  경로나 이름을 추측하지 않는다.
+  - 래퍼 경로: 래퍼가 출력하는 worktree 절대경로를 쓴다. handle은
+    `workmux list --json`에서 `path`가 그 경로와 같은 항목의 `handle`이다.
+    **폴백**: 래퍼가 만든 worktree가 아직 `workmux list --json`에 나타나지 않을 수
+    있다(이 전제는 스모크 테스트에서 검증되지 않는다 — git-crypt 경로 제외). 그때는
+    래퍼 출력 경로의 basename을 쓰되 `git worktree list --porcelain`에 그 경로가 있는지
+    대조하고, 그 값으로 `workmux open`을 실행한 뒤 R8.1에서 실제 창을 재확인한다.
+  - `workmux add --pr` 경로: 생성 후 `workmux list --json`에서 `branch`가 PR head
+    브랜치와 일치하는 항목의 `handle`과 `path`를 읽는다. workmux의 디렉터리 명명은
+    `worktree_naming` 설정에 좌우되므로 규칙으로 추정하지 않는다.
+  - 실행 전 `workmux add ... --dry-run`으로 예상 경로·handle을 미리 볼 수 있다.
+    영속 변경이 없으므로 확인용으로 쓴다.
+  - `workmux open`은 `git worktree list`로 worktree를 찾으므로 `worktree_dir` 밖의
+    형제 디렉터리도 그대로 인식한다(현행 규칙 유지).
+- **R6.10 git-crypt 필터가 있으나 래퍼가 없는 저장소.** 현행 규칙을 유지한다 —
+  `filter.git-crypt.smudge` 값이 있는데 `scripts/create-worktree.sh`가 없으면
+  사용자에게 확인받고 진행한다(`dot_claude/skills/create-worktree/SKILL.md:106`).
+  R6.1의 분기가 래퍼 존재 여부만 보므로, 이 확인 없이는 R6.2가 금지하는
+  `workmux add` 경로로 조용히 들어간다.
+
+### R7. 기존 worktree 상태별 동작
+
+- **R7.0 worktree 존재·경로 판정.** 세션 선택(R2)보다 먼저 대상 브랜치의 worktree
+  존재 여부와 경로를 확정한다. 저장 세션을 읽으려면 handle이 필요하고, handle은
+  `workmux list --json`에서 경로로 찾기 때문이다.
+
+  ```bash
+  git worktree list --porcelain   # branch refs/heads/{브랜치명} 항목의 worktree 경로
+  workmux list --json             # 그 경로와 일치하는 항목의 handle
+  ```
+
+- **R7.1 창 열림 여부와 위치 판정.** 창이 열려 있는지, 어느 세션·어느 창인지를
+  **파생한 이름이 아니라 저장된 값과 안정 식별자로** 판정한다.
+
+  1. **열림 여부** — `workmux list --json`에서 해당 handle 항목의 `is_open`.
+  2. **세션** — `git config --get workmux.worktree.{handle}.window-session`.
+  3. **창 이름** — `git config --get workmux.worktree.{handle}.target-window`.
+     이것은 workmux가 창을 만들 때 **저장해 둔** 이름이며, 이번 호출이 R5에서 파생하는
+     이름과 다를 수 있다. 저장값을 읽는 것이지 유추가 아니다.
+  4. **실제 창·pane 확정** — 위 세션과 창 이름으로 후보를 좁힌 뒤, pane의 작업
+     디렉터리로 교차 확인한다.
+
+     ```bash
+     tmux list-panes -a -F '#{session_name}:#{window_index} #{window_id} #{pane_id} #{pane_current_path}' \
+       | awk -v wt="{worktree절대경로}" '$4 == wt || index($4, wt"/") == 1'
+     ```
+
+     같은 worktree의 pane이 여러 개면 같은 `window_id`가 여러 줄로 나온다. `window_id`
+     기준으로 중복을 제거해 창 단위로 센다.
+
+  **이번 호출이 파생한 창 이름으로 매칭하지 않는다.** PR 모드는 `--target-name`을 반드시
+  쓰므로 handle과 창 이름이 구조적으로 갈라지고(dry-run 실측 2행), 같은 worktree를
+  브랜치 모드로 먼저 만들었다면 저장된 창 이름은 이번에 파생할 이름과 또 다르다. 파생한
+  이름으로 찾으면 열려 있는 창을 놓치고 R7.3의 중복 창 금지가 조용히 실패한다.
+
+  **확보한 `window_id`(`@N`)와 `pane_id`(`%N`)를 이후 조작의 기준으로 삼는다.** 둘은
+  `move-window`로 바뀌지 않는 반면 `session:index`는 바뀐다
+  (`move-window-to-session/SKILL.md:32-39`). 다만 이들은 **런타임 값이며 창을 닫으면
+  사라지므로** 이 문서에 특정 값을 적어 두지 않는다.
+
+  **매칭기의 한계.** 위 `awk`는 공백으로 필드를 나누므로 **worktree 경로에 공백이 있으면
+  동작하지 않는다.** pane의 cwd는 사용자가 `cd`로 바꿀 수도 있다. 두 경우 모두 아래
+  불일치 처리로 넘어간다.
+
+  **저장값 부재·스테일 처리.** 2단계(`window-session`)나 3단계(`target-window`) 값이
+  없거나 실제와 어긋날 수 있다 — workmux가 handle당 쓰는 키는 **최대** 네 개이고, 창을
+  수동으로 옮기거나 이름을 바꾸면 저장값이 뒤처진다. 다음을 따른다.
+
+  - 2·3단계 중 하나라도 조회가 exit 1이면 그 단계를 **후보 좁히기에서 제외**하고, 남은
+    단서와 4단계 pane 경로 매칭만으로 진행한다.
+  - 둘 다 없으면 4단계 단독으로 진행한다. 이때 매칭이 정확히 1건이면 그 창을 쓰되,
+    저장값이 없었다는 사실을 결과 보고에 남긴다.
+  - 4단계 매칭 결과가 2·3단계 값과 어긋나면(예: 저장 세션과 실제 세션이 다름) **실측인
+    4단계를 신뢰하고** 그 차이를 보고한다. R2.6이 그 실제 세션으로 갱신을 지시한다.
+
+  **불일치 처리.** `is_open`이 참인데 4단계 매칭이 0건이면 추측하지 말고, 2단계의
+  세션과 3단계의 창 이름을 근거로 후보를 사용자에게 보여 주고 확인받는다. 2·3단계 값도
+  없어 보여 줄 후보조차 없으면 그 사실을 그대로 보고하고 중단한다. 서로 다른
+  `window_id`가 2건 이상이면 그대로 보고하고 확인받는다. 어느 경우에도 창의 실제 세션이
+  확정되지 않았으므로 R2.6에 따라 `window-session`을 갱신하지 않는다.
+
+- **R7.2** 창이 닫혀 있으면(`is_open`이 거짓) 선택 세션으로 직접 연다.
+- **R7.3** 창이 열려 있고 선택 세션과 같은 세션이면 중복 창을 만들지 않고 기존 위치를
+  안내한다.
+- **R7.4 세션 미명시 + 창이 다른 세션에 열려 있음.** 사용자가 대상을 명시하지 않았으면
+  창을 **옮기지 않고 기존 위치를 존중한다.** 이 상태에 이르는 경로는 둘이다.
+
+  1. **저장값이 유효하고 생존해 우선순위 2로 선택된 경우** — `SELECTED_SESSION`이 창의
+     실제 세션과 같으므로 R7.3(중복 창 금지)으로 귀결된다. 갱신할 것이 없다.
+  2. **저장값이 레거시(R2.2)이거나 사라진 세션을 가리켜(R2.5) 우선순위 2가 건너뛰어진
+     경우** — `SELECTED_SESSION`이 우선순위 3·4의 값이 되어 창의 실제 세션과 **다르다.**
+     그래도 창은 옮기지 않는다. 대신 R2.6에 따라 `window-session`을 **창의 실제 세션**
+     으로 갱신한다. `SELECTED_SESSION`으로 갱신하면 config가 창의 실제 위치와 어긋난다.
+
+  두 경로 모두 창을 옮기지 않으므로, 옮기려면 사용자가 대상 세션을 명시해야 한다(R7.5).
+- **R7.5 열린 창의 명시적 이동.** 창이 열려 있고 다른 세션이며 사용자가 대상을
+  명시했으면, `workmux open`으로 재구성하지 않고 `move-window-to-session` 스킬을 쓴다.
+  살아 있는 pane과 에이전트 상태를 보존하기 위해서다.
+
+  그 스킬의 입력 계약은 `<윈도우이름|세션:번호> <대상세션>`이므로
+  (`move-window-to-session/SKILL.md:21`), R7.1이 확보한 `window_id`를 **그대로 넘기지
+  않는다.** 호출 직전에 `window_id`로 현재 위치를 해석해 `세션:번호` 형태로 넘긴다.
+
+  ```bash
+  SRC=$(tmux display-message -p -t "{window_id}" '#{session_name}:#{window_index}')
+  # move-window-to-session 에 넘기는 인자: "$SRC" "{선택세션}"
+  ```
+
+  `window_id`로 해석하는 이유는 그 사이 다른 창이 열리고 닫혀 번호가 밀렸을 수 있기
+  때문이다. 호출이 끝난 뒤에도 같은 `window_id`로 최종 위치를 재확인한다.
+
+  그 스킬은 내부적으로 worktree 경로와 worktree명(= handle)도 쓰므로
+  (`move-window-to-session/SKILL.md:114`), R7.0·R7.1에서 확보한 경로와 handle을 함께
+  전달한다. 그 스킬의 3-(a) 단계가 `window-session`을 대상 세션으로 갱신하므로 R2.4는
+  덮어쓰기가 아니라 **확인**으로 동작한다.
+
+- **R7.6** 같은 브랜치의 worktree가 이미 있으면 새로 만들지 않고 기존 경로를 안내한다.
+  R4.3과 같은 규칙이며 PR 모드에도 동일하게 적용된다.
+
+### R8. 생성 후 검증
+
+- **R8.1** `tmux list-windows -a -F '#{session_name}:#{window_index}\t#{window_name}'`로
+  실제 윈도우 이름과 세션을 확인한다. `workmux list`에는 윈도우 이름 열이 없으므로
+  추측해서 안내하면 사용자가 `workmux close`에 없는 이름을 넘기게 된다.
+- **R8.2** 실제 세션이 선택 세션과 다르면 알리고, 잘못 만들어진 세션과 git config 값을
+  함께 정리한다.
+- **R8.3** 결과 보고에 worktree 경로, handle, 브랜치, 실제 세션, 실제 윈도우 이름을
+  포함한다. PR 모드에서는 PR 번호와 head OID도 포함한다.
+
+### R9. 문서 동기화
+
+- **R9.1** 두 SKILL.md 본문은 Claude 전용 frontmatter를 제외하고 동일해야 한다.
+- **R9.2** 현존하는 workmux 버전 표기 불일치(`dot_agents:43` vs `dot_claude:46`)를
+  더 정확한 `dot_claude` 쪽 문구로 통일한다.
+- **R9.3** `openai.yaml`의 `default_prompt`에 대상 세션 또는 PR 참조 사례를 반영한다.
+- **R9.4** 홈의 적용본을 직접 수정하지 않는다. chezmoi 원본만 고치고 `chezmoi apply`로
+  적용한다.
+- **R9.5 `description` frontmatter 갱신.** 두 SKILL.md의 `description`은 현재 양쪽 다
+  브랜치만 언급한다(실측). 에이전트는 이 문장으로 호출을 라우팅하므로, PR 참조와 대상
+  세션이 유효한 입력이 된 뒤에도 이대로 두면 "PR 31을 2-review에 열어줘" 같은
+  R1.4·R1.6 호출이 스킬에 도달하지 못할 수 있다. 양쪽 모두 갱신하고 서로 동일하게
+  유지한다.
+- **R9.6 보존 대상 규칙 목록 (Goal 5의 검증 근거).** 아래 현행 규칙은 재작성 후에도
+  두 SKILL.md에 남아 있어야 한다.
+
+  | # | 보존 규칙 | 계승 위치 |
+  |---|---|---|
+  | 1 | git-crypt 저장소에서 `workmux add` 금지 | R6.2 |
+  | 2 | 래퍼 실패 시 중단, `workmux open` 미진행 | R6.5 |
+  | 3 | 래퍼 확인 프롬프트 자동 우회 금지 | R6.5 |
+  | 4 | 래퍼 실행 권한 없으면 경로 변경 없이 오류 보고 | R6.5 |
+  | 5 | git-crypt 필터 있는데 래퍼 없으면 사용자 확인 후 진행 | R6.10 |
+  | 6 | 저장소 루트 기준 경로 분기 | R6.1 |
+  | 7 | `has-session` 금지와 접두사 함정 근거 | R3.4 |
+  | 8 | 유령 세션 위험 서술(workmux가 없는 세션을 만들고 config에 저장) | R3.5 |
+  | 9 | 레거시 `window-session` 값의 정규식 판정과 glob 반례 | R2.2 |
+  | 10 | `--parent-session` 미지원 조합 예외 | R6.7 |
+  | 11 | 창 이름 충돌 재시도 | R5.6 |
+  | 12 | `workmux list`에 윈도우 이름 열이 없으므로 `tmux list-windows`로 확인 | R8.1 |
+  | 13 | `workmux open`이 `git worktree list`로 찾으므로 `worktree_dir` 밖 형제 디렉터리도 인식 | R6.9 |
+  | 14 | 에이전트 자동 실행 안 함 | 주의사항 절 유지 |
+  | 15 | 개발 서버는 별도 윈도우·pane (포트 충돌, 개당 1~2GB) | 주의사항 절 유지 |
+  | 16 | 레이아웃은 `~/.config/workmux/config.yaml`, 저장소별은 `.workmux.yaml` | 주의사항 절 유지 |
+  | 17 | 같은 브랜치 worktree가 있으면 기존 경로 안내 | R7.6 |
+  | 18 | 이슈 번호는 브랜치명 맨 앞의 숫자 또는 `ZF-숫자`만 | R5.2 |
+
+## Acceptance criteria
+
+검증 유형: **[실행]**(명령 종료 코드·출력으로 판정), **[문서]**(두 SKILL.md에 해당
+규칙이 기술되어 있는지 검토로 판정).
+
+| ID | 기준 | 검증 방법 | 커버 |
+|---|---|---|---|
+| AC-1 | 입력 계약이 `<브랜치명\|PR참조> [대상세션]`으로 문서화되고 첫 인자 누락 시 묻는다 | [문서] 파라미터 절 | R1.1, R1.2 |
+| AC-2 | positional 3개 이상이면 사용법 안내 후 중단 | [문서] R1.3 | R1.3 |
+| AC-3 | PR 모드 트리거 3종이 열거된다 | [문서] R1.4 | R1.4 |
+| AC-4 | 표지 없는 맨 숫자를 PR로 해석하지 않는 규칙과 근거가 기술된다 | [문서] R1.5 | R1.5 |
+| AC-5 | 자연어 → 2-튜플 환원과 "두 개 이상 중단"이 기술된다 | [문서] R1.6 | R1.6 |
+| AC-6 | 세션명 접두사 보정·추측 금지가 기술된다 | [문서] R1.7 | R1.7 |
+| AC-7 | `argument-hint`가 `<branch-name\|pr-ref> [target-session]`이다 | [실행] `grep -q` → exit 0 | R1.8 |
+| AC-8 | `{이름}`이 `workmux list --json`의 `handle`로 정의되고, 브랜치·창 이름 유추 금지가 각각의 구조적 근거와 함께 기술되며, 키 네임스페이스(4개 하위 키)가 명시된다 | [문서] R2.0 | R2.0 |
+| AC-9 | **(환경 전제)** workmux가 handle 이름으로만 키를 쓰며 브랜치·창 이름으로는 쓰지 않는다 | [실행] 0차 픽스처 A부. 아래 "AC-9의 실행 정의" 참조. **이 기준은 workmux의 동작만 판별하며 산출물의 정확성은 판정하지 않는다** | R2.0의 전제 |
+| AC-9b | **(산출물)** 스킬 절차를 따라 실행했을 때 실제로 조회된 config 키가 handle 기준이다 | [실행] 0차 픽스처 B부 — 픽스처 worktree를 대상으로 개정된 스킬의 식별 경로를 실행하고, 실행된 `git config` 명령의 키 이름을 기록해 `workmux.worktree.{F}.*`뿐이고 `{슬러그}`·`{W}` 기준 조회가 없음을 확인 | R2.0 |
+| AC-10 | 세션 우선순위가 명시값 > 저장값 > 모드 기본값 > `1-main`으로 기술된다 | [문서] 저장값이 모드 기본값보다 위임을 확인 | R2.1 |
+| AC-11 | 레거시 저장값을 정규식으로 판정하고 glob을 금지하는 근거가 기술된다 | [문서] R2.2 | R2.2 |
+| AC-12 | 선택 세션 확정 전 금지되는 workmux 명령이 **열거**되고, 읽기 전용 조회와 `--dry-run`이 예외로 명시된다 | [문서] R2.3에 `add`/`open`/`remove`/`close` 열거와 예외 서술이 있고, R7.0·R7.1이 세션 선택보다 먼저 `list --json`을 쓰는 것과 모순되지 않음 | R2.3 |
+| AC-12b | 창이 열려 있고 옮기지 않을 때 `window-session`이 **선택 세션이 아니라 창의 실제 세션**으로 갱신된다 | [문서] R2.6의 3행 표와 R7.4의 경로 2 서술. + [실행] 4차 — 레거시 값을 인위로 심고 세션 미명시로 재호출한 뒤 `window-session`이 창의 실제 세션이 됐는지 확인 | R2.6, R7.4 |
+| AC-13 | 명시 세션이 저장값을 덮으면 git config가 명시 세션을 가리킨다 | [실행] 스모크 3차에서 `window-session`이 1차 세션에서 3차 명시 세션으로 바뀜 | R2.4 |
+| AC-14 | 형식은 유효하나 사라진 저장 세션에 복구 경로가 있다 | [문서] R2.5의 4단계 | R2.5 |
+| AC-15 | tmux 서버 부재를 세션 부재와 구분해 감지한다 | [실행] `tmux -L quality-goal-nonexistent-socket list-sessions` → exit 1 + `error connecting to`. + [문서] 구분 서술 | R3.1, R3.2 |
+| AC-16 | 없는 세션은 `grep -qxF`로 부재 판정되고 자동 생성하지 않는다 | [실행] `... \| grep -qxF -- 'definitely-not-a-session'` → exit 1. + [문서] R3.5 | R3.3, R3.5 |
+| AC-17 | `has-session` 접두사 함정이 실측 근거와 함께 금지된다 | [실행] `has-session -t 2` → 0, `-t 2-rev` → 0, `grep -qxF 2-rev` → 1. + [문서] R3.4 | R3.4 |
+| AC-18 | 고정 `1-main` 검사가 선택 세션 검사로 일반화된다 | [실행] 아래 "`1-main` 잔존 검사" | R3.6, R6.6 |
+| AC-19 | `{owner}/{repo}`와 현재 저장소의 확정 방법이 입력 형태별로 기술된다 | [문서] R4.0의 표와 명령·폴백 | R4.0 |
+| AC-20 | PR 조회가 소비되는 필드만 요청하고 각 소비처가 명시된다 | [문서] R4.1 | R4.1 |
+| AC-21 | base 저장소 불일치 시 중단하며, 비교 대상 두 값이 R4.0에서 확정된 것임이 기술된다 | [문서] R4.2 | R4.2 |
+| AC-22 | 기존 worktree면 생성만 건너뛰고 R7으로 진행(전체 중단 아님) | [문서] R4.3 + 흐름도 분기 일치 | R4.3, R7.6 |
+| AC-23 | 동명 로컬 브랜치가 head OID와 다르면 중단 | [문서] R4.4 | R4.4 |
+| AC-24 | `gh` 부재·미인증·실패 시 추측 없이 중단 | [문서] R4.5 | R4.5 |
+| AC-25 | 래퍼 경로에서 `refs/pull/{N}/head`로 head를 확보하고 실패 시 래퍼를 부르지 않는다 | [문서] R4.6 + 래퍼 3단계 판별 근거 | R4.6 |
+| AC-26 | CLOSED·MERGED PR 처리에 4요소가 모두 기술된다 — (1) 상태를 알림, (2) 계속할지 확인, (3) head 브랜치 삭제 가능성 안내, (4) 자동 중단 금지 | [문서] R4.7에서 네 요소를 각각 확인 | R4.7 |
+| AC-27 | **`--pr`에 원시 사용자 입력이 아니라 정규화된 PR 번호가 들어간다** | [문서] R4.8의 환원 표 + R6.3·Interfaces 블록이 `--pr {PR번호}`로 표기됨. + [실행] 스모크 1차에서 실제로 실행한 명령의 `--pr` 인자가 숫자만인지 기록 | R4.8 |
+| AC-28 | 짧은 이름이 마지막 `/` 뒤로 파생된다 | [문서] R5.1 | R5.1 |
+| AC-29 | 브랜치 모드 이슈 번호 규칙이 유지된다 | [문서] R5.2 | R5.2 |
+| AC-30 | PR head가 이슈 번호로 시작해도 창 이름에 PR 번호가 쓰인다 | [실행] 스모크 1차에서 창 이름이 `{PR번호}-`로 시작하고 head 브랜치의 이슈 번호로 시작하지 않음 | R5.3 |
+| AC-31 | 이슈 번호 없으면 `--target-name` 생략 | [문서] R5.4 | R5.4 |
+| AC-32 | 소문자 정규화가 안내에 반영된다 | [문서] R5.5 | R5.5 |
+| AC-33 | PR 모드 충돌 재시도가 PR 번호를 보존한다 | [문서] R5.6의 모드별 구분 | R5.6 |
+| AC-34 | 경로 분기를 저장소 루트 기준으로 판정한다 | [문서] R6.1 | R6.1 |
+| AC-35 | git-crypt 저장소에서 `workmux add`를 쓰지 않는다 | [문서] R6.2 + git-crypt 분기에 래퍼 호출만 존재 | R6.2 |
+| AC-36 | 래퍼 없는 PR 경로가 positional·`--name`을 생략하고 `--pr`를 쓴다 | [실행] 스모크 1차에서 worktree 브랜치가 PR head 브랜치와 일치하고, handle이 기본 명명 결과임 | R6.3 |
+| AC-37 | 래퍼 있는 PR 경로가 확보 → 래퍼 → `workmux open` 순서로 기술된다 | [문서] R6.4 | R6.4 |
+| AC-38 | 래퍼 실패·권한 없음 시 창을 열지 않고 프롬프트를 우회하지 않는다 | [문서] R6.5 | R6.5 |
+| AC-39 | `--parent-session` 미지원 조합 예외가 유지된다 | [문서] R6.7 | R6.7 |
+| AC-40 | 생성된 worktree HEAD가 PR head OID와 일치한다 | [실행] 스모크 1차에서 `git -C {wt} rev-parse HEAD` == R4.1의 `headRefOid` | R6.8 |
+| AC-41 | 경로·handle을 명령 출력에서 얻고 추측하지 않는다 | [문서] R6.9. + [실행] 스모크 1차에서 `workmux list --json`으로 handle을 읽어 보고 | R6.9 |
+| AC-42 | git-crypt 필터가 있으나 래퍼가 없으면 사용자 확인 후 진행한다 | [문서] R6.10 | R6.10 |
+| AC-43 | worktree 존재 판정이 세션 선택보다 먼저다 | [문서] 흐름도에서 R7.0이 R2보다 앞 | R7.0 |
+| AC-44 | 창 탐지가 `is_open` + 저장된 `window-session`·`target-window` + pane 경로 교차 확인으로 규정되고, 이번 호출이 파생한 이름을 쓰지 않는 구조적 근거가 제시된다 | [문서] R7.1. + [실행] 스모크 1차에서 (a) pane 경로 매칭이 방금 만든 창의 `window_id`를 중복 제거 후 정확히 1개 반환하고, (b) `git config --get workmux.worktree.{handle}.target-window` 값이 `tmux list-windows -a`가 보여 주는 그 창의 이름과 일치 | R7.1 |
+| AC-45 | 매칭 0건·2건 이상, 경로 공백·`cd` 한계, **그리고 저장값 부재·스테일**에서 추측하지 않는다 | [문서] R7.1의 "저장값 부재·스테일 처리"와 "불일치 처리" 양쪽 | R7.1 |
+| AC-46 | 창이 닫혀 있으면 선택 세션으로 직접 연다 | [문서] R7.2 | R7.2 |
+| AC-47 | **선택 세션과 같은 세션에** 이미 열려 있으면 중복 창을 만들지 않는다 | [실행] 스모크 2차 | R7.3 |
+| AC-48 | 세션 미명시 시 기존 위치를 존중한다 | [문서] R7.4 | R7.4 |
+| AC-49 | 열린 창의 명시적 이동이 `move-window-to-session`의 입력 계약(`세션:번호`)에 맞춰 호출되고, `window_id`로 직전 해석·사후 재확인한다 | [문서] R7.5. + [실행] 스모크 3차에서 창이 명시 세션으로 이동하고 `window_id`가 1차와 동일 | R7.5 |
+| AC-50 | 생성 후 실제 세션·창 이름을 `tmux list-windows`로 확인한다 | [실행] 스모크 1차에서 실행·기록 | R8.1 |
+| AC-51 | 세션 불일치 시 잘못된 세션과 git config를 정리한다 | [문서] R8.2 | R8.2 |
+| AC-52 | 보고에 경로·handle·브랜치·세션·창이름(+PR번호·head OID) 포함 | [실행] 스모크 1차 보고에 7항목 존재 | R8.3 |
+| AC-53 | 두 SKILL.md 본문이 Claude frontmatter 외에 동일하다 | [실행] 아래 "결정적 명령 표기" 1번. 인자 순서를 고정한 `diff` 출력이 `3a4,6`과 그 3줄만 | R9.1, R9.2 |
+| AC-54 | `openai.yaml` `default_prompt`에 세션 또는 PR 사례 반영 | [실행] 아래 "결정적 명령 표기" 2번 | R9.3 |
+| AC-55 | chezmoi 원본만 수정되고 적용본이 일치한다 | [실행] `chezmoi apply` 후 3개 파일 `cmp` → exit 0 | R9.4 |
+| AC-56 | 두 SKILL.md의 `description`이 PR 참조와 대상 세션을 포함하도록 갱신되고 서로 동일하다 | [실행] 아래 "결정적 명령 표기" 3번 | R9.5 |
+| AC-57 | R9.6의 보존 규칙 18개가 모두 두 SKILL.md에 남아 있다 | [실행/검토] 각 항목을 두 파일에서 확인. 누락 0건 | R9.6, Goal 5 |
+| AC-58 | PR 모드 신규 worktree에서 세션 미명시 시 `2-review`가 선택된다 | [실행] 스모크 1차에서 창이 `2-review`에 열림 | R2 우선순위 3 |
+| AC-59 | 두 스킬이 frontmatter 검증 기준선을 만족한다 | [실행] 아래 "frontmatter 검증" | 도구 위생 |
+| AC-60 | 공백 오류·시크릿 유출 없음 | [실행] `git diff --check` → 0, `pre-commit run --all-files` 통과 | 저장소 위생 |
+
+### 요구사항 전수 대응 확인
+
+R1.1→AC-1, R1.2→AC-1, R1.3→AC-2, R1.4→AC-3, R1.5→AC-4, R1.6→AC-5, R1.7→AC-6,
+R1.8→AC-7, R2.0→AC-8·AC-9·AC-9b, R2.1→AC-10, R2.2→AC-11·AC-12b, R2.3→AC-12,
+R2.4→AC-13, R2.5→AC-14·AC-12b, R2.6→AC-12b,
+R3.1→AC-15, R3.2→AC-15, R3.3→AC-16, R3.4→AC-17, R3.5→AC-16, R3.6→AC-18,
+R4.0→AC-19, R4.1→AC-20, R4.2→AC-21, R4.3→AC-22, R4.4→AC-23, R4.5→AC-24, R4.6→AC-25,
+R4.7→AC-26, R4.8→AC-27, R5.1→AC-28, R5.2→AC-29, R5.3→AC-30, R5.4→AC-31, R5.5→AC-32,
+R5.6→AC-33, R6.1→AC-34, R6.2→AC-35, R6.3→AC-36·AC-27, R6.4→AC-37, R6.5→AC-38,
+R6.6→AC-18, R6.7→AC-39, R6.8→AC-40, R6.9→AC-41, R6.10→AC-42, R7.0→AC-43,
+R7.1→AC-44·AC-45, R7.2→AC-46, R7.3→AC-47, R7.4→AC-48·AC-12b, R7.5→AC-49, R7.6→AC-22,
+R8.1→AC-50, R8.2→AC-51, R8.3→AC-52, R9.1→AC-53, R9.2→AC-53, R9.3→AC-54, R9.4→AC-55,
+R9.5→AC-56, R9.6→AC-57. **미대응 요구사항 없음.**
+
+### 결정적 명령 표기 (AC-53·54·56의 실행 정의)
+
+표 셀 안의 정규식은 마크다운 이스케이프가 섞이므로, 실제로 실행할 형태를 여기에 둔다.
+
+```bash
+# 1. AC-53 — 인자 순서를 고정한다. 순서를 바꾸면 같은 정상 상태가 `4,6d3`으로 나와
+#    기대값 `3a4,6`과 어긋난다.
+diff dot_agents/skills/create-worktree/SKILL.md \
+     dot_claude/skills/create-worktree/SKILL.md
+
+# 2. AC-54
+grep -qE '2-review|pull/' dot_agents/skills/create-worktree/agents/openai.yaml
+
+# 3. AC-56 — 두 파일의 description 행이 PR과 session을 모두 언급하고 서로 같은지
+for f in dot_agents/skills/create-worktree/SKILL.md \
+         dot_claude/skills/create-worktree/SKILL.md; do
+  sed -n '3p' "$f" | grep -qiE 'pull request|[^a-z]PR[^a-z]' || echo "FAIL PR: $f"
+  sed -n '3p' "$f" | grep -qi 'session'                       || echo "FAIL session: $f"
+done
+[ "$(sed -n '3p' dot_agents/skills/create-worktree/SKILL.md)" \
+  = "$(sed -n '3p' dot_claude/skills/create-worktree/SKILL.md)" ] || echo "FAIL 불일치"
+```
+
+### AC-9의 실행 정의 (SPEC-009 해소)
+
+**문제.** `git config --get-regexp '^workmux\.worktree\.'`는 저장소의 **모든** workmux
+worktree 키를 돌려준다(공유 config, 실측). 따라서 "출력의 모든 키가 테스트 대상 handle
+기준"이라는 판정은 다른 worktree가 하나라도 있으면 올바른 구현에도 실패한다. 또한
+기본 명명에서는 handle이 브랜치 슬러그와 같으므로, 브랜치 유추 키만 확인하면 판별력이
+없다.
+
+**해법.** 테스트가 조건을 직접 만든다. `workmux add --name`으로 handle을 브랜치
+슬러그와 다르게 지정할 수 있음을 dry-run으로 확인했으므로, 기존 worktree를 찾을 필요가
+없다.
+
+**두 부분으로 나눈다.** A부는 workmux의 동작(= R2.0의 전제)을, B부는 **산출물**(개정된
+SKILL.md를 따랐을 때 실제로 무엇을 조회하는지)을 판별한다. A부만으로는 산출물에 결함이
+있어도 통과하므로 B부가 반드시 필요하다.
+
+**전제 확인 (픽스처 생성 전).**
+
+```bash
+# 잔여 키가 프로브 결과를 오염시키지 않는지 기준선을 남긴다
+git config --get-regexp '^workmux\.worktree\.' > /tmp/wm-keys-before.txt
+git config --get "workmux.worktree.{슬러그}.window-session"   # exit 1 이어야 한다
+git config --get "workmux.worktree.{W}.window-session"        # exit 1 이어야 한다
+```
+
+둘 중 하나라도 exit 0이면 잔여 키가 있는 것이므로 `{W}`를 다른 이름으로 바꾸거나 그
+사실을 기록하고 폴백(b)으로 간다. 이 기준선이 없으면 2·3번 프로브의 결과가 구현 때문인지
+잔여 키 때문인지 구분할 수 없다.
+
+**A부 — 환경 전제 (AC-9).** 스모크 1차보다 **먼저** 하고, 완전히 정리한 뒤 1차를
+시작한다(같은 PR head 브랜치에 두 worktree를 둘 수 없다).
+
+1. 픽스처를 만든다. `{F}`는 브랜치 슬러그와 다른 임의 handle, `{W}`는 `{F}`와도 다른
+   창 이름이다.
+
+   ```bash
+   workmux add --pr {PR번호} --name {F} --target-name {W} --parent-session {세션}
+   ```
+
+2. 세 프로브를 확인한다. `{슬러그}`는 PR head 브랜치의 `/`를 `-`로 바꾼 문자열이다.
+
+   | 프로브 | 기대 |
+   |---|---|
+   | `git config --get workmux.worktree.{F}.window-session` | exit 0, 값 존재 |
+   | `git config --get workmux.worktree.{슬러그}.window-session` | **exit 1** |
+   | `git config --get workmux.worktree.{W}.window-session` | **exit 1** |
+
+   `{F}` ≠ `{슬러그}` ≠ `{W}`이므로 브랜치 유추와 창 이름 유추 **양쪽 모두**에 판별력이
+   있다. 각 프로브가 특정 이름 하나만 조회하므로 다른 worktree의 키에 영향받지 않는다.
+
+**B부 — 산출물 (AC-9b).** 같은 픽스처 worktree를 대상으로, 개정된 SKILL.md의 식별
+경로(R7.0 → R2.0 → R7.1)를 그대로 수행하고 **실행한 `git config` 명령을 기록한다.**
+
+| 관찰 | 기대 |
+|---|---|
+| 기록된 `git config` 키 이름 전부 | `workmux.worktree.{F}.*` 형태만 존재 |
+| `{슬러그}` 또는 `{W}` 기준 조회 | **0건** |
+| 절차가 handle을 얻은 출처 | `workmux list --json`의 `handle` 필드 |
+
+이 관찰이 산출물의 결함을 잡는다 — SKILL.md가 브랜치나 창 이름으로 키를 만들도록
+적혀 있으면 기록에 그 조회가 나타난다.
+
+**정리.** `workmux remove {F}` 후 `git worktree list`·`workmux list --json`에 `{F}`가
+없고 `git config --get-regexp '^workmux\.worktree\.{F}\.'`가 exit 1인지, 그리고 전체 키
+목록이 `/tmp/wm-keys-before.txt`와 같은지 확인한다. 남아 있으면 보고하고 1차를 시작하지
+않는다.
+
+**폴백(b).** 픽스처 생성이 실패하거나(예: `--name` 조합 거부, 대상 브랜치에 이미
+worktree 존재 — 3층 전제 확인 참조) 전제 확인에서 잔여 키를 해소하지 못하면, AC-9·AC-9b의
+실행 판정을 포기하고 문서 검토로 강등한 뒤 잔여 격차를 보고서에 기록한다. 실행되지 않은
+검증을 통과로 기록하지 않는다.
+
+### `1-main` 잔존 검사 (AC-18의 실행 정의)
+
+```bash
+grep -n -- '1-main' dot_agents/skills/create-worktree/SKILL.md \
+                    dot_claude/skills/create-worktree/SKILL.md
+```
+
+**허용되는 잔존 용례**
+
+1. R2 우선순위 4순위를 설명하는 "전역 기본값 `1-main`" 서술
+2. 우선순위 예시 표에서 기본값 결과를 보이는 셀
+3. 유령 세션 위험이나 레거시 마이그레이션을 설명하며 예시로 드는 문장
+
+**금지되는 잔존 용례** — 하나라도 남으면 AC-18 실패.
+
+1. `--parent-session 1-main` 리터럴이 실행 명령 예시에 있음
+2. `grep -qxF -- 1-main`처럼 검증 대상이 고정됨
+3. `git config ... window-session 1-main`처럼 기록 값이 고정됨
+4. "`1-main` 세션이 없으면 여기서 멈춘다"처럼 중단 조건이 묶임
+5. "새로 만든 것이면 `1-main`"처럼 사후 검증 기대값이 고정됨
+
+### frontmatter 검증 (AC-59의 실행 정의)
+
+```bash
+QV=/Users/lee-kyu-hwan/.claude/plugins/marketplaces/claude-plugins-official/plugins/skill-creator/skills/skill-creator/scripts/quick_validate.py
+python3 "$QV" /Users/lee-kyu-hwan/code/dotfiles/dot_claude/skills/create-worktree
+python3 "$QV" /Users/lee-kyu-hwan/code/dotfiles/dot_agents/skills/create-worktree
+```
+
+실측 기준선(변경 전): `dot_agents` → `Skill is valid!` exit 0. `dot_claude` →
+`Unexpected key(s) in SKILL.md frontmatter: argument-hint, user-invocable.` **exit 0**.
+
+판정 기준은 **종료 코드 0 + `dot_claude`의 메시지가 위 Claude 전용 키 안내에서 늘어나지
+않을 것.**
+
+## Architecture
+
+스킬은 실행 코드가 아니라 에이전트가 읽고 따르는 절차 문서다. "아키텍처"는 문서가
+기술하는 결정 흐름과 그것이 호출하는 외부 도구 경계를 뜻한다.
+
+### 결정 흐름
+
+worktree 식별(R7.0)과 창 탐지(R7.1)가 세션 선택(R2)보다 **앞선다** — 저장 세션을
+읽으려면 handle이 필요하고 handle은 경로로 찾기 때문이다.
+
+```
+1. 입력 파싱 (R1)
+     ├─ positional 3개 이상 → 사용법 안내 후 중단
+     ├─ PR 참조 판정 (R1.4 / R1.5)
+     └─ 자연어면 2-튜플 환원 (R1.6)
+          ↓
+2. 저장소 확정 (R4.0)  [PR 모드]
+          ↓
+3. PR 해석 (R4.1, R4.2, R4.5, R4.7) → PR 참조 정규화 (R4.8)
+     ├─ 번호·head브랜치·headRefOid·state 조회
+     ├─ base 저장소 불일치 → 중단
+     ├─ state != OPEN → 알리고 확인
+     └─ 이후 --pr 에는 정규화된 PR 번호만 쓴다
+          ↓
+4. worktree 식별 (R7.0)
+          ↓
+5. 창 탐지 (R7.1)  [worktree가 있을 때만]
+     is_open → window-session → target-window → pane 경로 교차 확인
+          ↓
+6. 세션 선택 (R2)  /  7. 세션 검증 (R3)
+          ↓
+8. 이름 파생 (R5)
+          ↓
+9. 분기
+     ├─ [worktree 있음] (R4.3 → R7.2~R7.5)
+     │     ├─ is_open 거짓 → 선택 세션으로 workmux open
+     │     │       (R2.6: window-session ← 선택 세션)
+     │     ├─ is_open 참 & 같은 세션 → 안내만 (중복 창 금지)
+     │     ├─ is_open 참 & 다른 세션 & 미명시 → 옮기지 않고 존중 (R7.4)
+     │     │       (R2.6: window-session ← 창의 실제 세션. 선택 세션이 아니다)
+     │     └─ is_open 참 & 다른 세션 & 명시됨
+     │           → window_id로 세션:번호 해석 → move-window-to-session
+     │             (R2.6: window-session ← 선택 세션. 실제 쓰기는 그 스킬이 수행)
+     │
+     └─ [worktree 없음] → 브랜치 안전 검사 (R4.4) → 생성 (R6)
+           ├─ 래퍼 있음: R4.6 fetch → 래퍼 → workmux open
+           ├─ 래퍼 없음: workmux add --pr {PR번호} (positional·--name 생략)
+           └─ git-crypt 필터 있으나 래퍼 없음 → 사용자 확인 (R6.10)
+          ↓
+10. 생성 후 검증 (R6.8, R6.9, R8, R2.4)
+```
+
+### 구성 요소와 책임 경계
+
+| 구성 요소 | 책임 | 이번 변경 |
+|---|---|---|
+| `dot_claude/.../SKILL.md` | Claude Code가 읽는 절차 + Claude 전용 frontmatter | 본문 확장, `argument-hint`·`description` 갱신 |
+| `dot_agents/.../SKILL.md` | Codex·공용 에이전트가 읽는 절차 | 본문 동일 확장, `description` 갱신 |
+| `dot_agents/.../agents/openai.yaml` | Codex UI 메타데이터 | `default_prompt` 갱신 |
+| `workmux` (0.1.248) | worktree 생성·창 구성·`--pr` 체크아웃·`list --json` 상태 조회·`--dry-run` 미리보기 | 호출만 |
+| 대상 저장소의 `scripts/create-worktree.sh` | git-crypt worktree 생성·키 링크·의존성 설치 | 호출만. 3단계 판별의 전제를 R4.6이 보장 |
+| `gh` | PR 메타데이터·현재 저장소 조회 (읽기 전용) | 신규 의존 |
+| `git fetch origin refs/pull/N/head` | PR head 커밋 확보 | 신규 의존 (래퍼 경로) |
+| `tmux list-panes -a` | 창 확정의 교차 확인 | 신규 의존 (R7.1) |
+| `move-window-to-session` 스킬 | 열린 창 이동 + 메타데이터 동기화 | 호출만. 입력 계약에 맞춰 `세션:번호`로 호출 |
+| `~/.config/workmux/config.yaml` | pane 레이아웃, `base_branch: auto` | 변경 없음 |
+
+### 결정: 두 원본의 동기화 방식
+
+- **대안 A — 심볼릭 링크**: Claude 전용 frontmatter가 파일 앞에 있어야 하므로 파일
+  전체를 링크할 수 없다. 탈락.
+- **대안 B — 생성 스크립트**: 변경 범위(#35가 지정한 3개 파일)를 넘어서고 chezmoi
+  흐름에 빌드 단계를 넣는다. 탈락.
+- **대안 C — 수동 유지 + `diff` 검증(채택)**: 기존 관행과 같고 추가 장치가 없다.
+
+## Interfaces and data flow
+
+### 스킬 입력 계약
+
+```
+<브랜치명|PR참조> [대상세션]
+```
+
+| 입력 | 모드 | 대상 세션 | 창 이름 |
+|---|---|---|---|
+| `1290-bug/partner-robots-yeti-disallow` | 브랜치 | `1-main` (기본) | `1290-partner-robots-yeti-disallow` |
+| `1290-bug/... 2-review` | 브랜치 | `2-review` (명시) | 같음 |
+| `fix/login-bug` | 브랜치 | `1-main` | `--target-name` 생략 |
+| `https://github.com/owner/repo/pull/1247` | PR | `2-review` (모드 기본) | `1247-{짧은이름}` |
+| `owner/repo#1313` | PR | `2-review` | `1313-{짧은이름}` |
+| `.../pull/1247 3-personal` | PR | `3-personal` (명시) | `1247-...` |
+| 위 PR + 저장값(생존), 세션 미명시 | PR | 저장값 (우선) | `1247-...` |
+| 위 PR + 저장값, 다른 세션 명시 | PR | 명시값 + config 갱신 | `1247-...` |
+| 위 PR + 저장값이 형식 유효하나 세션 부재 | PR | R2.5 복구 → 확인 후 기본값 | `1247-...` |
+| `1313` (표지 없는 맨 숫자) | 브랜치 또는 확인 요청 | — | — |
+| "PR 1313을 2-review에 열어줘" | PR (표지 있음, 저장소는 현재 저장소) | `2-review` | `1313-...` |
+
+세 PR 입력 형태 모두 R4.8에서 **PR 번호로 환원되어** `--pr`에 들어간다.
+
+### 외부 명령 계약
+
+**저장소·PR 메타데이터 (읽기 전용)**
+
+```bash
+gh repo view --json owner,name -q '.owner.login + "/" + .name'
+gh pr view {번호} --repo {owner}/{repo} --json number,state,headRefName,headRefOid
+```
+
+**worktree 식별과 창 탐지**
+
+```bash
+git worktree list --porcelain
+workmux list --json          # handle, path, branch, is_open, mode
+git config --get workmux.worktree.{handle}.window-session
+git config --get workmux.worktree.{handle}.target-window
+tmux list-panes -a -F '#{session_name}:#{window_index} #{window_id} #{pane_id} #{pane_current_path}'
+```
+
+**PR head 확보 (래퍼 경로)**
+
+```bash
+git fetch origin "refs/pull/{PR번호}/head:{head브랜치명}"
+git rev-parse --verify "refs/heads/{head브랜치명}"
+```
+
+**생성 — 래퍼 없음 / 있음**
+
+```bash
+workmux add --pr {PR번호} --target-name {PR번호}-{짧은이름} --parent-session {선택세션}
+workmux add --pr {PR번호} --dry-run     # 사전 확인용, 영속 변경 없음
+
+./scripts/create-worktree.sh {head브랜치명}
+workmux open {handle} --target-name {PR번호}-{짧은이름} --parent-session {선택세션}
+```
+
+`--pr`에 들어가는 값은 R4.8이 정규화한 **PR 번호**다. 원시 사용자 입력을 그대로 넘기지
+않는다.
+
+**열린 창 이동 (R7.5)**
+
+```bash
+SRC=$(tmux display-message -p -t "{window_id}" '#{session_name}:#{window_index}')
+# move-window-to-session 인자: "$SRC" "{선택세션}"  (+ 컨텍스트로 worktree 경로·handle)
+```
+
+**생성 후 검증**
+
+```bash
+git -C {worktree경로} rev-parse HEAD                  # == headRefOid
+git -C {worktree경로} rev-parse --abbrev-ref HEAD     # == head브랜치명
+tmux list-windows -a -F '#{session_name}:#{window_index}\t#{window_name}'
+git -C {worktree경로} config --get workmux.worktree.{handle}.window-session
+```
+
+### 상태 저장소
+
+| 위치 | 내용 | 읽기 | 쓰기 |
+|---|---|---|---|
+| `workmux.worktree.{handle}.window-session` | 창이 속한 세션 | R2 우선순위 2, R7.1 | R2.2·R2.4·R2.5·R8.2 네 경우만. workmux와 `move-window-to-session`도 각자 쓴다 |
+| `workmux.worktree.{handle}.target-window` | workmux가 저장한 창 이름 | R7.1 | 이 스킬은 쓰지 않는다 |
+| `workmux.worktree.{handle}.mode` / `.window-token` | workmux 내부 상태 | — | 이 스킬은 읽지도 쓰지도 않는다 |
+| `workmux list --json` | handle·path·branch·is_open·mode | R7.0, R7.1, R6.9 | 없음 |
+| tmux 서버 | 세션·윈도우·pane 목록 | R3, R7.1, R8.1 | 창 이동(R7.5)은 `move-window-to-session`이 수행. 세션 자동 생성은 금지 |
+| `git worktree list` | worktree 경로·브랜치 | R7.0 | 없음 |
+| `~/.local/state/workmux/agents/*.json` | 에이전트 상태 | — | `move-window-to-session`이 담당 |
+
+**모든 workmux 키는 공유 저장소 config에 있다**(실측). worktree별로 분리되지 않으므로
+`--get-regexp`로 전수 조회하면 다른 worktree의 키도 함께 나온다. 판정할 때는 대상
+handle로 범위를 좁힌다.
+
+## Failure behavior
+
+| 실패 | 감지 | 동작 |
+|---|---|---|
+| positional 3개 이상 | 인자 개수 | 사용법 안내 후 중단 |
+| 자연어에서 브랜치·PR 참조 2개 이상 | R1.6 | 중단하고 확인 |
+| 자연어에서 세션명 2개 이상 | R1.6 | 중단하고 확인 |
+| 표지 없는 맨 숫자 | R1.5 | 브랜치로 해석하거나 확인. PR로 단정 금지 |
+| 현재 저장소를 확정 못 함 | `gh repo view`·`git remote` 모두 실패 | 중단 |
+| `gh` 없음·미인증·조회 실패 | 종료 코드 | 보고 후 중단. 추측 금지 |
+| PR base 저장소 불일치 | R4.0의 두 값 비교 | 중단 |
+| **정규화되지 않은 참조가 `--pr`에 도달** | R4.8 미적용 | workmux가 거부. R4.8로 사전 환원해 방지 |
+| PR state가 CLOSED·MERGED | R4.7 | 알리고 계속할지 확인. head 브랜치 삭제 가능성 안내 |
+| **PR head fetch 실패** | `git fetch` 종료 코드 | **중단. 래퍼를 부르지 않는다** — 부르면 빈 브랜치 worktree가 생긴다 |
+| **확보된 OID ≠ `headRefOid`** | `git rev-parse` 비교 | 중단. 래퍼를 부르지 않는다 |
+| **생성된 worktree HEAD ≠ `headRefOid`** | R6.8 | 성공으로 보고하지 않고 PR 내용 없음을 알린다 |
+| 동명 로컬 브랜치가 다른 커밋 | OID 비교 | 중단. 덮어쓰지 않음 |
+| PR head의 worktree가 이미 있음 | R7.0 | **중단이 아님.** 생성만 건너뛰고 R7 창 처리로 진행 |
+| **`is_open` 참인데 pane 매칭 0건** | R7.1 | 추측 금지. 저장된 세션·창 이름으로 후보를 보여 주고 확인 |
+| **서로 다른 `window_id` 2건 이상** | R7.1 | 그대로 보고하고 확인 |
+| **`window-session`·`target-window` 부재** | 조회 exit 1 | 그 단계를 후보 좁히기에서 제외하고 pane 경로 매칭으로 진행. 둘 다 없고 매칭도 0건이면 보고 후 중단 |
+| **저장값이 실측과 어긋남** | R7.1 4단계 vs 2·3단계 | 실측인 4단계를 신뢰하고 차이를 보고. R2.6이 실제 세션으로 갱신 |
+| **창이 열려 있는데 실제 세션 미확정** | R7.1 불일치 처리 | `window-session`을 갱신하지 않는다. 잘못된 값을 쓰는 것보다 옛 값을 두고 알리는 편이 안전 |
+| **창은 세션 X, 저장값은 레거시/사라짐, 세션 미명시** | R2.2·R2.5 + R7.4 | 창을 옮기지 않고 `window-session`을 **X로** 갱신(R2.6). 선택 세션으로 갱신하면 config가 실제 위치와 영구히 어긋난다 |
+| **worktree 경로에 공백** | R7.1 매칭기 한계 | 매칭 결과를 신뢰하지 않고 불일치 처리로 넘어감 |
+| handle을 얻지 못함 | `workmux list --json` 결과 없음 | 경로 basename 폴백 + `path` 대조. 대조 수단도 없으면 중단 |
+| tmux 서버 부재 | `list-sessions` exit 1 + `error connecting to` | "tmux 서버가 없다"로 보고. 세션 부재와 구분 |
+| **저장 세션이 형식 유효하나 부재** | R3.3 실패 + 출처가 저장값 | **중단이 아님.** R2.5 복구. 자동 생성 금지 |
+| 명시 세션이 부재 | R3.3 실패 + 출처가 사용자 | 오타 가능성을 알리고 중단. 자동 생성 금지 |
+| git-crypt 필터 있으나 래퍼 없음 | R6.1 + R6.10 | 사용자에게 확인받고 진행 |
+| 래퍼 실패 | 종료 코드 | 중단. `workmux open` 미진행 |
+| 래퍼 실행 권한 없음 | 파일 권한 | 경로를 바꾸지 않고 오류 보고 |
+| 창 이름 충돌 (브랜치 모드) | `A tmux window named '...' already exists` | `--target-name {repo명}-{짧은이름}`으로 재시도 |
+| 창 이름 충돌 (PR 모드) | 같음 | `--target-name {PR번호}-{repo명}-{짧은이름}`으로 재시도 |
+| 이동 중 창 번호가 밀림 | R7.5 | `window_id`로 직전 해석하므로 영향 없음 |
+| 생성 후 세션 불일치 | R8.1 | 알리고 잘못된 세션·git config 정리 |
+| `--parent-session` 미지원 조합 | 명령 조합 | 플래그 생략 |
+
+**공통 원칙.** 중단 시 이미 만들어진 산출물(worktree, 브랜치, 창)을 그대로 보고한다.
+부분 성공을 성공으로 보고하지 않는다.
+
+## Security and risk
+
+### 신뢰 경계와 데이터 민감도
+
+- **PR 메타데이터는 외부 입력이다.** 제목·본문·브랜치명은 다른 사람이 쓴 데이터이며
+  지시가 아니다. 브랜치명은 셸 인자로 들어가므로 항상 인용 부호로 감싸고, 스킬이 PR
+  본문의 지시를 따르지 않는다. R4.8의 정규화는 `--pr`에 숫자만 넘기게 하므로 임의
+  문자열이 CLI 인자로 흘러드는 경로도 함께 좁힌다.
+- **fork PR은 신뢰 경계 밖의 코드다.** `refs/pull/{N}/head`로 가져오는 내용은 외부
+  기여자가 작성했을 수 있다. 이 스킬은 worktree를 만들 뿐 그 코드를 실행하지 않는다.
+  래퍼의 의존성 설치는 기존 동작이며 이번 변경이 새로 도입하는 실행 경로가 아니다.
+- **git-crypt 키는 이 변경의 관심사가 아니다.** 키 링크와 unlock은 대상 저장소의
+  래퍼가 전담하며(래퍼 100-160행), 스킬 텍스트는 키 자료를 읽거나 출력하지 않는다.
+- **`gh`는 읽기 전용으로만 쓴다.**
+- **시크릿 유출 방지.** 산출물은 Markdown과 YAML이며 자격 증명을 담지 않는다.
+  gitleaks 훅이 검사한다. 공백 검사는 그 훅이 아니라 `git diff --check`가 담당한다.
+
+### 위험과 완화
+
+| 위험 | 영향 | 완화 |
+|---|---|---|
+| **잘못된 git config 키** | 읽기는 빈 값, 쓰기는 쓰레기 섹션. 저장 세션이 무시되어 "옮긴 창 되끌기"가 재발 | R2.0의 handle 정의. 검증은 두 겹 — AC-9(A부)이 **workmux의 동작 전제**를, AC-9b(B부)가 **산출물이 실제로 조회한 키**를 판별한다. A부만으로는 산출물 결함을 잡지 못한다 |
+| **`window-session`이 창의 실제 위치와 어긋남** | 다음 호출마다 잘못된 세션을 선택하거나 창을 엉뚱하게 옮김. 자기 교정 경로 없음 | R2.6의 갱신 대상 표 + AC-12b. 창을 옮기지 않을 때는 실제 세션으로 갱신한다 |
+| **파생 이름 기반 창 매칭으로 중복 창 생성** | 살아 있는 에이전트 pane 유실 | R7.1의 `is_open` + 저장된 `window-session`·`target-window` + pane 경로 교차 확인 |
+| **PR 내용이 없는 빈 worktree** | 리뷰 대상이 아닌 코드를 리뷰 | R4.6 사전 fetch + R6.8 사후 OID 검증 이중 방어 |
+| **정규화 누락으로 `--pr` 거부** | 세 입력 형태 중 둘이 실패 | R4.8 정규화 + AC-27 |
+| **사라진 저장 세션으로 영구 중단** | 매 호출 실패, 자기 교정 경로 없음 | R2.5 복구 경로 |
+| **증거가 휘발성 식별자에 묶임** | 워크트리가 제거되면 근거와 AC가 함께 죽는다 (1차·2차에서 실제로 발생) | 증거 규율 절 + 0차 자기 완결 픽스처 |
+| 유령 세션 생성 | workmux가 없는 세션을 만들고 config에 영구 저장 | R3.5 사전 검증 |
+| 의도적으로 옮긴 창 되끌기 | 사용자 배치가 조용히 무너짐 | R2.1 저장값 우선 |
+| 명시 세션 미반영 | 다음 호출이 옛 세션으로 되돌아감 | R2.4 |
+| 이동 중 창 번호 변동 | 엉뚱한 창을 옮김 | R7.5의 `window_id` 직전 해석 |
+| PR 번호와 이슈 번호 혼동 | 엉뚱한 창 이름 | R1.5, R5.3, R5.6. AC-30이 실측 |
+| 로컬 브랜치 덮어쓰기 | 미푸시 커밋 유실 | R4.4 |
+| `description` 미갱신으로 라우팅 실패 | PR 자연어 호출이 스킬에 도달하지 못함 | R9.5 + AC-56 |
+| 기존 규칙 유실 | 재작성 과정에서 안전장치가 사라짐 | R9.6 목록 + AC-57 |
+| 두 원본 drift | Claude와 Codex가 다르게 동작 | R9.1 + AC-53 |
+| 스모크 테스트 부작용 | 실제 worktree·창 생성 | `--dry-run` 사전 확인 + 0차·1차 각각의 정리 절차 |
+
+### 롤백
+
+산출물은 chezmoi 소스의 Markdown·YAML 3개 파일이다. 롤백은 `git revert` 또는
+`git checkout -- {경로}` 후 `chezmoi apply`이며 데이터 마이그레이션이 없다. 스모크
+테스트로 만들어진 worktree·창·로컬 브랜치는 Test strategy의 정리 절차로 제거한다.
+
+### 비적용 항목
+
+standard 등급이며 다음은 해당 사항이 없다.
+
+- **인증·인가·테넌시**: 권한 경계를 다루지 않는다. `gh`는 사용자 자신의 기존 자격
+  증명을 쓰며 이 변경이 권한을 넓히지 않는다.
+- **DB 스키마·마이그레이션·백필**: 영속 스키마가 없다.
+- **공개 API 호환성·멱등성·동시성**: 외부 노출 계약이 없다. 단일 사용자가 대화형으로
+  호출한다.
+- **프로덕션 변경**: 프로덕션 시스템을 건드리지 않는다.
+
+## Test strategy
+
+이 저장소에는 테스트 스위트·타입 체크·빌드가 없다(`package.json`, `Makefile`,
+`justfile`, `.github/workflows` 부재 실측). 검증은 세 층으로 한다.
+
+### 1층 — 부작용 없는 실행 검사
+
+| 검사 | 명령 | 커버 |
+|---|---|---|
+| frontmatter | `quick_validate.py` 2회, 기준선 대조 | AC-59 |
+| `argument-hint` | `grep -q` | AC-7 |
+| `description` | 두 파일 3행에 PR·session 표현 존재, 양쪽 동일 | AC-56 |
+| 두 본문 동일성 | `diff` → `3a4,6`과 그 3줄만 | AC-53 |
+| `1-main` 잔존 | 허용/금지 목록 대조 | AC-18 |
+| 보존 규칙 18개 | R9.6 목록을 두 파일에서 확인 | AC-57 |
+| `openai.yaml` | `grep -qE '2-review\|pull/'` | AC-54 |
+| tmux 서버 부재 | `tmux -L quality-goal-nonexistent-socket list-sessions` → exit 1 | AC-15 |
+| 없는 세션 판정 | `grep -qxF -- 'definitely-not-a-session'` → exit 1 | AC-16 |
+| 접두사 함정 | `has-session -t 2` → 0, `-t 2-rev` → 0, `grep -qxF 2-rev` → 1 | AC-17 |
+| chezmoi 일치 | `chezmoi diff` → `chezmoi apply` → 3개 파일 `cmp` | AC-55 |
+| 공백·시크릿 | `git diff --check`, `pre-commit run --all-files` | AC-60 |
+
+tmux 검사 3종은 읽기 전용이거나 별도 소켓을 쓰므로 실제 세션 배치를 바꾸지 않는다.
+
+### 2층 — 문서 검토
+
+`[문서]` 기준은 절차 서술이므로 해당 규칙이 두 SKILL.md에 명시적으로 기술되어 있는지
+검토로 판정한다. 확인 대상은 수용 기준 표에 특정해 두었다.
+
+**이 층의 한계.** 문서 존재 검사는 "규칙이 올바르게 적혀 있음"만 보이고 "따랐을 때
+실제로 옳은 결과가 나옴"은 보이지 않는다. 그래서 위험도가 높은 항목들(유령 세션 방지,
+서버 부재 구분, 접두사 함정, git config 키 유추 금지, 창 매칭 정확도, 중복 창 금지,
+창 이동, PR 번호 파생, `--pr` 정규화, worktree 내용, 세션 덮어쓰기, description
+라우팅, 보존 규칙)은 1층·3층의 실행 검사로 끌어올렸다. 남은 `[문서]` 기준은 실패
+상황을 인위로 만들어야 검증되는 것들(fetch 실패, 저장소 불일치, 래퍼 부재 등)이며,
+이 한계를 보고서에 기록한다.
+
+### 3층 — 실제 스모크 테스트
+
+**대상**: `lee-kyu-hwan/dotfiles` PR #31 (실측 `state=OPEN`, head 브랜치와
+`refs/pull/31/head`가 같은 OID로 원격에 존재).
+
+**선정 근거**: PR 번호와 head 브랜치의 이슈 번호가 달라 R5.3을 판별한다. dotfiles는
+git-crypt가 아니고 래퍼도 없으므로 `workmux add --pr` 경로를 탄다.
+
+**전제 확인 (0차 시작 전, 모두 읽기 전용).** 0차와 1차는 대상 PR head 브랜치로
+worktree를 새로 만드는 것을 전제한다. 아래 중 하나라도 어긋나면 그 전제가 깨진다.
+
+```bash
+gh pr view {PR번호} --json state,headRefName,headRefOid     # state와 OID 확보
+git ls-remote origin "refs/pull/{PR번호}/head"               # head가 원격에 있는지
+git worktree list --porcelain | grep -F "refs/heads/{head브랜치명}"   # 없어야 한다
+git branch --list '{head브랜치명}'                            # 비어 있거나
+git rev-parse --verify '{head브랜치명}'                       #   OID == headRefOid
+workmux add --pr {PR번호} --dry-run                          # 예상 경로·handle·target
+```
+
+| 관찰 | 판정 |
+|---|---|
+| PR이 닫히고 head 브랜치가 원격에 없음 | 대체 PR로 교체 |
+| head 브랜치의 worktree가 이미 존재 | 대체 PR로 교체 (R7.6에 따라 신규 생성이 성립하지 않음) |
+| 동명 로컬 브랜치가 `headRefOid`와 다른 커밋 | 대체 PR로 교체 (R4.4에 따라 중단됨) |
+| 위 셋 다 아님 | 그대로 진행 |
+
+**대체 계획**: 교체 대상은 같은 조건(PR 번호 ≠ head 브랜치 접두사 숫자, 그리고 위 전제
+확인 통과)을 만족하는 다른 열린 PR이다. 그런 PR이 없으면 실행 기준
+(AC-9·9b·12b·13·27·30·36·40·41·44·47·49·50·52·58)을 문서 검토로 강등하고 보고서에
+한계로 명시한다. 이 강등은 **위 전제 확인 표에서 실제로 관찰된 사유가 있을 때만**
+발동한다.
+
+#### 0차 — AC-9 픽스처 (1차보다 먼저, 완전히 정리 후 1차 시작)
+
+위 "AC-9의 실행 정의" 절차를 그대로 수행한다. 같은 PR head 브랜치에 worktree를 둘 수
+없으므로 **0차 정리가 끝나기 전에는 1차를 시작하지 않는다.**
+
+| 단계 | 관찰 | 커버 |
+|---|---|---|
+| 픽스처 생성 (`--name {F}`, `--target-name {W}`) | 생성 성공 | AC-9 |
+| handle 키 조회 | exit 0, 값 존재 | AC-9 |
+| 브랜치 슬러그 유추 키 조회 | exit 1 | AC-9 |
+| 창 이름 유추 키 조회 | exit 1 | AC-9 |
+| 정리 후 잔여물 확인 | `git worktree list`·`workmux list --json`·`config --get-regexp ...{F}\.` 모두 `{F}` 없음 | — |
+
+#### 1차 — 세션 미명시 신규 생성
+
+| 단계 | 관찰 | 커버 |
+|---|---|---|
+| 세션 미명시로 PR 모드 실행 | 창이 `2-review`에 열림 | AC-58 |
+| **실행한 명령 기록** | `--pr` 인자가 숫자만임 | AC-27 |
+| 창 이름 | `{PR번호}-{짧은이름}`이며 head 브랜치의 이슈 번호로 시작하지 않음 | AC-30 |
+| worktree 브랜치·handle | 브랜치가 PR head와 일치, handle은 기본 명명 결과 | AC-36 |
+| worktree HEAD | `rev-parse HEAD` == R4.1의 `headRefOid` | AC-40 |
+| handle·경로 확보 | `workmux list --json`에서 읽어 보고 | AC-41 |
+| 창 매칭 정확도 | pane 경로 매칭이 `window_id` 중복 제거 후 정확히 1개 | AC-44 |
+| 실제 창 위치 | `tmux list-windows -a` 출력 기록 | AC-50 |
+| 결과 보고 | 경로·handle·브랜치·세션·창이름·PR번호·head OID 7항목 | AC-52 |
+
+#### 2차 — 같은 세션 재호출 (R7.3의 조건)
+
+1차의 창이 있는 **같은 세션을 명시해** 재호출한다.
+
+| 단계 | 관찰 | 커버 |
+|---|---|---|
+| 같은 PR을 1차와 같은 세션 명시로 재호출 | 중복 창이 생기지 않음 — `window_id` 기준 1개 유지, 값도 1차와 동일 | AC-47 |
+
+#### 3차 — 다른 세션 명시 이동 (R7.5·R2.4의 조건)
+
+| 단계 | 관찰 | 커버 |
+|---|---|---|
+| 같은 PR을 1차와 다른 세션 명시로 재호출 | 창이 그 세션으로 이동하고 `window_id`가 1차와 동일(재생성 아님) | AC-49 |
+| git config 갱신 | `window-session`이 1차 세션에서 3차 명시 세션으로 바뀜 | AC-13 |
+
+#### 4차 — 레거시 저장값 + 세션 미명시 (R2.6·R7.4의 조건)
+
+3차로 창이 어떤 세션에 있는 상태에서, `window-session`에 **레거시 형식 값**을 인위로
+심고(`^[0-9]+-.+$` 불만족, 예: `legacy`) 세션을 명시하지 않고 재호출한다. 이것이
+SPEC-011이 지적한 경로 — 우선순위 2가 건너뛰어져 `SELECTED_SESSION`이 창의 실제 세션과
+달라지는 상태 — 를 실제로 만든다.
+
+```bash
+git config workmux.worktree.{handle}.window-session legacy   # 인위로 심는다
+```
+
+| 단계 | 관찰 | 커버 |
+|---|---|---|
+| 세션 미명시로 재호출 | 창이 **옮겨지지 않음** — `window_id`와 세션이 3차와 동일 | AC-48 |
+| git config 갱신 대상 | `window-session`이 `2-review`(우선순위 3)가 아니라 **창의 실제 세션**으로 바뀜 | AC-12b |
+
+두 번째 관찰이 핵심이다. `2-review`로 바뀌면 config가 창의 실제 위치와 어긋난 것이므로
+실패다.
+
+#### 정리 절차 (0차·1~4차 각각 수행)
+
+```bash
+workmux remove {handle}              # worktree + 창 제거
+git worktree list                    # 잔여물 없음 확인
+workmux list --json                  # 해당 handle 없음 확인
+tmux list-windows -a                 # 잔여 창 없음 확인
+git config --get-regexp "^workmux\.worktree\.{handle}\."   # exit 1 확인
+git branch --list '{head브랜치명}'    # 남아 있으면 그때만 -D
+```
+
+`workmux remove`가 로컬 브랜치까지 지우므로(`remove-worktree/SKILL.md:26`)
+`git branch -D`를 무조건 실행하지 않는다. 남아 있는지 먼저 확인하고 남았을 때만 지운다.
+정리 후 잔여물이 확인되면 그 사실을 보고하고 다음 단계로 넘어가지 않는다.
+
+**git-crypt 경로(AC-37)는 스모크 테스트하지 않는다.** `zambaguni-front` worktree
+생성은 의존성 설치로 개당 1~2GB를 쓰고 업무 저장소에 부작용을 남긴다. 문서 검토로
+판정하고 보고서에 한계로 기록한다. 다만 R4.6의 근거인 래퍼의 3단계 판별 로직은
+`zambaguni-front/scripts/create-worktree.sh:82-98`을 직접 읽어 확인했다.
+
+## Decisions
+
+### D1. 세션 우선순위에서 저장값이 모드 기본값보다 우선한다
+
+이슈 #35는 "명시값 > 모드 기본값 > 저장 세션 > 1-main"을 권장했다. 이를 뒤집어
+"명시값 > 저장 세션 > 모드 기본값 > 1-main"으로 채택했다.
+
+근거: 저장값은 사용자가 `move-window-to-session`으로 직접 창을 옮긴 행동의 기록이고,
+모드 기본값은 관습이다. 관습이 기록을 덮으면 현행 "예외 1"이 막으려던 실패가
+`2-review` 이름으로 재발한다. 사용자가 2026-08-27 확인에서 이 순서를 선택했다.
+
+### D2. PR 참조는 표지가 있을 때만 인식한다
+
+표지 없는 맨 숫자를 PR로 해석하지 않는다. GitHub는 이슈와 PR이 번호 공간을 공유하므로
+맨 숫자를 PR로 단정하면 엉뚱한 브랜치를 체크아웃할 수 있다. R1.4의 자연어 케이스가
+R1.5와 모순되지 않는 이유는 금지 대상이 **표지 없는** 맨 숫자이기 때문이다.
+
+### D3. PR 모드에서 positional 브랜치명과 `--name`을 생략한다
+
+`workmux add --help` 실측: "`[BRANCH_NAME]` ... When used with `--pr`, this becomes the
+custom local branch name". positional을 주면 PR head 대신 그 이름으로 로컬 브랜치가
+생긴다. `--name`도 쓰지 않는다 — 기본 명명을 그대로 두어야 R6.9의 handle 확보 규칙이
+실제 상황을 검증한다. `--name`은 0차 픽스처 전용이다.
+
+### D4. worktree 식별자는 handle이며 유추하지 않는다
+
+`{이름}`을 `workmux list --json`의 `handle`로 정의했다.
+
+대안 비교:
+
+- **대안 A — 브랜치명 사용**: handle이 브랜치 슬러그와 같을 수도 다를 수도 있어
+  예측 불가능하다. dry-run 실측이 양쪽 사례를 보인다 — 기본 명명은 슬러그와 같고,
+  `--name`을 주면 다르다. 탈락.
+- **대안 B — tmux 창 이름 사용**: PR 모드는 `--target-name`을 반드시 쓰므로 handle과
+  창 이름이 **구조적으로 항상** 갈라진다(dry-run 2행). 탈락.
+- **대안 C — 경로 basename 사용**: 대체로 handle과 같지만 `worktree_naming` 설정이
+  바뀌면 어긋날 수 있다. `workmux list --json`이 없을 때의 폴백으로만 두고 `path`
+  대조를 요구한다.
+- **대안 D — `workmux list --json`의 `handle`(채택)**: workmux 자신이 쓰는 이름을
+  직접 읽으므로 유추가 없다.
+
+**근거를 특정 worktree에 걸지 않는다.** 1차·2차 Spec은 당시 존재하던 worktree 하나를
+반례로 인용했다가 그 worktree가 제거되며 근거가 죽었다. 이 Spec은 대신 `--dry-run`으로
+재현 가능한 명령 결과를 근거로 쓰고, 실행 검증은 0차 픽스처가 조건을 직접 만든다.
+
+### D5. 창 탐지는 파생 이름이 아니라 저장값과 안정 식별자로 한다
+
+`is_open` → 저장된 `window-session` → 저장된 `target-window` → pane 경로 교차 확인
+순서를 쓰고, 얻은 `window_id`·`pane_id`를 이후 조작의 기준으로 삼는다.
+
+대안 비교:
+
+- **대안 A — 이번 호출이 파생한 창 이름으로 매칭**: PR 모드는 `--target-name`을 반드시
+  쓰므로 handle과 갈라지고, 같은 worktree를 브랜치 모드로 먼저 만들었다면 저장된 이름과
+  또 다르다. 열린 창을 놓치고 중복 창을 만든다. 탈락.
+- **대안 B — `session:index` 추적**: `move-window`와 번호 재정렬로 바뀐다. 탈락.
+- **대안 C — 에이전트 state 파일 조회**: `~/.local/state/workmux/agents/*.json`은
+  에이전트가 붙은 pane만 담는다. 레이아웃이 nvim만 자동 실행하므로
+  (`~/.config/workmux/config.yaml`) 창이 있어도 항목이 없을 수 있다. 탈락.
+- **대안 D — 저장값 + pane 경로 + `window_id`(채택)**: `target-window`는 workmux가
+  창을 만들 때 저장한 값이므로 읽는 것이지 유추가 아니다. pane 경로는 교차 확인으로
+  두어 저장값이 스테일할 때를 잡는다.
+
+pane cwd는 사용자가 바꿀 수 있고 매칭기가 공백 경로에 약하므로 완전하지 않다. 그래서
+0건·2건 이상·공백 경로에서 추측하지 않고 확인받는 규칙을 함께 둔다(R7.1).
+
+### D6. 래퍼는 고치지 않고 스킬이 전제를 보장한다
+
+래퍼의 "둘 다 없으면 현재 HEAD에서 새 브랜치"는 브랜치 모드에서는 올바른 동작이다.
+문제는 PR 모드에서 head가 `origin`에 없을 때(fork PR)뿐이다.
+
+- **대안 A — 래퍼에 `--pr` 지원 추가**: 다른 저장소를 고쳐야 하고 변경 범위 밖. 탈락.
+- **대안 B — 스킬이 호출 전 fetch로 전제 보장(채택)**: `refs/pull/{N}/head`를 로컬
+  브랜치로 가져오면 래퍼의 2번 경로로 확정된다.
+- **대안 C — PR 모드에서 git-crypt 저장소 미지원**: #28의 요구를 포기. 탈락.
+
+사후 검증(R6.8)을 함께 두어 전제 보장이 실패해도 조용한 성공이 되지 않게 한다.
+
+### D7. 기존 worktree는 중단이 아니라 창 처리로 분기한다
+
+이슈 #28의 "중단한다"는 **중복 worktree나 별칭 브랜치를 만들지 말라**는 뜻이지 창을
+열지 말라는 뜻이 아니다. 문자 그대로 전체 중단으로 읽으면 PR 리뷰 창을 두 번째부터
+영영 열 수 없어 Goal 2와 R7 전체가 무의미해진다.
+
+### D8. PR state는 소비하되 자동 중단하지 않는다
+
+`state`를 조회 필드에 넣고 R4.7에서 소비한다. CLOSED·MERGED PR을 사후에 들여다보는
+것은 정당한 용도이므로 자동 중단하지 않고 알린 뒤 확인받는다. 저장소 관련 필드는 R4.0이
+확정하므로 조회 필드에서 제외했고, fork 여부는 pull ref가 균일 처리하므로 넣지 않는다 —
+요구만 하고 쓰지 않는 필드는 검증을 형식화한다.
+
+### D9. workmux 버전 표기 불일치를 `dot_claude` 쪽으로 통일한다
+
+이슈 #35는 두 원본이 frontmatter만 다르다고 전제했으나 실측에서 문구가 1줄 다르다.
+`dot_claude` 쪽이 현재 설치 버전까지 재확인한 더 정확한 서술이므로 그쪽으로 통일한다.
+
+### D10. 스모크 테스트를 0차 + 4단계로 나눈다
+
+- 0차 — AC-9 픽스처. A부는 workmux 동작 전제를, B부는 산출물이 실제로 조회한 키를
+  판별한다.
+- 1차 — 신규 생성, 세션 미명시 → R2 우선순위 3, 이름 파생, 내용 검증, `--pr` 정규화
+- 2차 — 같은 세션 명시 → R7.3의 중복 창 금지
+- 3차 — 다른 세션 명시 → R7.5의 이동과 R2.4의 config 갱신
+- 4차 — 레거시 저장값 + 세션 미명시 → R2.6의 갱신 대상과 R7.4의 경로 2
+
+각 분기는 상호 배타적이라 조건을 만드는 호출이 각각 필요하다. 2차를 빼면 R7.3이,
+4차를 빼면 R2.6의 세 번째 행(SPEC-011이 지적한 경로)이 한 번도 실행되지 않는다. 0차는
+같은 PR head 브랜치를 쓰므로 1차 전에 완전히 정리한다.
+
+### D11. 정리 시 `git branch -D`를 조건부로 한다
+
+`remove-worktree/SKILL.md:26`에 따르면 `workmux remove`가 로컬 브랜치까지 지운다.
+무조건 실행하면 정리 중 오류가 난다. `git branch --list`로 확인한 뒤 남았을 때만 지운다.
+
+### D12. `move-window-to-session`의 입력 계약에 맞춰 호출한다
+
+그 스킬의 계약은 `<윈도우이름|세션:번호> <대상세션>`이며 내부에서 `{원본세션}:{번호}`,
+`{worktree경로}`, `{worktree명}`을 쓴다. 스킬 수정은 비범위이므로 `window_id`를 그대로
+넘기지 않고, 호출 직전에 `tmux display-message`로 현재 `세션:번호`를 해석해 넘긴다.
+그 스킬의 3-(a)가 `window-session`을 갱신하므로 R2.4는 확인으로 동작한다.
+
+### D13. `description`도 갱신한다
+
+`argument-hint`만 고치면 인자 힌트는 맞지만 **라우팅이 바뀌지 않는다.** `description`은
+에이전트가 "이 요청에 이 스킬을 쓸까"를 판단하는 문장이고, 현재 양쪽 파일 모두 브랜치만
+언급한다(실측). PR 참조가 유효한 입력이 된 이상 그 문장도 PR과 대상 세션을 포함해야
+자연어 PR 호출이 스킬에 도달한다.
+
+### D14. 보존 대상 규칙을 명시적으로 열거한다
+
+Goal 5의 "회귀 없음"은 검증 가능해야 한다. 재작성 과정에서 조용히 사라지기 쉬운 현행
+규칙 18개를 R9.6에 열거하고 AC-57로 확인한다.
+
+### D15. AC-9은 자기 완결 픽스처로 판별한다 (SPEC-009 해소)
+
+2차 Spec의 AC-9은 "`--get-regexp` 출력의 모든 키가 대상 handle 기준"이었다. 두 가지
+이유로 성립하지 않는다.
+
+1. workmux 키는 **공유 저장소 config**에 있어 다른 worktree의 키도 함께 나온다(실측).
+   무관한 worktree가 하나라도 있으면 올바른 구현에도 실패한다.
+2. 기본 명명에서는 handle == 브랜치 슬러그라, 대상으로 범위를 좁히면 브랜치 유추
+   프로브가 동어반복이 된다.
+
+대안 비교:
+
+- **대안 A — 조건에 맞는 기존 worktree를 찾아 쓴다**: 1차·2차가 그렇게 했다가 그
+  worktree가 제거되며 근거가 죽었다. 지금 존재하는 것들도 진행 중 작업용이라 같은
+  운명이다. 탈락.
+- **대안 B — 조건부 증거로 강등**: 실행 판별을 포기하고 문서 검토로 덮는다. 안전하지만
+  R2.0의 핵심 규칙이 실행으로 검증되지 않는다.
+- **대안 C — 테스트가 조건을 직접 만든다(채택)**: `workmux add --name`으로 handle을
+  브랜치 슬러그와 다르게, `--target-name`으로 창 이름을 handle과 다르게 지정하면 세
+  이름이 모두 갈라진다. dry-run으로 그렇게 동작함을 확인했다. 세 프로브가 특정 이름만
+  조회하므로 다른 worktree의 존재에 영향받지 않고, 픽스처는 검증 후 제거되므로 다음
+  실행에 남지 않는다.
+
+**폴백으로 B를 유지한다.** 픽스처 생성이 실패하면 실행 판정을 포기하고 강등한 뒤 잔여
+격차를 기록한다 — 실행되지 않은 검증을 통과로 적지 않는다.
+
+### D16. `--pr` 인자를 정규화한다 (SPEC-010 해소)
+
+`workmux add --pr`의 계약은 `<NUMBER|URL>`이다(실측). R1.4가 허용하는 세 형태 중
+`{owner}/{repo}#{번호}`와 표지 있는 자연어는 그대로 넘기면 거부된다. R4.0·R4.1이 이미
+저장소와 번호를 분해하므로, R4.8에서 **PR 번호로 환원**해 넘긴다.
+
+URL을 넘기는 선택지도 계약상 유효하지만 쓰지 않는다 — R4.2가 저장소 불일치를 중단시켜
+`--pr`에 도달하는 값은 항상 현재 저장소의 PR이므로, 번호만으로 충분하고 더 짧다.
+
+### D17. 증거에서 휘발성 식별자를 배제한다
+
+1차 Spec은 특정 worktree를 R2.0·R7.1·D4의 근거로 인용했고, 2차가 그 인용을 이어받았다.
+그 worktree가 제거되면서 세 곳의 근거가 동시에 죽었다. 같은 사이클을 반복하지 않기
+위해 이 Spec은 특정 worktree 디렉터리명·브랜치명, `pane_id`·`window_id`·`세션:번호`를
+증거나 AC의 고정 대상으로 쓰지 않는다. 대신 재현 가능한 명령 결과, 커밋된 파일 인용,
+그리고 테스트가 직접 만드는 픽스처를 쓴다.
+
+### D18. `window-session` 갱신 대상은 창의 실제 위치가 정한다
+
+R2.2·R2.5가 저장값을 갱신할 때 무조건 `SELECTED_SESSION`을 쓰면, 창을 옮기지 않는
+경로에서 config가 창의 실제 위치와 어긋난다. 저장값이 레거시이거나 사라진 세션을
+가리키면 우선순위 2가 건너뛰어져 `SELECTED_SESSION`이 우선순위 3·4의 값이 되는데,
+사용자가 세션을 명시하지 않았으면 R7.4가 창을 옮기지 않기 때문이다.
+
+- **대안 A — 항상 `SELECTED_SESSION`으로 갱신**: 위 어긋남을 만든다. R2.0·R2.4가 막으려던
+  상태를 스킬이 스스로 생성하고 매 호출 재생산한다. 탈락.
+- **대안 B — 갱신하지 않는다**: 레거시 값이 영영 남아 R2.2의 마이그레이션 목적이 무너
+  지고, R2.5의 막다른 길도 해소되지 않는다. 탈락.
+- **대안 C — 창을 `SELECTED_SESSION`으로 옮긴다**: 사용자가 명시하지 않았는데 배치를
+  바꾸는 것이라 R2.1·R7.4의 취지("의도적으로 옮긴 창을 되끌지 않는다")에 정면으로
+  어긋난다. 탈락.
+- **대안 D — 창이 열려 있고 옮기지 않으면 실제 세션으로 갱신(채택)**: config가 항상
+  창의 실제 위치를 가리키고, 레거시 값도 해소되며, 배치는 그대로다.
+
+실제 세션이 확정되지 않았으면(R7.1 불일치 처리) 갱신하지 않는다 — 잘못된 값을 쓰는
+것보다 옛 값을 두고 알리는 편이 안전하다.
+
+### D19. AC-9을 환경 전제(A부)와 산출물(B부)로 나눈다
+
+0차 픽스처가 `workmux add`를 직접 실행하고 `git config`로 결과를 보는 것만으로는
+**workmux 0.1.248의 동작**만 판별한다. 산출물인 SKILL.md가 브랜치나 창 이름으로 키를
+만들도록 잘못 적혀 있어도 그 검사는 통과한다.
+
+그래서 B부를 두어, 같은 픽스처를 대상으로 개정된 절차를 수행하고 **실행된 `git config`
+명령의 키 이름을 기록**한다. 산출물에 결함이 있으면 기록에 `{슬러그}`나 `{W}` 기준
+조회가 나타난다. 위험 표의 완화 주장도 이 두 겹으로 정정했다 — A부 단독을 "실행 판별"로
+적는 것은 실제보다 강한 보증이었다.
+
+전제 확인으로 픽스처 생성 전 키 기준선을 남기는 단계도 추가했다. 그것이 없으면
+프로브의 exit 0이 구현 때문인지 잔여 키 때문인지 구분할 수 없다.
+
+### D20. R2.3의 금지 대상을 열거한다
+
+"선택 세션 확정 전에는 어떤 workmux 명령도 실행하지 않는다"는 R7.0·R7.1이 세션 선택보다
+먼저 `workmux list --json`을 쓰고 R6.9가 `--dry-run`을 허용하는 것과 정면으로 충돌한다.
+그대로 SKILL.md에 옮기면 자기모순인 문서가 배포된다. 의도는 **영속 변경을 만드는
+명령**의 금지였으므로 `add`·`open`·`remove`·`close`를 열거하고 읽기 전용 조회와
+`--dry-run`을 예외로 명시했다.
+
+### 미해결 사항
+
+없다. 모든 중대 결정이 위에 해소되어 있다.

--- a/dot_agents/skills/create-worktree/SKILL.md
+++ b/dot_agents/skills/create-worktree/SKILL.md
@@ -1,193 +1,316 @@
 ---
 name: create-worktree
-description: Use when creating a new git worktree for a branch to work on in isolation from the main workspace
+description: Use when creating a git worktree for a branch or a pull request (PR) review, optionally opening it in a named tmux session
 ---
 
 # Create Worktree
 
-git worktree를 만들고 workmux로 tmux 윈도우를 연다. pane 레이아웃은
-`~/.config/workmux/config.yaml`(좌 nvim / 우상 / 우하)이 담당하므로 여기서
-tmux를 직접 조작하지 않는다. 새 workmux 윈도우는 `1-main` 세션에 연다
-(이미 다른 세션으로 옮겨 둔 worktree는 예외 — 아래 "부모 tmux 세션" 참조).
+브랜치 또는 PR의 git worktree를 만들거나 기존 worktree를 열고, 선택한 tmux 세션의
+workmux 윈도우로 연결한다. 창과 세션 상태를 추측하지 말고 아래 순서대로 확인한다.
+
+## 실행 순서 요약
+
+1. 입력 파싱(파라미터)
+2. PR 모드면 저장소 확정과 PR 해석 → head 브랜치·`headRefOid` 확보
+3. 기존 worktree 존재·경로 판정 → handle 확보
+4. 창이 있으면 창 탐지(`is_open` → 저장 세션 → `target-window` → pane 경로)
+5. 세션 선택(명시값 > 유효·생존 저장값 > 모드 기본값 > 전역 기본값)
+6. 세션 검증
+7. 이름 파생
+8. 분기: 기존 worktree면 창 처리, 없으면 생성·오픈 경로
+9. 사후 검증과 보고
+
+아래 절은 주제별로 묶여 있어 이 순서와 배열이 다르다. 실행은 이 순서를 따른다.
 
 ## 파라미터
 
-- **args** (필수): 브랜치명 (예: `278-feat/chat-infrastructure`, `ZF-100-feat/login`)
-- args가 비어있으면 사용자에게 브랜치명을 물어본다.
+- 첫 번째 positional 인자는 필수인 브랜치명 또는 PR 참조다. 없으면 사용자에게 묻는다.
+- 두 번째 positional 인자는 선택 사항이며 정확한 tmux 세션명이다.
+- positional 인자가 세 개 이상이면 추측하지 말고 `<branch-name|pr-ref> [target-session]`
+  사용법을 안내한 뒤 중단한다.
+- PR 모드는 다음 세 형태에서만 선택한다.
+  - `https://github.com/{owner}/{repo}/pull/{번호}` 전체 URL
+  - `{owner}/{repo}#{번호}`
+  - `PR 1313`, `1313번 PR`, `pull request 1313`처럼 번호 앞뒤에 표지가 있는 자연어
+- 표지 없는 맨 숫자(`1313`)는 PR로 단정하지 않는다. GitHub의 이슈와 PR은 번호 공간을
+  공유하므로 엉뚱한 대상을 checkout할 수 있다. 브랜치로 해석하거나 해석할 수 없으면
+  확인한다.
+- 자연어 호출은 `(브랜치명|PR 참조, 대상 세션)` 2-튜플로 환원한다. 브랜치/PR 참조가
+  둘 이상이거나 세션명이 둘 이상이면 중단하고 확인한다. 자연어가 2-튜플로 환원됐으면
+  positional 인자 수 제한을 적용하지 않는다.
+- 세션명에 접두사를 붙이거나 현재 세션 목록에서 비슷한 이름을 추측하지 않는다.
 
-## 부모 tmux 세션
+## 워크트리 식별자
 
-window mode의 `workmux add`와 `workmux open` 호출에 `--parent-session 1-main`을
-넘긴다. 실행 중인 에이전트가 `3-personal` 같은 다른 세션에 있어도 현재 세션을 부모로
-사용하지 않는다.
+git config 키의 `{handle}`은 `workmux list --json` 항목의 `handle` 필드다.
+브랜치명이나 tmux 창 이름으로 유추하지 않는다. handle은 기본 명명에서는 `path`의
+basename과 같을 수 있지만 `worktree_naming`, `worktree_prefix`, `--name`에 따라 달라질
+수 있다. 특히 PR 모드의 `--target-name`은 handle과 창 이름을 구조적으로 갈라놓는다.
 
-```bash
-tmux list-sessions -F '#{session_name}'    # 종료 코드를 먼저 본다
-```
+handle 하나에는 최대 `.mode`, `.target-window`, `.window-session`, `.window-token` 하위
+키가 있다. 이 스킬은 `.window-session`만 읽거나 쓰고, `.target-window`는 창 탐지에서만
+읽는다. 잘못된 handle로 `git config`를 쓰면 오류 없이 새 섹션이 생기므로 실제 값을
+확보하기 전에는 쓰지 않는다.
 
-`list-sessions`가 exit 1 + `error connecting to ...`로 실패하면 tmux 서버 자체가 없는
-것이다. "세션이 없다"와 구분해 그대로 보고한다 — `grep`에 바로 물리면 두 상황이 똑같이
-"없음"으로 뭉개져 사용자가 엉뚱한 안내를 받는다.
+`workmux list --json`을 쓸 수 없을 때만 worktree 절대경로의 basename을 폴백으로 쓴다.
+그 경우 `path` 필드와 대조해 확인하며, 대조할 수 없으면 중단한다.
 
-```bash
-tmux list-sessions -F '#{session_name}' | grep -qxF -- 1-main && echo 있음 || echo 없음
-```
+## 세션 선택
 
-`has-session -t 1-main`을 쓰지 않는 이유: tmux 타깃은 접두사 매칭을 하므로
-`1-maintenance` 세션만 있어도 exit 0을 낸다(실측). 순번 접두사를 쓰는 지금은 함정이
-더 넓다 — `1-main`만 있어도 `has-session -t 1`이 exit 0이다. 없는데 있다고 판정하면
-아래 오류 처리가 발동하지 않는다.
+먼저 대상 브랜치의 기존 worktree와 경로를 확인해 handle을 확보한다. 그 후
+`SELECTED_SESSION`을 다음 우선순위로 정한다.
 
-`1-main` 세션이 없으면 **여기서 멈춘다.** 현재 세션으로 대체하지 말고 사용자에게
-오류를 알린다. 이 체크를 건너뛰면 안전망이 없다 — workmux는 `--parent-session`에 없는
-세션명을 받으면 **오류 없이 그 세션을 새로 만들고**(rc=0, 0.1.233 실측) 그 값을
-`workmux.worktree.{이름}.window-session` git config에 영구 저장한다. 그러면 아래
-"예외 1"이 그 잘못된 값을 "의도적으로 옮긴 것"으로 승격시켜, 이후 모든 `workmux open`이
-유령 세션을 계속 존중한다. 자기 교정 경로가 없다.
+1. 이번 호출에서 사용자가 명시한 세션
+2. 기존 worktree의 `workmux.worktree.{handle}.window-session`이 `^[0-9]+-.+$`를 만족하고
+   실제로 존재할 때의 저장값
+3. 모드 기본값: PR 모드면 `2-review`
+4. 전역 기본값 `1-main`
 
-**예외 1 — 이미 옮겨 둔 worktree.** `workmux open`은 기존 worktree도 여는 명령이다.
-git config의 `workmux.worktree.{이름}.window-session`이 `1-main`이 아니면 그것은
-`move-window-to-session`으로 **의도적으로 옮긴** 것이므로, `--parent-session`을
-생략해 그 값을 존중한다. 무조건 붙이면 옮겨 둔 창을 조용히 `1-main`으로 되끌고 온다.
+저장값은 사용자가 창을 직접 옮긴 기록이고 모드 기본값은 관습이므로, 저장값이 모드
+기본값보다 우선한다.
 
-```bash
-git -C {worktree경로} config --get workmux.worktree.{이름}.window-session
-```
+| 명시 세션 | 유효하고 생존한 저장값 | 모드 | 선택 결과 |
+| --- | --- | --- | --- |
+| `3-personal` | `2-review` | PR | `3-personal` |
+| 없음 | `3-personal` | PR | `3-personal` |
+| 없음 | 없음 | PR | `2-review` |
+| 없음 | 없음 | 브랜치 | 전역 기본값 `1-main` |
 
-**단, 값이 `{순번}-{이름}` 형식이 아니면 의도적인 이동이 아니다.** 규칙 이전의 값이
-그대로 남은 것이다. 현재 모든 세션명은 `숫자-`로 시작하므로, `move-window-to-session`이
-기록한 값이라면 반드시 그 형태다. `main`뿐 아니라 `review`, `personal`, `eslint`,
-`quick`도 마찬가지다 — 열거로 판정하지 말고 형식으로 판정한다.
+저장값은 셸 glob(`[0-9]*-*`)이 아니라 정규식 `^[0-9]+-.+$`로 판정한다. glob의 첫
+`*`는 숫자 반복이 아닌 임의 문자열이어서 `1legacy-session`과 `1-`도 통과한다. 예전
+마이그레이션에서 남은 값(예: `1-main`이 아닌 형식 밖 값)은 레거시로 취급한다.
 
-```bash
-v=$(git -C {worktree경로} config --get workmux.worktree.{이름}.window-session)
-if [ -z "$v" ]; then
-  echo "값 없음 → --parent-session 1-main"
-elif printf '%s' "$v" | grep -qE '^[0-9]+-.+$'; then
-  echo "규칙에 맞는 값: $v → 의도적인 이동, 예외 1 적용"
-else
-  echo "규칙 밖 값: $v → 레거시로 판단"
-fi
-```
+선택 세션이 확정되기 전에는 영속 변경을 만드는 `workmux add`, `workmux open`,
+`workmux remove`, `workmux close`를 실행하지 않는다. 읽기 전용 `workmux list --json`과
+`--dry-run` 조회는 예외다.
 
-셸 glob(`[0-9]*-*`)으로 판정하면 안 된다. 첫 `*`가 숫자 반복이 아니라 임의 문자열이라
-`1legacy-session`이나 `1-`처럼 규칙에 맞지 않는 값까지 통과한다(실측). 위 정규식은
-숫자 접두사 + 곧바로 이어지는 하이픈 + 비어 있지 않은 이름을 요구한다.
+명시 세션이 유효한 저장값을 덮었으면 창을 연 뒤 handle의 `window-session`이 명시 세션을
+가리키는지 확인하고 다르면 갱신한다. 형식은 유효하지만 사라진 저장 세션이면 다음처럼
+복구한다.
 
-규칙 밖 값이면 예외를 적용하지 말고 `--parent-session 1-main`을 넘기면서 git config
-값도 갱신한다. 그냥 존중하면 workmux가 그 레거시 세션을 조용히 되살리고, 값이 계속
-남아 매번 재생산된다. 어느 새 이름으로 옮길지 애매하면(예: `personal` → `3-personal`
-이 맞는지) 추측하지 말고 사용자에게 확인한다.
+1. 사라진 저장값을 사용자에게 알린다.
+2. 모드 기본값과 전역 기본값으로 계산한 대안을 제시하고 확인받는다.
+3. 확인된 세션으로 진행한다.
+4. 세션을 자동 생성하지 않는다.
 
-```bash
-git -C {worktree경로} config workmux.worktree.{이름}.window-session 1-main
-```
+레거시 또는 사라진 저장값을 고칠 때 기록할 값은 창의 실제 위치로 정한다.
 
-**예외 2 — 지원되지 않는 조합.** `--parent-session`은 session mode, 샌드박스 안,
-그리고 여러 worktree를 한 번에 만드는 경우(`--count`, `--foreach`, 여러 `--agent`,
-stdin)에는 거부된다. 그때는 생략한다.
+| 상태 | `window-session` 갱신 대상 |
+| --- | --- |
+| 창이 닫혀 있음 | `SELECTED_SESSION` |
+| 창이 열려 있고 명시 세션으로 이동함 | `SELECTED_SESSION` |
+| 창이 열려 있으나 이동하지 않음 | 창 탐지로 확정한 실제 세션 |
 
-## 실행 순서
+실제 세션을 확정하지 못했으면 갱신하지 않는다. 세션 미명시 호출에서 열린 창을 옮기지
+않는 경우에는 선택값이 아니라 실제 위치를 기록해야 config와 창 위치가 어긋나지 않는다.
 
-저장소가 **래퍼 스크립트를 제공하는지**로 경로가 갈린다. 판정은 저장소 루트를 기준으로
-한다 — 상대 경로로 판정하면 서브디렉터리나 기존 worktree 안에서 스킬을 부를 때 false가
-되어, git-crypt 저장소인데도 아래에서 금지하는 `workmux add` 경로로 빠진다.
+## 세션 검증
 
-```bash
-ROOT=$(git rev-parse --show-toplevel)
-[[ -f "$ROOT/scripts/create-worktree.sh" ]] && echo "스크립트 경로" || echo "workmux 경로"
-git -C "$ROOT" config --get filter.git-crypt.smudge   # 값이 있으면 git-crypt 저장소
-```
-
-스크립트가 있는데 실행 권한이 없으면 경로를 바꾸지 말고 그 사실을 오류로 알린다.
-`git-crypt` 필터가 설정되어 있는데 스크립트가 없으면 사용자에게 확인받고 진행한다.
-
-### 스크립트가 있을 때 (git-crypt 저장소)
-
-`workmux add`를 쓰지 않는다. workmux는 내부적으로 `git worktree add`를 실행하는데,
-git-crypt 저장소에서는 그것이 smudge 필터 에러로 **실패한다**. 아래 `--no-checkout`
-서술은 이 git-crypt 경로에 대한 것이다 — 래퍼의 비-git-crypt 분기는 평범한
-`git worktree add`를 쓴다.
+선택 세션은 영속 workmux 명령 전에 검증한다.
 
 ```bash
-./scripts/create-worktree.sh {브랜치명}    # --no-checkout 생성·키 링크·체크아웃 + 의존성 설치
-workmux open {디렉토리명} --target-name {윈도우이름} --parent-session 1-main  # 이슈 번호가 있을 때
-workmux open {디렉토리명} --parent-session 1-main                          # 이슈 번호가 없을 때
+tmux list-sessions -F '#{session_name}'
 ```
 
-- **스크립트가 실패하면 여기서 멈춘다.** 종료 코드를 확인하고, 실패했으면
-  `workmux open`으로 넘어가지 않는다. 스크립트는 worktree를 `--no-checkout`으로 만든 뒤
-  키 링크·체크아웃·의존성 설치를 하므로 뒤쪽에서 죽어도 worktree는 남는다 — 그 상태로
-  `workmux open`을 실행하면 성공해버려서 파일이 암호화된 채이거나 의존성이 없는
-  worktree를 정상으로 보고하게 된다.
-- 스크립트의 확인 프롬프트는 `-y`나 `yes |`로 우회하지 않고 사용자에게 직접 확인받는다.
-- **스크립트 출력에서 worktree 절대경로를 확보한다.** `workmux open`에 넘길
-  디렉토리명은 그 경로의 basename이다 (아래 "이름 파생" 참조).
-- `workmux open`은 `git worktree list`로 worktree를 찾으므로 `worktree_dir` 밖의
-  형제 디렉토리도 그대로 인식한다.
-
-### 스크립트가 없을 때
-
-workmux가 생성과 윈도우 구성을 한 번에 한다.
+먼저 종료 코드를 확인한다. exit 1과 `error connecting to ...`는 tmux 서버 부재이므로
+세션 부재와 구분해 보고하고 중단한다. 목록 조회가 성공했을 때만 다음처럼 전체 문자열
+일치로 확인한다.
 
 ```bash
-workmux add {브랜치명} --target-name {윈도우이름} --parent-session 1-main  # 이슈 번호가 있을 때
-workmux add {브랜치명} --parent-session 1-main                          # 이슈 번호가 없을 때
+tmux list-sessions -F '#{session_name}' | grep -qxF -- "$SELECTED_SESSION"
 ```
+
+`tmux has-session -t`는 쓰지 않는다. tmux target은 접두사 매칭을 하므로 `2`나 `2-rev`가
+의도치 않은 세션에 매칭될 수 있다. 선택 세션이 없으면 자동 생성하지 않는다. 명시값이면
+오타 가능성을 알리고 중단하며, 저장값이면 앞 절의 복구 경로를 따른다. 검증 없이
+`--parent-session`에 없는 값을 주면 workmux가 세션을 만들고 config에 영구 저장하는 유령
+세션 위험이 있다.
+
+## PR 해석
+
+PR 입력에서는 다음 표로 `{owner}/{repo}`를 확정한다.
+
+| 입력 | `{owner}/{repo}` 출처 |
+| --- | --- |
+| 전체 PR URL | URL 경로 |
+| `{owner}/{repo}#{번호}` | 입력 문자열 |
+| 표지가 있는 자연어 | 현재 저장소 |
+
+현재 저장소는 우선 `gh repo view --json owner,name -q '.owner.login + "/" + .name'`으로
+구하고, 실패하면 `git remote get-url origin`을 파싱한다. 둘 다 실패하면 중단한다.
+입력 저장소와 현재 저장소가 다르면 두 값을 알리고 중단한다.
+
+확정한 저장소에서 다음 네 필드를 조회한다.
+
+```bash
+gh pr view {번호} --repo {owner}/{repo} --json number,state,headRefName,headRefOid
+```
+
+`number`, `headRefName`, `headRefOid`는 각각 이름 파생과 내용 검증에 쓰고, `state`는
+CLOSED·MERGED 처리에 쓴다. `gh`가 없거나 인증·조회에 실패하면 추측하지 말고 중단한다.
+CLOSED 또는 MERGED면 상태를 알리고 계속할지 확인한다. 자동 중단하지 않되 head 브랜치가
+삭제되어 fetch가 실패할 수 있음을 안내한다.
+
+동일한 head 브랜치의 worktree가 이미 있으면 생성만 건너뛰고 기존 경로의 창 처리로
+진행한다. 같은 이름의 로컬 브랜치가 head OID와 다르면 덮어쓰지 않고 중단한다.
+
+래퍼 경로에서 새 worktree를 만들기 전, 로컬 브랜치가 없을 때는 PR head를 확보한다.
+
+```bash
+git fetch origin "refs/pull/{PR번호}/head:{head브랜치명}"
+git rev-parse --verify "refs/heads/{head브랜치명}"
+```
+
+검증 OID가 `headRefOid`와 다르거나 fetch가 실패하면 중단하고 래퍼를 호출하지 않는다.
+래퍼는 브랜치를 찾지 못하면 현재 HEAD에서 빈 브랜치를 만들 수 있다.
+래퍼가 없는 경로는 `workmux add --pr`가 체크아웃을 직접 하므로 사전 fetch가 필요 없다.
+대신 생성 후 `HEAD`가 `headRefOid`와 같은지 검증해 같은 보장을 얻는다.
+
+`workmux add --pr`에는 원시 입력을 넘기지 않는다. 저장소 일치와 PR 조회로 확정한 숫자만
+정규화해 넘긴다. 따라서 `{owner}/{repo}#{번호}`와 자연어 표지 입력도 `--pr {PR번호}`가
+된다.
 
 ## 이름 파생
 
-- **짧은 이름**: 브랜치명에서 마지막 `/`까지를 제거한다.
-  `392-feat/add-partner-chat-enabled` → `add-partner-chat-enabled`
-- **이슈 번호**: 브랜치명 **맨 앞**의 숫자 또는 `ZF-숫자`만 인식한다. 맨 앞이 아니면
-  이슈 번호가 아니다 — `feat/392-add-x`는 이슈 번호가 없는 것으로 본다.
-- **윈도우이름**: 이슈 번호가 있을 때만 `{이슈번호}-{짧은이름}`을 만들어
-  `--target-name`에 넘긴다. **이슈 번호가 없으면 `--target-name`을 생략한다.**
-  짧은 이름만 넘기는 것은 어느 경로에서도 하지 않는다 — 브랜치 prefix와 저장소
-  이름을 모두 잃어 충돌 확률만 높아진다.
+- 짧은 이름은 브랜치명(또는 PR head 브랜치명)의 마지막 `/` 뒤 부분이다.
+  `392-feat/add-partner-chat-enabled`의 짧은 이름은 `add-partner-chat-enabled`다.
+- 브랜치 모드의 이슈 번호는 브랜치명 맨 앞의 숫자 또는 `ZF-숫자`만 인식한다.
+  `feat/392-add-x`에는 이슈 번호가 없다.
+- PR 모드 창 이름은 `{PR번호}-{짧은이름}`이며, head 브랜치의 이슈 번호보다 PR 번호를
+  우선한다.
+- 브랜치 모드에 이슈 번호가 없으면 `--target-name`을 생략한다.
+- workmux가 target name을 소문자로 정규화하므로 안내와 재사용에도 소문자 값을 쓴다.
+- 창 이름 충돌 시 브랜치 모드는 `{repo명}-{짧은이름}`, PR 모드는
+  `{PR번호}-{repo명}-{짧은이름}`으로 재시도한다.
 
-  | 브랜치 | `--target-name` | `add` 경로 윈도우 | `open` 경로 윈도우 |
-  | --- | --- | --- | --- |
-  | `392-feat/add-partner-chat-enabled` | `392-add-partner-chat-enabled` | `392-add-partner-chat-enabled` | 같음 |
-  | `ZF-115-chore/some-feature` | `ZF-115-some-feature` | `zf-115-some-feature` | 같음 |
-  | `fix/login-bug` | 생략 | `fix-login-bug` | `zambaguni-front-login-bug` |
+## 생성·오픈 경로
 
-  생략했을 때 workmux가 쓰는 기본 이름은 경로마다 다르다.
-  `workmux open`은 넘긴 디렉토리명(`{repo명}-{짧은이름}`)을 그대로 써서 저장소 이름이
-  들어가지만, `workmux add`는 브랜치명 슬러그를 써서 저장소 이름이 **없다**. 그래서
-  `add` 경로에서는 두 저장소가 같은 브랜치명을 쓰면 두 번째가
-  `✗ A tmux window named '...' already exists`로 실패한다 — 그때는
-  `--target-name {repo명}-{짧은이름} --parent-session 1-main`으로 재시도한다.
-
-  workmux는 target name을 소문자로 정규화한다. 사용자에게 안내하거나 이후 명령에
-  재사용할 이름은 정규화된 소문자 쪽이다.
-- **디렉토리명**: 스크립트는 계속 `../{repo명}-{짧은이름}` 에 만들며 이슈 번호를 붙이지 않는다.
-  `workmux open`에는 이 디렉토리명(`zambaguni-front-add-partner-chat-enabled`)을 넘긴다.
-- 같은 브랜치의 worktree가 이미 있으면 새로 만들지 않고 기존 경로를 안내한다.
-
-## 마무리
+저장소 루트에서 분기한다. 서브디렉터리나 기존 worktree에서의 오판을 막기 위해 상대
+경로로 판정하지 않는다.
 
 ```bash
-workmux list
+ROOT=$(git rev-parse --show-toplevel)
+test -f "$ROOT/scripts/create-worktree.sh"
+git -C "$ROOT" config --get filter.git-crypt.smudge
+```
+
+git-crypt 저장소에서는 PR 모드를 포함해 원칙적으로 `workmux add`를 쓰지 않는다.
+
+- 래퍼가 있으면 실행 권한을 먼저 확인한다. **실행 권한이 없으면** 경로를 바꾸지 말고
+  오류로 보고한다. 래퍼가 실패하면 즉시 중단하고 `workmux open`으로 진행하지 않는다.
+  확인 프롬프트를 `-y`나 `yes |`로 자동 우회하지 않는다.
+- **예외:** git-crypt 필터가 있는데 래퍼가 없으면 `workmux add` 전에 사용자에게 확인받고
+  진행한다.
+
+래퍼 경로의 PR 모드는 head 브랜치를 확보한 뒤 다음 순서로 실행한다.
+
+```bash
+./scripts/create-worktree.sh {head브랜치명}
+workmux open {handle} --target-name {PR번호}-{짧은이름} --parent-session "$SELECTED_SESSION"
+```
+
+브랜치 모드도 래퍼가 출력한 경로와 handle을 확보한 뒤 `workmux open`을 사용한다.
+이슈 번호가 없으면 `--target-name`을 생략한다. 래퍼 출력에서 worktree 절대경로를 얻고,
+그 경로와 일치하는 `workmux list --json` 항목의 handle을 쓴다. 아직 목록에 없으면
+경로 basename을 `git worktree list --porcelain`으로 대조한 폴백으로만 사용하고, open 뒤
+실제 창을 다시 확인한다. `workmux open`은 `git worktree list`로 찾으므로 `worktree_dir`
+밖의 형제 디렉터리도 인식한다.
+
+래퍼가 없는 PR 모드는 positional 브랜치명과 `--name`을 생략한다.
+
+```bash
+workmux add --pr {PR번호} --target-name {PR번호}-{짧은이름} --parent-session "$SELECTED_SESSION"
+```
+
+브랜치 모드는 이슈 번호가 있을 때만 `--target-name {이슈번호}-{짧은이름}`을 추가한다.
+생성 전 `workmux add ... --dry-run`으로 예상 경로와 handle을 확인할 수 있다. 생성 뒤에는
+출력과 `workmux list --json`에서 실제 경로·handle을 얻으며 이름을 추측하지 않는다.
+
+`--parent-session`은 session mode, 샌드박스 안, `--count`, `--foreach`, 여러 `--agent`,
+stdin을 통한 여러 worktree 생성에서는 지원되지 않으므로 그 조합에서는 생략한다.
+PR worktree 생성 뒤에는 `git -C "{worktree경로}" rev-parse HEAD`가 `headRefOid`와 같은지
+검증한다. 다르면 성공으로 보고하지 않는다.
+
+## 기존 worktree 처리
+
+세션 선택보다 먼저 `git worktree list --porcelain`과 `workmux list --json`으로 브랜치의
+기존 worktree 경로·handle을 확인한다. 같은 브랜치가 이미 있으면 새로 만들지 않고 그
+경로를 안내한다.
+
+기존 창은 이번 호출에서 파생한 이름으로 찾지 않는다. 다음 순서로 탐지한다.
+
+1. `workmux list --json`의 handle 항목에서 `is_open`을 확인한다.
+2. `workmux.worktree.{handle}.window-session` 저장값으로 세션 후보를 좁힌다.
+3. `workmux.worktree.{handle}.target-window` 저장값으로 창 후보를 좁힌다. 저장값은 실제
+   창 이름의 접미사다. `nerdfont` 설정에 따라 글리프와 공백이 앞에 붙을 수 있으므로
+   동등 비교가 아니라 접미사 비교로 판정한다.
+4. pane 현재 경로를 worktree 절대경로와 교차 확인한다.
+
+```bash
+tmux list-panes -a -F '#{session_name}:#{window_index} #{window_id} #{pane_id} #{pane_current_path}' \
+  | awk -v wt="{worktree절대경로}" '$4 == wt || index($4, wt"/") == 1'
+```
+
+동일 `window_id`의 여러 pane은 하나의 창으로 중복 제거한다. 이후 조작은 바뀌지 않는
+`window_id`와 `pane_id`를 기준으로 하며, 변하는 `session:index`를 기준으로 하지 않는다.
+경로에 공백이 있으면 위 매칭은 신뢰할 수 없고 pane cwd는 사용자가 `cd`로 바꿀 수 있다.
+
+`window-session` 또는 `target-window`가 없으면 그 단서만 제외하고 나머지와 pane 경로로
+진행한다. 둘 다 없어도 pane 매칭이 정확히 하나면 사용하되 결과에 기록한다. 저장값과
+pane 실측이 다르면 실측을 신뢰하고 차이를 보고한다. 단, `target-window` 앞의 글리프·공백
+접두사 때문에 생기는 차이는 "저장값과 실측이 다르다"에 해당하지 않는다. 그 보고는 저장
+세션이나 창 자체가 어긋났을 때만 한다. `is_open`인데 pane 매칭이 없거나 서로 다른
+`window_id`가 둘 이상이면 추측하지 않는다. 저장된 세션·창 이름 후보를 보여 주고
+확인받으며, 실제 위치를 확정하지 못했으면 `window-session`을 갱신하지 않는다.
+
+- 창이 닫혀 있으면 선택 세션으로 연다.
+- 창이 열려 있고 실제 세션이 선택 세션과 같으면 중복 창을 만들지 않고 기존 위치를
+  안내한다.
+- 창이 열려 있고 사용자가 세션을 명시하지 않았으면 다른 세션에 있어도 옮기지 않는다.
+  레거시·사라진 저장값을 고치는 경우에는 실제 세션을 기록한다.
+- 창이 열려 있고 사용자가 다른 세션을 명시했으면 `workmux open`으로 재구성하지 말고
+  `move-window-to-session` 스킬로 이동한다.
+
+이동 직전 `window_id`에서 현재 위치를 다시 해석해 `세션:번호` 형태로 얻고, 반드시
+`move-window-to-session` 스킬을 호출한다. 그 스킬에 넘기는 인자는 `<세션:번호>`와
+`<대상세션>` 두 개뿐이다. handle과 worktree 경로는 인자가 아니라 이후 확인에 쓰는 참고
+값이다. 그 스킬을 인라인으로 베껴 수행하지 않는다. 그 스킬만이 agent state 동기화와
+resurrect 즉시 저장을 수행하므로 이를 건너뛰면 재부팅 후 이동이 사라지거나 dashboard가
+옛 세션을 가리킬 수 있다. 이동 후에도 같은 `window_id`로 위치를 확인한다. 그 스킬은
+`workmux list`의 PATH basename에서 이름을 파생하므로, 기본 명명이 아니면 handle과
+어긋날 수 있다. 이동이 끝나면
+`workmux.worktree.{handle}.window-session`을 읽는다.
+
+- 대상 세션과 같으면 정상이다.
+- 다르면 그 스킬이 basename 키에 쓴 것이다. handle 키를 직접 대상 세션으로 갱신하고
+  그 사실을 보고한다. 갱신도 실패하면 중단한다.
+
+## 사후 검증
+
+실제 창 이름과 세션은 다음으로 확인한다. `workmux list`에는 창 이름 열이 없으므로
+추측해서 안내하지 않는다.
+
+```bash
 tmux list-windows -a -F '#{session_name}:#{window_index}\t#{window_name}'
 ```
 
-`workmux list`의 어떤 열에도 윈도우 이름이 없다. `MUX ✓`는 윈도우가 열렸다는 것만
-알려주므로, 사용자에게 윈도우 이름을 안내하기 전에 `tmux list-windows`로 실제 이름을
-확인한다. 추측한 이름을 안내하면 사용자가 `workmux close`에 없는 이름을 넘기게 된다.
+실제 창 위치를 확인한 뒤의 처리는 이번 호출이 무엇을 했는지에 따라 다르다.
 
-**윈도우가 실제로 어느 세션에 있는지 확인하는 것은 생략할 수 없다.** workmux는 존재하지
-않는 `--parent-session` 값을 받아도 오류 없이 그 세션을 만들어 버리므로(위 "부모 tmux
-세션" 참조), 창이 엉뚱한 세션에 열린 것을 알려 주는 신호가 이 검증뿐이다. 새로 만든
-것이면 `1-main`, 그 밖에는 git config의 `window-session`이 가리키는 세션이어야 한다.
-어긋나면 사용자에게 알리고 잘못 만들어진 세션과 git config 값을 함께 정리한다.
+- **창을 새로 만들거나 열었으면**: 실제 세션이 선택 세션과 다르면 잘못 만들어진
+  세션과 git config를 함께 정리한다.
+- **창을 옮겼으면**: 최종 위치가 선택 세션과 다르면 이동이 완결되지 않은 것이다.
+  그 사실을 보고하고, config에 잘못된 값을 쓰지 않는다.
+- **창을 옮기지 않았으면**: 실제 세션이 선택 세션과 다른 것이 정상이다. 정리하지
+  않는다. 이때의 `window-session` 갱신은 "세션 선택"의 갱신 대상 표가 관장한다.
+
+결과에는 worktree 경로, handle, 브랜치, 실제 세션, 실제 창 이름을 보고한다. PR 모드는
+PR 번호와 head OID도 포함한다.
 
 ## 주의사항
 
-- **git-crypt 저장소에서 `workmux add`를 쓰지 않는다.** 위 분기를 반드시 지킨다.
-- 에이전트(claude·codex)는 자동 실행되지 않는다. 레이아웃 설정이 nvim만 띄우고
-  나머지 pane은 빈 셸로 열며, 필요할 때 사용자가 직접 시작한다.
-- 개발 서버는 이 레이아웃에 없다. 별도 윈도우나 pane으로 띄운다 —
-  worktree마다 상주시키면 포트가 충돌하고 개당 1~2GB를 쓴다.
-- 레이아웃을 바꾸려면 스킬이 아니라 `~/.config/workmux/config.yaml`을 고친다.
-  저장소별로 다르게 하려면 저장소 루트에 `.workmux.yaml`을 둔다.
+- 에이전트(Claude·Codex)는 자동 실행하지 않는다. 레이아웃은 nvim만 실행하고 나머지는
+  빈 셸이므로 필요할 때 사용자가 직접 시작한다.
+- 개발 서버는 별도 윈도우나 pane에서 실행한다. worktree마다 상주시켜서는 안 된다.
+  포트가 충돌하고 개당 1~2GB를 쓸 수 있다.
+- 레이아웃은 `~/.config/workmux/config.yaml`에서 바꾸며, 저장소별 설정은 저장소 루트의
+  `.workmux.yaml`에 둔다.

--- a/dot_agents/skills/create-worktree/agents/openai.yaml
+++ b/dot_agents/skills/create-worktree/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Create Worktree"
-  short_description: "브랜치용 Git worktree 생성 및 Workmux 윈도우 구성"
-  default_prompt: "Use $create-worktree to create a Workmux worktree for 392-feat/add-partner-chat-enabled."
+  short_description: "브랜치 또는 PR용 Git worktree 생성 및 Workmux 윈도우 구성"
+  default_prompt: "Use $create-worktree to open https://github.com/owner/repo/pull/1247 in the 2-review session."

--- a/dot_claude/skills/create-worktree/SKILL.md
+++ b/dot_claude/skills/create-worktree/SKILL.md
@@ -1,196 +1,319 @@
 ---
 name: create-worktree
-description: Use when creating a new git worktree for a branch to work on in isolation from the main workspace
-argument-hint: <branch-name>
+description: Use when creating a git worktree for a branch or a pull request (PR) review, optionally opening it in a named tmux session
+argument-hint: <branch-name|pr-ref> [target-session]
 user-invocable: true
 allowed-tools: Bash
 ---
 
 # Create Worktree
 
-git worktree를 만들고 workmux로 tmux 윈도우를 연다. pane 레이아웃은
-`~/.config/workmux/config.yaml`(좌 nvim / 우상 / 우하)이 담당하므로 여기서
-tmux를 직접 조작하지 않는다. 새 workmux 윈도우는 `1-main` 세션에 연다
-(이미 다른 세션으로 옮겨 둔 worktree는 예외 — 아래 "부모 tmux 세션" 참조).
+브랜치 또는 PR의 git worktree를 만들거나 기존 worktree를 열고, 선택한 tmux 세션의
+workmux 윈도우로 연결한다. 창과 세션 상태를 추측하지 말고 아래 순서대로 확인한다.
+
+## 실행 순서 요약
+
+1. 입력 파싱(파라미터)
+2. PR 모드면 저장소 확정과 PR 해석 → head 브랜치·`headRefOid` 확보
+3. 기존 worktree 존재·경로 판정 → handle 확보
+4. 창이 있으면 창 탐지(`is_open` → 저장 세션 → `target-window` → pane 경로)
+5. 세션 선택(명시값 > 유효·생존 저장값 > 모드 기본값 > 전역 기본값)
+6. 세션 검증
+7. 이름 파생
+8. 분기: 기존 worktree면 창 처리, 없으면 생성·오픈 경로
+9. 사후 검증과 보고
+
+아래 절은 주제별로 묶여 있어 이 순서와 배열이 다르다. 실행은 이 순서를 따른다.
 
 ## 파라미터
 
-- **args** (필수): 브랜치명 (예: `278-feat/chat-infrastructure`, `ZF-100-feat/login`)
-- args가 비어있으면 사용자에게 브랜치명을 물어본다.
+- 첫 번째 positional 인자는 필수인 브랜치명 또는 PR 참조다. 없으면 사용자에게 묻는다.
+- 두 번째 positional 인자는 선택 사항이며 정확한 tmux 세션명이다.
+- positional 인자가 세 개 이상이면 추측하지 말고 `<branch-name|pr-ref> [target-session]`
+  사용법을 안내한 뒤 중단한다.
+- PR 모드는 다음 세 형태에서만 선택한다.
+  - `https://github.com/{owner}/{repo}/pull/{번호}` 전체 URL
+  - `{owner}/{repo}#{번호}`
+  - `PR 1313`, `1313번 PR`, `pull request 1313`처럼 번호 앞뒤에 표지가 있는 자연어
+- 표지 없는 맨 숫자(`1313`)는 PR로 단정하지 않는다. GitHub의 이슈와 PR은 번호 공간을
+  공유하므로 엉뚱한 대상을 checkout할 수 있다. 브랜치로 해석하거나 해석할 수 없으면
+  확인한다.
+- 자연어 호출은 `(브랜치명|PR 참조, 대상 세션)` 2-튜플로 환원한다. 브랜치/PR 참조가
+  둘 이상이거나 세션명이 둘 이상이면 중단하고 확인한다. 자연어가 2-튜플로 환원됐으면
+  positional 인자 수 제한을 적용하지 않는다.
+- 세션명에 접두사를 붙이거나 현재 세션 목록에서 비슷한 이름을 추측하지 않는다.
 
-## 부모 tmux 세션
+## 워크트리 식별자
 
-window mode의 `workmux add`와 `workmux open` 호출에 `--parent-session 1-main`을
-넘긴다. 실행 중인 에이전트가 `3-personal` 같은 다른 세션에 있어도 현재 세션을 부모로
-사용하지 않는다.
+git config 키의 `{handle}`은 `workmux list --json` 항목의 `handle` 필드다.
+브랜치명이나 tmux 창 이름으로 유추하지 않는다. handle은 기본 명명에서는 `path`의
+basename과 같을 수 있지만 `worktree_naming`, `worktree_prefix`, `--name`에 따라 달라질
+수 있다. 특히 PR 모드의 `--target-name`은 handle과 창 이름을 구조적으로 갈라놓는다.
 
-```bash
-tmux list-sessions -F '#{session_name}'    # 종료 코드를 먼저 본다
-```
+handle 하나에는 최대 `.mode`, `.target-window`, `.window-session`, `.window-token` 하위
+키가 있다. 이 스킬은 `.window-session`만 읽거나 쓰고, `.target-window`는 창 탐지에서만
+읽는다. 잘못된 handle로 `git config`를 쓰면 오류 없이 새 섹션이 생기므로 실제 값을
+확보하기 전에는 쓰지 않는다.
 
-`list-sessions`가 exit 1 + `error connecting to ...`로 실패하면 tmux 서버 자체가 없는
-것이다. "세션이 없다"와 구분해 그대로 보고한다 — `grep`에 바로 물리면 두 상황이 똑같이
-"없음"으로 뭉개져 사용자가 엉뚱한 안내를 받는다.
+`workmux list --json`을 쓸 수 없을 때만 worktree 절대경로의 basename을 폴백으로 쓴다.
+그 경우 `path` 필드와 대조해 확인하며, 대조할 수 없으면 중단한다.
 
-```bash
-tmux list-sessions -F '#{session_name}' | grep -qxF -- 1-main && echo 있음 || echo 없음
-```
+## 세션 선택
 
-`has-session -t 1-main`을 쓰지 않는 이유: tmux 타깃은 접두사 매칭을 하므로
-`1-maintenance` 세션만 있어도 exit 0을 낸다(실측). 순번 접두사를 쓰는 지금은 함정이
-더 넓다 — `1-main`만 있어도 `has-session -t 1`이 exit 0이다. 없는데 있다고 판정하면
-아래 오류 처리가 발동하지 않는다.
+먼저 대상 브랜치의 기존 worktree와 경로를 확인해 handle을 확보한다. 그 후
+`SELECTED_SESSION`을 다음 우선순위로 정한다.
 
-`1-main` 세션이 없으면 **여기서 멈춘다.** 현재 세션으로 대체하지 말고 사용자에게
-오류를 알린다. 이 체크를 건너뛰면 안전망이 없다 — workmux는 `--parent-session`에 없는
-세션명을 받으면 **오류 없이 그 세션을 새로 만들고**(rc=0, 0.1.233 확인·0.1.248 재확인) 그 값을
-`workmux.worktree.{이름}.window-session` git config에 영구 저장한다. 그러면 아래
-"예외 1"이 그 잘못된 값을 "의도적으로 옮긴 것"으로 승격시켜, 이후 모든 `workmux open`이
-유령 세션을 계속 존중한다. 자기 교정 경로가 없다.
+1. 이번 호출에서 사용자가 명시한 세션
+2. 기존 worktree의 `workmux.worktree.{handle}.window-session`이 `^[0-9]+-.+$`를 만족하고
+   실제로 존재할 때의 저장값
+3. 모드 기본값: PR 모드면 `2-review`
+4. 전역 기본값 `1-main`
 
-**예외 1 — 이미 옮겨 둔 worktree.** `workmux open`은 기존 worktree도 여는 명령이다.
-git config의 `workmux.worktree.{이름}.window-session`이 `1-main`이 아니면 그것은
-`move-window-to-session`으로 **의도적으로 옮긴** 것이므로, `--parent-session`을
-생략해 그 값을 존중한다. 무조건 붙이면 옮겨 둔 창을 조용히 `1-main`으로 되끌고 온다.
+저장값은 사용자가 창을 직접 옮긴 기록이고 모드 기본값은 관습이므로, 저장값이 모드
+기본값보다 우선한다.
 
-```bash
-git -C {worktree경로} config --get workmux.worktree.{이름}.window-session
-```
+| 명시 세션 | 유효하고 생존한 저장값 | 모드 | 선택 결과 |
+| --- | --- | --- | --- |
+| `3-personal` | `2-review` | PR | `3-personal` |
+| 없음 | `3-personal` | PR | `3-personal` |
+| 없음 | 없음 | PR | `2-review` |
+| 없음 | 없음 | 브랜치 | 전역 기본값 `1-main` |
 
-**단, 값이 `{순번}-{이름}` 형식이 아니면 의도적인 이동이 아니다.** 규칙 이전의 값이
-그대로 남은 것이다. 현재 모든 세션명은 `숫자-`로 시작하므로, `move-window-to-session`이
-기록한 값이라면 반드시 그 형태다. `main`뿐 아니라 `review`, `personal`, `eslint`,
-`quick`도 마찬가지다 — 열거로 판정하지 말고 형식으로 판정한다.
+저장값은 셸 glob(`[0-9]*-*`)이 아니라 정규식 `^[0-9]+-.+$`로 판정한다. glob의 첫
+`*`는 숫자 반복이 아닌 임의 문자열이어서 `1legacy-session`과 `1-`도 통과한다. 예전
+마이그레이션에서 남은 값(예: `1-main`이 아닌 형식 밖 값)은 레거시로 취급한다.
 
-```bash
-v=$(git -C {worktree경로} config --get workmux.worktree.{이름}.window-session)
-if [ -z "$v" ]; then
-  echo "값 없음 → --parent-session 1-main"
-elif printf '%s' "$v" | grep -qE '^[0-9]+-.+$'; then
-  echo "규칙에 맞는 값: $v → 의도적인 이동, 예외 1 적용"
-else
-  echo "규칙 밖 값: $v → 레거시로 판단"
-fi
-```
+선택 세션이 확정되기 전에는 영속 변경을 만드는 `workmux add`, `workmux open`,
+`workmux remove`, `workmux close`를 실행하지 않는다. 읽기 전용 `workmux list --json`과
+`--dry-run` 조회는 예외다.
 
-셸 glob(`[0-9]*-*`)으로 판정하면 안 된다. 첫 `*`가 숫자 반복이 아니라 임의 문자열이라
-`1legacy-session`이나 `1-`처럼 규칙에 맞지 않는 값까지 통과한다(실측). 위 정규식은
-숫자 접두사 + 곧바로 이어지는 하이픈 + 비어 있지 않은 이름을 요구한다.
+명시 세션이 유효한 저장값을 덮었으면 창을 연 뒤 handle의 `window-session`이 명시 세션을
+가리키는지 확인하고 다르면 갱신한다. 형식은 유효하지만 사라진 저장 세션이면 다음처럼
+복구한다.
 
-규칙 밖 값이면 예외를 적용하지 말고 `--parent-session 1-main`을 넘기면서 git config
-값도 갱신한다. 그냥 존중하면 workmux가 그 레거시 세션을 조용히 되살리고, 값이 계속
-남아 매번 재생산된다. 어느 새 이름으로 옮길지 애매하면(예: `personal` → `3-personal`
-이 맞는지) 추측하지 말고 사용자에게 확인한다.
+1. 사라진 저장값을 사용자에게 알린다.
+2. 모드 기본값과 전역 기본값으로 계산한 대안을 제시하고 확인받는다.
+3. 확인된 세션으로 진행한다.
+4. 세션을 자동 생성하지 않는다.
 
-```bash
-git -C {worktree경로} config workmux.worktree.{이름}.window-session 1-main
-```
+레거시 또는 사라진 저장값을 고칠 때 기록할 값은 창의 실제 위치로 정한다.
 
-**예외 2 — 지원되지 않는 조합.** `--parent-session`은 session mode, 샌드박스 안,
-그리고 여러 worktree를 한 번에 만드는 경우(`--count`, `--foreach`, 여러 `--agent`,
-stdin)에는 거부된다. 그때는 생략한다.
+| 상태 | `window-session` 갱신 대상 |
+| --- | --- |
+| 창이 닫혀 있음 | `SELECTED_SESSION` |
+| 창이 열려 있고 명시 세션으로 이동함 | `SELECTED_SESSION` |
+| 창이 열려 있으나 이동하지 않음 | 창 탐지로 확정한 실제 세션 |
 
-## 실행 순서
+실제 세션을 확정하지 못했으면 갱신하지 않는다. 세션 미명시 호출에서 열린 창을 옮기지
+않는 경우에는 선택값이 아니라 실제 위치를 기록해야 config와 창 위치가 어긋나지 않는다.
 
-저장소가 **래퍼 스크립트를 제공하는지**로 경로가 갈린다. 판정은 저장소 루트를 기준으로
-한다 — 상대 경로로 판정하면 서브디렉터리나 기존 worktree 안에서 스킬을 부를 때 false가
-되어, git-crypt 저장소인데도 아래에서 금지하는 `workmux add` 경로로 빠진다.
+## 세션 검증
 
-```bash
-ROOT=$(git rev-parse --show-toplevel)
-[[ -f "$ROOT/scripts/create-worktree.sh" ]] && echo "스크립트 경로" || echo "workmux 경로"
-git -C "$ROOT" config --get filter.git-crypt.smudge   # 값이 있으면 git-crypt 저장소
-```
-
-스크립트가 있는데 실행 권한이 없으면 경로를 바꾸지 말고 그 사실을 오류로 알린다.
-`git-crypt` 필터가 설정되어 있는데 스크립트가 없으면 사용자에게 확인받고 진행한다.
-
-### 스크립트가 있을 때 (git-crypt 저장소)
-
-`workmux add`를 쓰지 않는다. workmux는 내부적으로 `git worktree add`를 실행하는데,
-git-crypt 저장소에서는 그것이 smudge 필터 에러로 **실패한다**. 아래 `--no-checkout`
-서술은 이 git-crypt 경로에 대한 것이다 — 래퍼의 비-git-crypt 분기는 평범한
-`git worktree add`를 쓴다.
+선택 세션은 영속 workmux 명령 전에 검증한다.
 
 ```bash
-./scripts/create-worktree.sh {브랜치명}    # --no-checkout 생성·키 링크·체크아웃 + 의존성 설치
-workmux open {디렉토리명} --target-name {윈도우이름} --parent-session 1-main  # 이슈 번호가 있을 때
-workmux open {디렉토리명} --parent-session 1-main                          # 이슈 번호가 없을 때
+tmux list-sessions -F '#{session_name}'
 ```
 
-- **스크립트가 실패하면 여기서 멈춘다.** 종료 코드를 확인하고, 실패했으면
-  `workmux open`으로 넘어가지 않는다. 스크립트는 worktree를 `--no-checkout`으로 만든 뒤
-  키 링크·체크아웃·의존성 설치를 하므로 뒤쪽에서 죽어도 worktree는 남는다 — 그 상태로
-  `workmux open`을 실행하면 성공해버려서 파일이 암호화된 채이거나 의존성이 없는
-  worktree를 정상으로 보고하게 된다.
-- 스크립트의 확인 프롬프트는 `-y`나 `yes |`로 우회하지 않고 사용자에게 직접 확인받는다.
-- **스크립트 출력에서 worktree 절대경로를 확보한다.** `workmux open`에 넘길
-  디렉토리명은 그 경로의 basename이다 (아래 "이름 파생" 참조).
-- `workmux open`은 `git worktree list`로 worktree를 찾으므로 `worktree_dir` 밖의
-  형제 디렉토리도 그대로 인식한다.
-
-### 스크립트가 없을 때
-
-workmux가 생성과 윈도우 구성을 한 번에 한다.
+먼저 종료 코드를 확인한다. exit 1과 `error connecting to ...`는 tmux 서버 부재이므로
+세션 부재와 구분해 보고하고 중단한다. 목록 조회가 성공했을 때만 다음처럼 전체 문자열
+일치로 확인한다.
 
 ```bash
-workmux add {브랜치명} --target-name {윈도우이름} --parent-session 1-main  # 이슈 번호가 있을 때
-workmux add {브랜치명} --parent-session 1-main                          # 이슈 번호가 없을 때
+tmux list-sessions -F '#{session_name}' | grep -qxF -- "$SELECTED_SESSION"
 ```
+
+`tmux has-session -t`는 쓰지 않는다. tmux target은 접두사 매칭을 하므로 `2`나 `2-rev`가
+의도치 않은 세션에 매칭될 수 있다. 선택 세션이 없으면 자동 생성하지 않는다. 명시값이면
+오타 가능성을 알리고 중단하며, 저장값이면 앞 절의 복구 경로를 따른다. 검증 없이
+`--parent-session`에 없는 값을 주면 workmux가 세션을 만들고 config에 영구 저장하는 유령
+세션 위험이 있다.
+
+## PR 해석
+
+PR 입력에서는 다음 표로 `{owner}/{repo}`를 확정한다.
+
+| 입력 | `{owner}/{repo}` 출처 |
+| --- | --- |
+| 전체 PR URL | URL 경로 |
+| `{owner}/{repo}#{번호}` | 입력 문자열 |
+| 표지가 있는 자연어 | 현재 저장소 |
+
+현재 저장소는 우선 `gh repo view --json owner,name -q '.owner.login + "/" + .name'`으로
+구하고, 실패하면 `git remote get-url origin`을 파싱한다. 둘 다 실패하면 중단한다.
+입력 저장소와 현재 저장소가 다르면 두 값을 알리고 중단한다.
+
+확정한 저장소에서 다음 네 필드를 조회한다.
+
+```bash
+gh pr view {번호} --repo {owner}/{repo} --json number,state,headRefName,headRefOid
+```
+
+`number`, `headRefName`, `headRefOid`는 각각 이름 파생과 내용 검증에 쓰고, `state`는
+CLOSED·MERGED 처리에 쓴다. `gh`가 없거나 인증·조회에 실패하면 추측하지 말고 중단한다.
+CLOSED 또는 MERGED면 상태를 알리고 계속할지 확인한다. 자동 중단하지 않되 head 브랜치가
+삭제되어 fetch가 실패할 수 있음을 안내한다.
+
+동일한 head 브랜치의 worktree가 이미 있으면 생성만 건너뛰고 기존 경로의 창 처리로
+진행한다. 같은 이름의 로컬 브랜치가 head OID와 다르면 덮어쓰지 않고 중단한다.
+
+래퍼 경로에서 새 worktree를 만들기 전, 로컬 브랜치가 없을 때는 PR head를 확보한다.
+
+```bash
+git fetch origin "refs/pull/{PR번호}/head:{head브랜치명}"
+git rev-parse --verify "refs/heads/{head브랜치명}"
+```
+
+검증 OID가 `headRefOid`와 다르거나 fetch가 실패하면 중단하고 래퍼를 호출하지 않는다.
+래퍼는 브랜치를 찾지 못하면 현재 HEAD에서 빈 브랜치를 만들 수 있다.
+래퍼가 없는 경로는 `workmux add --pr`가 체크아웃을 직접 하므로 사전 fetch가 필요 없다.
+대신 생성 후 `HEAD`가 `headRefOid`와 같은지 검증해 같은 보장을 얻는다.
+
+`workmux add --pr`에는 원시 입력을 넘기지 않는다. 저장소 일치와 PR 조회로 확정한 숫자만
+정규화해 넘긴다. 따라서 `{owner}/{repo}#{번호}`와 자연어 표지 입력도 `--pr {PR번호}`가
+된다.
 
 ## 이름 파생
 
-- **짧은 이름**: 브랜치명에서 마지막 `/`까지를 제거한다.
-  `392-feat/add-partner-chat-enabled` → `add-partner-chat-enabled`
-- **이슈 번호**: 브랜치명 **맨 앞**의 숫자 또는 `ZF-숫자`만 인식한다. 맨 앞이 아니면
-  이슈 번호가 아니다 — `feat/392-add-x`는 이슈 번호가 없는 것으로 본다.
-- **윈도우이름**: 이슈 번호가 있을 때만 `{이슈번호}-{짧은이름}`을 만들어
-  `--target-name`에 넘긴다. **이슈 번호가 없으면 `--target-name`을 생략한다.**
-  짧은 이름만 넘기는 것은 어느 경로에서도 하지 않는다 — 브랜치 prefix와 저장소
-  이름을 모두 잃어 충돌 확률만 높아진다.
+- 짧은 이름은 브랜치명(또는 PR head 브랜치명)의 마지막 `/` 뒤 부분이다.
+  `392-feat/add-partner-chat-enabled`의 짧은 이름은 `add-partner-chat-enabled`다.
+- 브랜치 모드의 이슈 번호는 브랜치명 맨 앞의 숫자 또는 `ZF-숫자`만 인식한다.
+  `feat/392-add-x`에는 이슈 번호가 없다.
+- PR 모드 창 이름은 `{PR번호}-{짧은이름}`이며, head 브랜치의 이슈 번호보다 PR 번호를
+  우선한다.
+- 브랜치 모드에 이슈 번호가 없으면 `--target-name`을 생략한다.
+- workmux가 target name을 소문자로 정규화하므로 안내와 재사용에도 소문자 값을 쓴다.
+- 창 이름 충돌 시 브랜치 모드는 `{repo명}-{짧은이름}`, PR 모드는
+  `{PR번호}-{repo명}-{짧은이름}`으로 재시도한다.
 
-  | 브랜치 | `--target-name` | `add` 경로 윈도우 | `open` 경로 윈도우 |
-  | --- | --- | --- | --- |
-  | `392-feat/add-partner-chat-enabled` | `392-add-partner-chat-enabled` | `392-add-partner-chat-enabled` | 같음 |
-  | `ZF-115-chore/some-feature` | `ZF-115-some-feature` | `zf-115-some-feature` | 같음 |
-  | `fix/login-bug` | 생략 | `fix-login-bug` | `zambaguni-front-login-bug` |
+## 생성·오픈 경로
 
-  생략했을 때 workmux가 쓰는 기본 이름은 경로마다 다르다.
-  `workmux open`은 넘긴 디렉토리명(`{repo명}-{짧은이름}`)을 그대로 써서 저장소 이름이
-  들어가지만, `workmux add`는 브랜치명 슬러그를 써서 저장소 이름이 **없다**. 그래서
-  `add` 경로에서는 두 저장소가 같은 브랜치명을 쓰면 두 번째가
-  `✗ A tmux window named '...' already exists`로 실패한다 — 그때는
-  `--target-name {repo명}-{짧은이름} --parent-session 1-main`으로 재시도한다.
-
-  workmux는 target name을 소문자로 정규화한다. 사용자에게 안내하거나 이후 명령에
-  재사용할 이름은 정규화된 소문자 쪽이다.
-- **디렉토리명**: 스크립트는 계속 `../{repo명}-{짧은이름}` 에 만들며 이슈 번호를 붙이지 않는다.
-  `workmux open`에는 이 디렉토리명(`zambaguni-front-add-partner-chat-enabled`)을 넘긴다.
-- 같은 브랜치의 worktree가 이미 있으면 새로 만들지 않고 기존 경로를 안내한다.
-
-## 마무리
+저장소 루트에서 분기한다. 서브디렉터리나 기존 worktree에서의 오판을 막기 위해 상대
+경로로 판정하지 않는다.
 
 ```bash
-workmux list
+ROOT=$(git rev-parse --show-toplevel)
+test -f "$ROOT/scripts/create-worktree.sh"
+git -C "$ROOT" config --get filter.git-crypt.smudge
+```
+
+git-crypt 저장소에서는 PR 모드를 포함해 원칙적으로 `workmux add`를 쓰지 않는다.
+
+- 래퍼가 있으면 실행 권한을 먼저 확인한다. **실행 권한이 없으면** 경로를 바꾸지 말고
+  오류로 보고한다. 래퍼가 실패하면 즉시 중단하고 `workmux open`으로 진행하지 않는다.
+  확인 프롬프트를 `-y`나 `yes |`로 자동 우회하지 않는다.
+- **예외:** git-crypt 필터가 있는데 래퍼가 없으면 `workmux add` 전에 사용자에게 확인받고
+  진행한다.
+
+래퍼 경로의 PR 모드는 head 브랜치를 확보한 뒤 다음 순서로 실행한다.
+
+```bash
+./scripts/create-worktree.sh {head브랜치명}
+workmux open {handle} --target-name {PR번호}-{짧은이름} --parent-session "$SELECTED_SESSION"
+```
+
+브랜치 모드도 래퍼가 출력한 경로와 handle을 확보한 뒤 `workmux open`을 사용한다.
+이슈 번호가 없으면 `--target-name`을 생략한다. 래퍼 출력에서 worktree 절대경로를 얻고,
+그 경로와 일치하는 `workmux list --json` 항목의 handle을 쓴다. 아직 목록에 없으면
+경로 basename을 `git worktree list --porcelain`으로 대조한 폴백으로만 사용하고, open 뒤
+실제 창을 다시 확인한다. `workmux open`은 `git worktree list`로 찾으므로 `worktree_dir`
+밖의 형제 디렉터리도 인식한다.
+
+래퍼가 없는 PR 모드는 positional 브랜치명과 `--name`을 생략한다.
+
+```bash
+workmux add --pr {PR번호} --target-name {PR번호}-{짧은이름} --parent-session "$SELECTED_SESSION"
+```
+
+브랜치 모드는 이슈 번호가 있을 때만 `--target-name {이슈번호}-{짧은이름}`을 추가한다.
+생성 전 `workmux add ... --dry-run`으로 예상 경로와 handle을 확인할 수 있다. 생성 뒤에는
+출력과 `workmux list --json`에서 실제 경로·handle을 얻으며 이름을 추측하지 않는다.
+
+`--parent-session`은 session mode, 샌드박스 안, `--count`, `--foreach`, 여러 `--agent`,
+stdin을 통한 여러 worktree 생성에서는 지원되지 않으므로 그 조합에서는 생략한다.
+PR worktree 생성 뒤에는 `git -C "{worktree경로}" rev-parse HEAD`가 `headRefOid`와 같은지
+검증한다. 다르면 성공으로 보고하지 않는다.
+
+## 기존 worktree 처리
+
+세션 선택보다 먼저 `git worktree list --porcelain`과 `workmux list --json`으로 브랜치의
+기존 worktree 경로·handle을 확인한다. 같은 브랜치가 이미 있으면 새로 만들지 않고 그
+경로를 안내한다.
+
+기존 창은 이번 호출에서 파생한 이름으로 찾지 않는다. 다음 순서로 탐지한다.
+
+1. `workmux list --json`의 handle 항목에서 `is_open`을 확인한다.
+2. `workmux.worktree.{handle}.window-session` 저장값으로 세션 후보를 좁힌다.
+3. `workmux.worktree.{handle}.target-window` 저장값으로 창 후보를 좁힌다. 저장값은 실제
+   창 이름의 접미사다. `nerdfont` 설정에 따라 글리프와 공백이 앞에 붙을 수 있으므로
+   동등 비교가 아니라 접미사 비교로 판정한다.
+4. pane 현재 경로를 worktree 절대경로와 교차 확인한다.
+
+```bash
+tmux list-panes -a -F '#{session_name}:#{window_index} #{window_id} #{pane_id} #{pane_current_path}' \
+  | awk -v wt="{worktree절대경로}" '$4 == wt || index($4, wt"/") == 1'
+```
+
+동일 `window_id`의 여러 pane은 하나의 창으로 중복 제거한다. 이후 조작은 바뀌지 않는
+`window_id`와 `pane_id`를 기준으로 하며, 변하는 `session:index`를 기준으로 하지 않는다.
+경로에 공백이 있으면 위 매칭은 신뢰할 수 없고 pane cwd는 사용자가 `cd`로 바꿀 수 있다.
+
+`window-session` 또는 `target-window`가 없으면 그 단서만 제외하고 나머지와 pane 경로로
+진행한다. 둘 다 없어도 pane 매칭이 정확히 하나면 사용하되 결과에 기록한다. 저장값과
+pane 실측이 다르면 실측을 신뢰하고 차이를 보고한다. 단, `target-window` 앞의 글리프·공백
+접두사 때문에 생기는 차이는 "저장값과 실측이 다르다"에 해당하지 않는다. 그 보고는 저장
+세션이나 창 자체가 어긋났을 때만 한다. `is_open`인데 pane 매칭이 없거나 서로 다른
+`window_id`가 둘 이상이면 추측하지 않는다. 저장된 세션·창 이름 후보를 보여 주고
+확인받으며, 실제 위치를 확정하지 못했으면 `window-session`을 갱신하지 않는다.
+
+- 창이 닫혀 있으면 선택 세션으로 연다.
+- 창이 열려 있고 실제 세션이 선택 세션과 같으면 중복 창을 만들지 않고 기존 위치를
+  안내한다.
+- 창이 열려 있고 사용자가 세션을 명시하지 않았으면 다른 세션에 있어도 옮기지 않는다.
+  레거시·사라진 저장값을 고치는 경우에는 실제 세션을 기록한다.
+- 창이 열려 있고 사용자가 다른 세션을 명시했으면 `workmux open`으로 재구성하지 말고
+  `move-window-to-session` 스킬로 이동한다.
+
+이동 직전 `window_id`에서 현재 위치를 다시 해석해 `세션:번호` 형태로 얻고, 반드시
+`move-window-to-session` 스킬을 호출한다. 그 스킬에 넘기는 인자는 `<세션:번호>`와
+`<대상세션>` 두 개뿐이다. handle과 worktree 경로는 인자가 아니라 이후 확인에 쓰는 참고
+값이다. 그 스킬을 인라인으로 베껴 수행하지 않는다. 그 스킬만이 agent state 동기화와
+resurrect 즉시 저장을 수행하므로 이를 건너뛰면 재부팅 후 이동이 사라지거나 dashboard가
+옛 세션을 가리킬 수 있다. 이동 후에도 같은 `window_id`로 위치를 확인한다. 그 스킬은
+`workmux list`의 PATH basename에서 이름을 파생하므로, 기본 명명이 아니면 handle과
+어긋날 수 있다. 이동이 끝나면
+`workmux.worktree.{handle}.window-session`을 읽는다.
+
+- 대상 세션과 같으면 정상이다.
+- 다르면 그 스킬이 basename 키에 쓴 것이다. handle 키를 직접 대상 세션으로 갱신하고
+  그 사실을 보고한다. 갱신도 실패하면 중단한다.
+
+## 사후 검증
+
+실제 창 이름과 세션은 다음으로 확인한다. `workmux list`에는 창 이름 열이 없으므로
+추측해서 안내하지 않는다.
+
+```bash
 tmux list-windows -a -F '#{session_name}:#{window_index}\t#{window_name}'
 ```
 
-`workmux list`의 어떤 열에도 윈도우 이름이 없다. `MUX ✓`는 윈도우가 열렸다는 것만
-알려주므로, 사용자에게 윈도우 이름을 안내하기 전에 `tmux list-windows`로 실제 이름을
-확인한다. 추측한 이름을 안내하면 사용자가 `workmux close`에 없는 이름을 넘기게 된다.
+실제 창 위치를 확인한 뒤의 처리는 이번 호출이 무엇을 했는지에 따라 다르다.
 
-**윈도우가 실제로 어느 세션에 있는지 확인하는 것은 생략할 수 없다.** workmux는 존재하지
-않는 `--parent-session` 값을 받아도 오류 없이 그 세션을 만들어 버리므로(위 "부모 tmux
-세션" 참조), 창이 엉뚱한 세션에 열린 것을 알려 주는 신호가 이 검증뿐이다. 새로 만든
-것이면 `1-main`, 그 밖에는 git config의 `window-session`이 가리키는 세션이어야 한다.
-어긋나면 사용자에게 알리고 잘못 만들어진 세션과 git config 값을 함께 정리한다.
+- **창을 새로 만들거나 열었으면**: 실제 세션이 선택 세션과 다르면 잘못 만들어진
+  세션과 git config를 함께 정리한다.
+- **창을 옮겼으면**: 최종 위치가 선택 세션과 다르면 이동이 완결되지 않은 것이다.
+  그 사실을 보고하고, config에 잘못된 값을 쓰지 않는다.
+- **창을 옮기지 않았으면**: 실제 세션이 선택 세션과 다른 것이 정상이다. 정리하지
+  않는다. 이때의 `window-session` 갱신은 "세션 선택"의 갱신 대상 표가 관장한다.
+
+결과에는 worktree 경로, handle, 브랜치, 실제 세션, 실제 창 이름을 보고한다. PR 모드는
+PR 번호와 head OID도 포함한다.
 
 ## 주의사항
 
-- **git-crypt 저장소에서 `workmux add`를 쓰지 않는다.** 위 분기를 반드시 지킨다.
-- 에이전트(claude·codex)는 자동 실행되지 않는다. 레이아웃 설정이 nvim만 띄우고
-  나머지 pane은 빈 셸로 열며, 필요할 때 사용자가 직접 시작한다.
-- 개발 서버는 이 레이아웃에 없다. 별도 윈도우나 pane으로 띄운다 —
-  worktree마다 상주시키면 포트가 충돌하고 개당 1~2GB를 쓴다.
-- 레이아웃을 바꾸려면 스킬이 아니라 `~/.config/workmux/config.yaml`을 고친다.
-  저장소별로 다르게 하려면 저장소 루트에 `.workmux.yaml`을 둔다.
+- 에이전트(Claude·Codex)는 자동 실행하지 않는다. 레이아웃은 nvim만 실행하고 나머지는
+  빈 셸이므로 필요할 때 사용자가 직접 시작한다.
+- 개발 서버는 별도 윈도우나 pane에서 실행한다. worktree마다 상주시켜서는 안 된다.
+  포트가 충돌하고 개당 1~2GB를 쓸 수 있다.
+- 레이아웃은 `~/.config/workmux/config.yaml`에서 바꾸며, 저장소별 설정은 저장소 루트의
+  `.workmux.yaml`에 둔다.


### PR DESCRIPTION
`#28`과 `#35`를 함께 구현한다. PR 참조(URL / `owner/repo#N` / 태그된 자연어)를 입력하면 그 PR의 실제 head 브랜치로 worktree를 만들고, 창 이름에 head 브랜치가 담은 이슈 번호가 아니라 **PR 번호**를 쓴다. 별칭 브랜치는 만들지 않는다. 대상 tmux 세션도 직접 지정할 수 있어 `1-main`에 연 뒤 옮기던 절차가 사라진다.

## 무엇이 바뀌나

| | 전 | 후 |
|---|---|---|
| PR 링크 입력 | 지원 없음 | head 브랜치로 worktree, 창 이름은 PR 번호 |
| 세션 지정 | `1-main`에 연 뒤 이동 | 호출 시 직접 지정, PR 모드 기본값 `2-review` |
| config 키 | 창 이름·브랜치명 혼용 여지 | `workmux list --json`의 `handle`로 고정 |
| 창 탐지 | 이름 기반 | `window_id`·pane 경로 기반 |

## 설계상 중요한 네 가지

**config 키를 handle로 고정한다.** workmux는 `workmux.worktree.{handle}.*`에 키를 쓰는데 `--target-name`을 쓰면 handle과 창 이름이 갈라진다. 이번 검증에서 실제로 handle이 `30-enhancement-tmux-open-pr-shortcut`, 창 이름이 `31-tmux-open-pr-shortcut`으로 갈라졌다. 창 이름으로 키를 조립하면 **오류 없이 유령 섹션이 생긴다.**

**`target-window`는 접미사 비교로 판정한다.** `nerdfont: true`가 창 이름 앞에 `U+E418` + 공백을 붙이므로 동등 비교는 이 환경에서 항상 불일치가 난다. 실측 확인:

```
저장값  'pr31-fixture-window'
실제    '<U+E418> pr31-fixture-window'
동등 비교  거짓 / 접미사 비교  참
```

**`tmux has-session -t`를 쓰지 않는다.** tmux target은 접두사 매칭을 하므로 `2`나 `2-rev`로도 exit 0이 난다. `list-sessions` + `grep -qxF`로 전체 일치를 본다.

**창을 옮기지 않는 경로에서는 선택 세션이 아니라 실측 세션을 기록한다.** 이것이 Spec 리뷰가 잡은 유일한 블로커(SPEC-011)였고, 재스모크로 수정 효과를 실증했다.

## 실행 증거

하위 에이전트에 PR URL만 주고 세션명·창이름·인자 형태를 알려주지 않은 상태에서 하네스가 기록한 argv:

```
workmux add --pr 31 --target-name 31-tmux-open-pr-shortcut --parent-session 2-review
```

PR 번호 `31`이 head 브랜치의 이슈 번호 `30`을 이겼다. `#28`·`#35`가 요구한 동작이다.

검증은 `workmux`·`git`·`tmux`를 argv 로깅 shim으로 감싼 하네스로 했다. 오퍼레이터가 값을 타이핑하면 단언이 구성적으로 참이 되므로(Plan 리뷰 PLAN-001·PLAN-002 지적), 하위 에이전트에 **입력만** 주고 스킬이 파생한 값을 로그에서 읽었다.

## 품질 게이트 결과 — NEEDS_REDESIGN

`REVIEW_LIMIT_EXHAUSTED:code`. **산출물 결함이 아니라 수용 기준과 검증 도구의 구조적 모순 때문이다.** 코드 리뷰 3라운드가 82 → 86 → 88로 오르며 모두 블로커 0이었다.

### AC-59 미충족 (사용자 인정)

Spec R1.8이 `argument-hint`를 요구하는데 skill-creator의 `quick_validate.py`는 그 키를 모른다.

```
42: ALLOWED_PROPERTIES = {'name','description','license','allowed-tools','metadata','compatibility'}
45: unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
99: sys.exit(1)
```

R1.8을 지키는 한 `dot_claude` 쪽 exit 0이 **구조적으로 불가능**하다. 기준과 요구사항이 서로를 배제한다. 산출물 결함은 아니다 — 변경 전후 unexpected key 집합이 `argument-hint, user-invocable`로 동일하고 메시지도 기준선과 같다.

정오표로 판정 기준을 고쳐 쓰려 했으나 코드 리뷰가 거부했다(구현 쪽 문서로 승인된 기준을 대체할 수 없음). Spec 라운드 한도 소진으로 정식 개정도 불가능했다.

**후속**: 검증기를 Claude frontmatter 스키마 반영본으로 교체하거나 `dot_agents` 쪽에만 적용해야 한다.

### plan digest 불일치 — `#59`의 실전 근거

- 라운드 1 리뷰의 실제 대상: `8c239061`
- state에 기록된 digest: `d49db8b8` (라운드 1·2가 공유)
- 승인·구현에 쓰인 digest: `fdbd2ddf`

리뷰를 기록하기 전에 Plan을 개정한 순서 오류다. `record_review`가 **리뷰 시점이 아니라 현재 등록 파일 기준**으로 digest를 검사하므로 원래 값으로 기록할 수 없었다. `set_artifact`는 경로만 쓰고 `artifact_digests`를 갱신하는 유일한 지점이 `record_review`이며, `approve_plan`은 경로만 비교한 뒤 digest를 새로 계산해 교차 검사하지 않는다.

> **시점 주의** — 이 서술은 이 실행이 돌던 **v1.0.0 기준**이다. 이후 `#47`이 PR `#54`로 고쳐져 **현재 배포본(v3.0.0)의 `approve_plan`은 `artifact_digests["plan"]`과 교차 검사한다** (`quality_state.py:523-539` — 기록된 리뷰 digest가 없거나 승인 digest와 다르면 `StateError`). 즉 이 실행에서 일어난 `d49db8b8`(리뷰) ↔ `fdbd2ddf`(승인) 불일치는 지금이라면 승인 시점에 거부된다. 여기 남긴 기록은 수정 전 동작의 실증 사례로 읽어야 하며, 현재 결함으로 읽으면 안 된다.

### `#43` 3회 발현

마지막 코드 리뷰를 기록하는 순간 상태가 자동으로 `NEEDS_REDESIGN`이 됐다(`record-review`가 라운드 한도와 비-PASS를 보고 스스로 종결). 그 뒤 다음이 모두 거부됐다.

```
set-artifact --kind report        → terminal state is immutable
record-verification --fingerprint → terminal state is immutable
```

스킬은 "터미널 전이 **전에** 보고서를 등록하라"고 규정하는데, 전이가 보고서 작성보다 먼저 일어나 규정된 순서를 지키는 것이 구조적으로 불가능했다. **우회하지 않았다.** 결과로 `state.json`의 검증 지문 `4a6ed493`이 마지막 재실측(R5·R6) 이전을 가리키고 `artifacts.report`는 `null`이다. 보고서는 경로로만 존재한다.

## 미검증으로 남긴 것

| 항목 | 사유 |
|---|---|
| AC-37 (git-crypt 래퍼 경로) | 업무 저장소에 1~2GB 부작용을 만들지 않기 위해 문서 검토만 |
| SPEC-022 분기 (basename ≠ handle) | 이 저장소 기본 명명에서 둘이 같아 스모크로 발동 불가 |
| 실패 상황 기준 (fetch 실패·저장소 불일치·래퍼 부재) | 인위 조성이 다른 기준 판정을 흐림 |
| AC-9b의 음성 단언 | 하네스 완전 준수를 전제로 하며 부분 우회는 탐지하지 못한다 |

자동 검증 카테고리(targeted_tests·full_suite·type_check·build)는 이 저장소에 대상이 없어 `not configured`다. lint는 pre-commit 미설치로 gitleaks를 직접 실행했다(0건).

## 실행 이력

1·2차는 라운드 한도로 구현에 도달하지 못했고 3차만 구현까지 갔다. 1·2차 보고서는 `#52`에 있다. 2차 Spec이 이후 제거된 worktree를 근거로 삼아 증거가 죽는 문제가 있었고, 3차는 휘발성 식별자를 증거에서 제거하는 것을 전제로 시작했다.

## 리뷰 시 봐주면 좋을 곳

- 두 `SKILL.md`의 **본문은 바이트 동일**해야 한다. `diff dot_agents/... dot_claude/...` 출력이 정확히 `3a4,6` + `>` 3줄이어야 하고, 인자 순서를 바꾸면 `4,6d3`이 나온다
- `1-main` 잔존은 각 파일 3회이며 허용 용례 3가지(전역 기본값 서술, 우선순위 표 셀, 레거시 설명 예시)뿐이다

Closes #28
Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

