### PR TITLE
chore(deep-research): Verify 단계를 sonnet으로 고정한다

### DIFF
--- a/dot_claude/workflows/deep-research.js
+++ b/dot_claude/workflows/deep-research.js
@@ -6,7 +6,7 @@ export const meta = {
     { title: "Scope", detail: "Decompose question (from args) into 3-6 search angles" },
     { title: "Search", detail: "One WebSearch agent per angle, in parallel", model: "haiku" },
     { title: "Fetch", detail: "URL-dedup, fetch up to 15 sources, extract falsifiable claims", model: "haiku" },
-    { title: "Verify", detail: "3-vote adversarial verification on top 25 claims (2 refutes kill)" },
+    { title: "Verify", detail: "3-vote adversarial verification on top 25 claims (2 refutes kill)", model: "sonnet" },
     { title: "Synthesize", detail: "Merge semantic dupes, derive confidence from provenance, cite sources" },
   ],
 }
@@ -989,11 +989,18 @@ const panelResults = await parallel(
   rankedClaims.map(claim => guardParallelTask("verifier-panel", async () => {
     const voteResults = await parallel(
       Array.from({ length: VOTES_PER_CLAIM }, (_, v) => guardParallelTask("verifier-vote", async () => {
-        // Verification is this harness's entire point, so these agents inherit the
-        // session model and effort instead of pinning a cheap tier. The prompt
-        // requires an explicit supported/refuted/unverified outcome, so use the
-        // strongest available verifier for merit-based adjudication and reliable
-        // separation of infrastructure failures.
+        // Verification is this harness's entire point, so these agents are pinned to
+        // sonnet rather than the cheap tier Search/Fetch use. The failure modes are
+        // asymmetric in visibility: a false "supported" survives into the report with
+        // its quote and URL, where a reader can check it, but a false "refuted" is
+        // silent — 2 of 3 votes kill the claim and it never appears at all. A weak
+        // verifier therefore deletes true findings unobserved. Opus is not worth its
+        // cost here: each vote is a bounded single-claim adjudication against a strict
+        // schema, and the 2-of-3 majority is itself the error-correcting mechanism, so
+        // three sonnet votes adjudicate more reliably than one stronger vote.
+        // Deliberately no `effort` override — the checklist (quote-vs-claim overreach,
+        // contradicting-source search, recency, and the refuted/unverified split)
+        // degrades under "low", which would cancel out the point of raising the tier.
         const verifyPrompt = VERIFY_PROMPT(claim, v)
         const verifyOptions = {
           // claim.claim is model-extracted web page text: untrusted, same as a
@@ -1001,6 +1008,7 @@ const panelResults = await parallel(
           label: "v" + v + ":" + quotedLabel(claim.claim),
           phase: "Verify",
           schema: VERDICT_SCHEMA,
+          model: "sonnet",
         }
         try {
           return await callAgent(verifyPrompt, verifyOptions)


### PR DESCRIPTION
## 배경

`~/.claude/workflows/deep-research.js` 오버라이드에서 `model: "haiku"`가 붙은 단계는 **Search·Fetch 둘뿐**이고, Verify에는 `model`이 없어 부모 세션 모델을 상속하고 있었다. Opus 세션에서 딥 리서치를 돌리면 verify 75개(25 claims × 3 votes)가 전부 Opus로 뜬다.

## 왜 haiku가 아니라 sonnet인가

판정 오류의 **가시성이 비대칭**이다.

| 오류 | 결과 |
|---|---|
| 거짓 `supported` | 보고서에 quote·URL과 함께 남음 → 사람이 링크 눌러 검증 가능 |
| 거짓 `refuted` | 3표 중 2표면 주장이 죽고 **보고서에 아예 안 나옴** |

즉 약한 verifier가 만드는 손실은 관측되지 않는다. Search/Fetch는 실패해도 로그에 남고 다른 각도가 커버하지만 Verify는 그렇지 않다.

`VERIFY_PROMPT`가 요구하는 것도 단순 분류가 아니다 — WebSearch로 반박 증거 탐색, quote-vs-claim 과장 판별, 소스 품질 대비 주장 강도 평가, `publishDate` 기반 노후 판정, 그리고 인프라 실패(`unverified`)와 실제 반박(`refuted`)의 구분.

## 왜 Opus가 아닌가

각 표는 claim 하나에 대한 경계가 명확한 판정이고 출력은 엄격한 스키마로 고정돼 있어 한계 추론력이 쓰일 여지가 적다. 게다가 **2-of-3 다수결 자체가 오류 정정 장치**라, sonnet 3표가 더 강한 1표보다 판정이 안정적이다. 표 수를 줄여 Opus를 쓰는 건 나쁜 트레이드다.

## 변경

- `verifyOptions`에 `model: "sonnet"` 추가
- `meta.phases`의 Verify 항목에도 같은 표기 → phase 목록에서 티어가 보임
- 코드와 어긋나게 된 "세션 모델을 상속한다" 근거 주석 교체

`effort`는 **일부러 지정하지 않았다**. Search/Fetch의 `effort: "low"`를 여기 복사하면 위 체크리스트를 건너뛰는 쪽으로 퇴화해 티어를 올린 의미가 상쇄된다.

## 검증

- 런타임 래퍼 기준 문법 파싱 OK (원본·수정본 동일 조건에서 비교). 이 스크립트는 top-level `return`을 쓰므로 맨손 `node --check`로는 검증되지 않는다
- `chezmoi apply` 완료 — 소스와 `~/.claude/workflows/deep-research.js` byte-identical
- 워크플로 레지스트리는 세션 시작 시에만 스캔되므로 **다음 세션부터 반영**된다

🤖 Generated with [Claude Code](https://claude.com/claude-code)