### PR TITLE
fix(quality-goal): 리뷰 루프 결함 3건 수정 — prior 전문 전달·미검증 REVISE 라운드 비소모·no-PASS 결정적 강제 (#44 #37 #38)

### DIFF
--- a/docs/development/2026-09-03-quality-goal-review-loop/plan.md
+++ b/docs/development/2026-09-03-quality-goal-review-loop/plan.md
@@ -1,0 +1,463 @@
+# Quality Goal Implementation Plan
+
+- Task ID: 20260903T092537Z-44-37-38-quality-goal-리뷰-루프-결함-3건-수정-라운드-33f2fb89
+- Mode: standard
+- Status: PLAN_REVIEW (round 1)
+- Created: 2026-09-03T10:20:00Z
+- Updated: 2026-09-03T10:20:00Z
+- Source goal: #44 #37 #38 quality-goal 리뷰 루프 결함 3건 수정 — 라운드 2+ prior findings 전문 전달, 미검증 사유 REVISE의 라운드 소모 방지, no-PASS-when-unverified 결정적 게이트 승격
+
+## Spec link
+
+- 승인 대상 Spec: `docs/development/2026-09-03-quality-goal-review-loop/spec.md`
+- Spec SHA-256: `35733b1bf51274b696d94c83babeee52ef65fce9eaa7d5c264f8eaef7bc306f6`
+  (상태 파일의 `artifact_digests.spec`와 동일한 값이며, spec 리뷰 라운드 2가 PASS를 낸
+  바로 그 내용이다)
+- Spec 리뷰 결과: 라운드 1 REVISE(84, blocker SPEC-001) → 라운드 2 PASS(93, blocker 0,
+  Critical/High 0). 게이트 `{"passed":true,"reasons":[]}`.
+
+### Spec의 미해소 advisory 2건에 대한 이 Plan의 처리
+
+Spec 라운드 2가 Low 2건을 advisory로 남겼다. 통과한 Spec은 동결이므로 편집하지 않고,
+이 Plan이 권위 서술을 제공한다.
+
+- **SPEC-006 (Low)** — Spec의 Test strategy 절이 변이 검증 대상을 "신규 규칙 11개"로
+  적었으나 AC-55는 13개를 열거한다. R5.5가 AC-55의 목록을 권위로 선언한다.
+  **이 Plan은 변이 대상을 13개로 확정한다**(T6 참조). 구현자는 Spec의 Test strategy 절
+  숫자가 아니라 AC-55의 (1)~(13)을 따른다.
+- **SPEC-007 (Low)** — 두 곳의 Decision 인용이 어긋났고, **둘 다 리뷰어 지적이 맞다.**
+  Spec 라운드 2 개정에서 D3(2번째 호출을 exit 0으로 두는 결정)을 새로 끼워넣으면서 이후
+  번호가 하나씩 밀렸는데, 본문의 두 인용을 따라 고치지 않은 결과다.
+  - Spec R4.3 말미의 `(D9)`는 **D11**이어야 한다. D9는 재수행 digest 바인딩 결정이고,
+    유지보수 문서의 추적 목록을 열거 + 권위 포인터로 바꾸는 결정은 D11이다.
+    **이 Plan은 T5에서 D11을 근거로 인용한다.**
+  - Spec Non-goal 1 말미의 `(D3)`는 **D4**여야 한다. "새 실패 경로가 같은 결함(#43)을
+    재생산하지 않아야 한다"를 결정하는 것은 자동 터미널 전이를 금지한 D4(`spec.md:929`)
+    이고, D3(`spec.md:913`)은 그 금지 때문에 형제 함수의 persist-then-transition 패턴을
+    쓸 수 없다는 **파생 결정**이다. **이 Plan은 T2 전제 2와 T2-3c에서 D4를 근거로
+    인용한다.**
+  두 인용 오류는 요구사항·AC·설계 내용을 바꾸지 않으므로 통과한 Spec을 편집하지 않고
+  이 Plan이 권위 서술을 제공한다.
+
+## Global constraints
+
+1. **변경 파일 allow-list (Spec Non-goal 11).** 변경은 다음 세 경로 아래로만 허용한다:
+   `dot_claude/skills/quality-goal/`, `dot_claude/agents/quality-reviewer.md`, `docs/`.
+   `.gitignore`, 다른 스킬, chezmoi 소스의 다른 파일은 건드리지 않는다.
+2. **#43 블록 동결 (Spec Non-goal 1).** `quality_state.py`의
+   `recurring = next(...)`부터 `REVIEW_LIMIT_EXHAUSTED`까지 9줄은 base revision과 바이트
+   동일해야 한다. 이 블록 **앞쪽**에 검사를 추가하는 것은 허용되고, 블록 자체의 수정은
+   금지다.
+3. **`ROUND_LIMITS`·`references/` 동결 (Spec Non-goal 7, 8).** `ROUND_LIMITS`는
+   `{"spec": 3, "plan": 2, "code": 3}` 그대로, `references/` 5개 파일은 전부 불변이다.
+4. **배포 금지 (Spec Non-goal 2).** 구현·검증·리뷰 단계에서 `chezmoi apply`를 실행하지
+   않는다. 인자 없는 `chezmoi apply`는 어느 단계에서도 금지다.
+5. **커밋·머지 (Spec Non-goal 3).** Codex는 커밋하지 않는다. 커밋과 PR 생성은
+   오케스트레이터가 사용자 승인 이후 수행하고, 머지는 하지 않는다.
+6. **`__pycache__` 위생.** 모든 Python 호출에 `PYTHONDONTWRITEBYTECODE=1`을 붙인다.
+   변이 검증 사이클마다
+   `find dot_claude/skills/quality-goal -name '__pycache__' -type d -prune -exec rm -rf {} +`
+   를 실행한다. `.gitignore`가 `__pycache__/`를 덮어 `git status`에 나타나지 않으므로
+   오염이 조용히 오판을 만든다.
+7. **테스트 우선.** 각 태스크는 실패하는 검증을 먼저 기록하고, 최소 구현을 넣고, 통과를
+   기록한다. 예외는 T2뿐이며 그 사유와 승인 근거는 "Task dependencies"에 기록한다.
+8. **기준선.** base revision `5ed7b57387d6a271e8e014091ff8143f488e0d29`, 전체 스위트
+   201개 통과(exit 0), 사전 dirty 경로 0건. 완료 시 스위트는 201을 초과하고 실패 0건이다.
+9. **Codex 실행 규율.** `--skip-git-repo-check`, `--full-auto`, `--yolo`는 금지다.
+   샌드박스는 `workspace-write`, 모델은 `gpt-5.6-terra`, effort `high`
+   (`references/model-routing.md`의 standard 경로).
+10. **Codex 라운드는 1회로 계획한다.** 코드 리뷰 한도가 3라운드이고 Codex 라운드마다
+    리뷰 라운드를 1개 소모하므로, 전체 구현을 한 번에 넘기고 남은 2라운드를 bounded fix에
+    남긴다.
+
+## File map
+
+| 경로 | 조치 | 책임 / 영향 인터페이스 |
+|---|---|---|
+| `dot_claude/skills/quality-goal/scripts/validate_review.py` | 수정 | `_prior_open_finding_ids` 확장(R1.1~R1.8), `EVIDENCE_FIELDS`에 `verified` 추가 + `EVIDENCE_STRING_FIELDS` 신설 + boolean 검사(R3.2), PASS+미검증 금지(R3.3). `evaluate_gate`는 불변 |
+| `dot_claude/skills/quality-goal/scripts/quality_state.py` | 수정 | `record_review_unverified` 함수 + `record-review-unverified` 서브파서(R2.2~R2.7, R2.4b), 초기 상태에 `review_unverified_retry: None`(R5.2), `record_review`에 R2.12 digest 바인딩 검사와 R2.8 초기화 추가. `record_review`의 자동 전이 블록·`ROUND_LIMITS`·`ALLOWED_TRANSITIONS`·`TERMINAL_STATES`는 불변 |
+| `dot_claude/skills/quality-goal/schemas/review.schema.json` | 수정 | evidence 항목에 `verified` boolean 필수 추가(R3.1). `additionalProperties: false`·`uniqueItems` 2곳·나머지 enum 불변 |
+| `dot_claude/skills/quality-goal/SKILL.md` | 수정 | Review invocation contract 확장(R1.9·R1.10), 미검증 REVISE 정책 신설(R2.9·R2.11·R2.12), frontmatter `version: 4.0.0`(R4.1). 500행 미만 유지(R5.6) |
+| `dot_claude/agents/quality-reviewer.md` | 수정 | 라운드 2+ open finding 해소 판정 규칙(R1.11), `verified` 기입 규칙(R2.10·R3.6). frontmatter·도구 목록·BLOCKED payload 8필드 규칙 불변 |
+| `dot_claude/skills/quality-goal/tests/test_validate_review.py` | 수정 | prior 확장 수용·거부, `verified` 검증, PASS 금지, `SchemaDriftTests` evidence 필수 필드, `valid_review()` 헬퍼에 `verified` 추가. **`:384`의 `for field in ("claim", "location")` 루프는 불변**(R3.5) |
+| `dot_claude/skills/quality-goal/tests/test_quality_state.py` | 수정 | `record-review-unverified` 수용·거부 전수, 상태 키 집합, digest 바인딩, `record_review`의 PASS+미검증 거부, `valid_review()` 헬퍼에 `verified` 추가 |
+| `dot_claude/skills/quality-goal/tests/test_content_contracts.py` | 수정 | frontmatter `version` 기대값 `4.0.0`, SKILL.md 계약 5건, quality-reviewer 계약 3건 |
+| `dot_claude/skills/quality-goal/tests/fixtures/review-valid-plan.json` | 수정 | evidence 항목에 `"verified": true` 추가 |
+| `dot_claude/skills/quality-goal/tests/fixtures/review-high-finding.json` | 수정 | evidence 항목에 `"verified": true` 추가 |
+| `dot_claude/skills/quality-goal/tests/fixtures/verification-pass.json` | **불변** | evidence 배열이 없어 영향 없음. AC-51이 `git diff` 빈 출력으로 확인 |
+| `docs/quality-goal-maintenance.md` | 수정 | 추적 목록 갱신(R4.3, 근거 D11) |
+| `docs/development/2026-09-03-quality-goal-review-loop/{spec,plan,report}.md` | 생성 | 산출물(R4.4). `spec.md`·`plan.md`는 이미 존재, `report.md`는 종결 직전 생성 |
+| `dot_claude/skills/quality-goal/references/*.md` | **불변** | Non-goal 8. AC-58이 `git diff` 빈 출력으로 확인 |
+
+## Task dependencies
+
+```
+T1 (#44 prior 확장)      ──┐
+                           ├─→ T3 (#38 스키마·evidence) ──→ T6 (통합 검증·변이·범위)
+T2 (#37 상태 머신)       ──┘                                    ▲
+T4 (문서 계약 + content 테스트) ────────────────────────────────┤
+T5 (버전 4.0.0 + 유지보수 문서) ────────────────────────────────┘
+```
+
+- **T1 → T3**: 둘 다 `validate_review.py`를 만진다. T1이 prior 검증부(`:70-93` 인근)를,
+  T3이 evidence 검증부(`:233-268` 인근)를 만져 코드 영역은 겹치지 않지만, 순차 적용해
+  충돌을 없앤다. 사용자 지정 순서 #44 → #37 → #38과도 일치한다.
+- **T2 → T3 (역방향 의존, 승인된 예외)**: T2가 구현하는 R2.1 트리거 조건은 T3이
+  도입하는 `evidence[].verified`를 참조한다. 따라서 **T2 종료 시점에는 T2의 신규 테스트가
+  실패한다** — `verified` 키가 아직 `EVIDENCE_FIELDS`에 없어 `unknown field: 'verified'`
+  검증 오류가 나기 때문이다. 이는 Spec D8이 명시한 예상된 중간 상태이며, 전제 7(테스트
+  우선)의 유일한 예외다. **T2와 T3은 하나의 검증 단위**이며 녹색 판정은 T3 종료 시점의
+  전체 스위트로만 한다. 구현자는 T2에서 그 실패 메시지를 기록하고 T3 직후 같은 테스트가
+  통과함을 기록한다.
+- **T4·T5는 코드 경로와 독립**이다. T4는 Markdown 계약과 그것을 고정하는 content 테스트만,
+  T5는 frontmatter 값과 문서만 만진다. T1~T3과 병렬 가능하나, 단일 Codex 라운드로
+  넘기므로 순차 실행한다.
+- **T6은 전 태스크 완료 후**에만 의미가 있다. 변이 검증은 최종 소스를 대상으로 한다.
+
+## Tasks
+
+### T1 — #44: `--prior` 입력 확장 (R1.1~R1.8)
+
+**대상**: `scripts/validate_review.py`, `tests/test_validate_review.py`
+
+1. **실패 기록.** `tests/test_validate_review.py`에 AC-1~AC-14의 테스트를 먼저 추가한다.
+   `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s dot_claude/skills/quality-goal/tests -p 'test_validate_review.py'`
+   → 신규 테스트가 실패한다(현재 `_prior_open_finding_ids`가 `open_findings`·
+   `resolved_finding_ids`·최상위 unknown 키를 전혀 보지 않으므로, 거부를 기대하는 테스트가
+   `valid: true`를 받아 실패). 실패 개수와 메시지를 기록한다.
+2. **구현.** `_prior_open_finding_ids`를 확장하거나 그 옆에 `_validate_prior`를 신설한다.
+   - 상수 `PRIOR_FIELDS = ("open_finding_ids", "open_findings", "resolved_finding_ids")`,
+     `OPEN_FINDING_FIELDS = ("id", "severity", "description", "evidence_location",
+     "required_resolution", "resolution_claim", "resolution_evidence")`,
+     `OPEN_FINDING_STRING_FIELDS = ("id", "severity", "description", "evidence_location",
+     "required_resolution")`를 모듈 상단 상수 블록(`:39-48` 인근)에 둔다.
+   - 최상위 unknown 키는 기존 `_unknown_keys`/`_format_key` 헬퍼(`:59-67`)를 재사용해
+     `prior has unknown field: 'X'` 형태로 오류를 낸다(R1.8).
+   - `open_findings` 항목: 7필드 필수·unknown 키 거부·`OPEN_FINDING_STRING_FIELDS`는
+     `_is_non_empty_string`·`severity`는 `SEVERITIES` 멤버십·`resolution_claim`과
+     `resolution_evidence`는 `None` 또는 `str`·`id` 중복 거부.
+   - `open_findings` 존재 시 `open_finding_ids ⊆ {open_findings[*].id}`(R1.5, 역방향
+     비요구).
+   - `resolved_finding_ids`: 문자열 배열·중복 거부·`open_finding_ids`와 교집합 거부.
+   - 기존 반환 계약(`open_finding_ids` 목록)은 유지해 `validate_review`의 라운드 2 blocker
+     검사(`:270-287`)가 그대로 동작하게 한다(R1.7).
+3. **통과 기록.** 위 targeted 명령 → exit 0. 이어서 전체 스위트 → exit 0, 실패 0건.
+   `record-review` 라운드 2 경로(AC-13)가 계속 성공함을 `test_quality_state.py`의 기존
+   테스트로 확인한다.
+
+**실패 처리**: 하위 호환 테스트(AC-12·AC-13)가 깨지면 구현이 prior를 필수화한 것이므로
+되돌린다 — D5가 선택 필드를 요구한다.
+
+### T2 — #37: `record-review-unverified`와 재수행 회계 (R2.2~R2.8, R2.12, R2.13, R2.4b)
+
+**대상**: `scripts/quality_state.py`, `tests/test_quality_state.py`
+
+1. **실패 기록.** AC-18~AC-32, AC-52, AC-61~AC-63의 테스트를 먼저 추가한다.
+   `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s dot_claude/skills/quality-goal/tests -p 'test_quality_state.py'`
+   → 실패한다(서브커맨드 부재 + `verified` 키 미도입). 실패 메시지를 기록한다.
+2. **구현 2a — 초기 상태.** `init`이 만드는 상태 dict(`:195-215` 인근)의
+   `"review_validation_retry": None` 바로 뒤에 `"review_unverified_retry": None`을 넣는다.
+   `schema_version`은 1 그대로다(Non-goal 6).
+3. **구현 2b — `record_review_unverified(state, review_path, artifact_digest)`.**
+   `record_review`(`:561`) 바로 뒤에 배치하고, R2.4의 9단계 순서를 그대로 구현한다.
+   `record_review`와 공통인 앞 6단계는 헬퍼로 추출하지 말고 **명시적으로 같은 순서로
+   작성**한다 — `record_review` 본문 편집을 최소화해 전제 2(#43 블록 동결)의 위험을
+   낮춘다.
+   - 7단계의 `validate_review` 호출은 `round >= 2`일 때
+     `{"open_finding_ids": list(state["open_finding_ids"][artifact])}`를 만들어 넘긴다
+     (R2.4b, `record_review:599-607`과 동일).
+   - 8단계 트리거: `verdict == "REVISE" and not blockers and any(
+     item.get("verified") is False for item in review["evidence"])`.
+   - 9단계 회계: 저장 기록이 `artifact`·`round` 모두 일치할 때만 누적. 일치 시
+     `attempts == 2`면 `TransitionError("... REVIEWER_UNVERIFIED_PERSISTS ...")`,
+     `attempts == 1`이면 digest 바인딩 검사 후 `attempts=2`·`exhausted=True`로 갱신하고
+     `discarded_reviews`·`unverified_claims`에 append. 불일치·부재면 새 기록으로 대체
+     (`attempts=1`, `exhausted=False`, `artifact_digest=<이번 값>`).
+   - 어떤 경로에서도 `rounds[artifact]`를 바꾸지 않고 스테이지를 전이하지 않는다(R2.6).
+4. **구현 2c — `record_review` 최소 편집.** `record_review` 안에서 두 곳만 바꾼다.
+   - **바인딩 검사**: 라운드 일치 검사와 한도 검사 이후, `validate_review` 호출 이전에
+     `review_unverified_retry`가 `artifact`와 `expected_round` 모두 일치하면
+     `artifact_digest`가 저장값과 같은지 확인하고 다르면 `StateError`(R2.12·R2.13).
+   - **초기화**: 기존 `state["review_validation_retry"] = None` 줄 바로 뒤에
+     `state["review_unverified_retry"] = None`을 추가한다(R2.8). 이 줄은
+     `recurring = next(...)` 블록보다 **위**에 있으므로 전제 2를 침범하지 않는다.
+5. **구현 2d — CLI.** `record-review-unverified` 서브파서를 `record-review`
+   (`:1086` 인근) 바로 뒤에 추가한다. 인자는 `--state`, `--review`, `--artifact-digest`
+   **셋뿐이며 `--prior`를 추가하지 않는다**(R2.4b·AC-62). `--artifact-digest`는
+   `required=True`. dispatch는 `_mutating_result`를 쓴다.
+6. **통과 기록 (조건부).** targeted 명령을 실행한다. `verified` 키에 의존하지 않는
+   테스트(AC-22·AC-23·AC-25·AC-26·AC-52)는 이 시점에 통과해야 한다. `verified`에
+   의존하는 테스트(AC-18~AC-21, AC-24, AC-27~AC-32, AC-61, AC-63)는 **실패가 정상이며**
+   그 실패 메시지가 `evidence[0] has unknown field: 'verified'` 계열임을 기록한다. 다른
+   원인의 실패는 구현 결함이므로 고친다. 최종 녹색 판정은 T3에서 한다.
+
+**실패 처리**: 전제 2 위반(9줄 블록 변경)이 감지되면 즉시 되돌린다 — T6의 AC-57이
+결정적으로 잡는다. 새 서브커맨드가 스스로 터미널 전이를 하도록 구현됐다면 그 역시
+되돌린다 — **D4**(`spec.md:929`)가 #43 재생산을 막기 위해 자동 전이를 금지하고, AC-29가
+전이 이후 `set-artifact --kind report`가 막히지 않음을 실증한다.
+
+### T3 — #38: `evidence[].verified` 도입 (R3.1~R3.7, R5.1)
+
+**대상**: `schemas/review.schema.json`, `scripts/validate_review.py`,
+`tests/fixtures/review-valid-plan.json`, `tests/fixtures/review-high-finding.json`,
+`tests/test_validate_review.py`, `tests/test_quality_state.py`
+
+1. **실패 기록.** AC-37~AC-44, AC-51의 테스트를 추가하고 targeted 두 명령을 실행한다 →
+   실패. T2에서 남긴 red 테스트도 여전히 실패 중임을 확인한다.
+2. **구현 3a — 스키마.** `review.schema.json`의 evidence 항목
+   (`:46-66`)에서 `required`를 `["claim", "location", "verified"]`로, `properties`에
+   `"verified": {"type": "boolean"}`을 추가한다. `additionalProperties: false`와
+   배열의 `uniqueItems: true`는 유지한다. 새 `uniqueItems`나 정규식은 도입하지 않는다
+   (R5.3).
+3. **구현 3b — 검증기.** `validate_review.py`에서
+   - `EVIDENCE_FIELDS = ("claim", "location", "verified")`,
+     `EVIDENCE_STRING_FIELDS = ("claim", "location")`으로 상수를 분리한다(`:48`).
+   - 필수 키 루프(`:245`)와 unknown 키 루프(`:248`)는 `EVIDENCE_FIELDS`를 쓴다.
+   - 비어 있지 않은 문자열 루프(`:251`)는 `EVIDENCE_STRING_FIELDS`로 바꾼다.
+   - `verified`는 `isinstance(value, bool)` 검사를 별도로 받는다. 문자열 `"false"`와
+     정수 `0`은 거부된다.
+   - `verdict == "PASS"` 분기(`:266-268`)에 규칙을 추가한다: `evidence`에
+     `verified is False`인 항목이 1개 이상이면 `errors.append(...)`로 미검증 항목 존재를
+     명시한다(R3.3). `verdict != "PASS"`에는 적용하지 않는다(R3.4).
+   - `evaluate_gate`는 손대지 않는다(Non-goal 4).
+4. **구현 3c — fixture·헬퍼 4곳.** `review-valid-plan.json:9-12`,
+   `review-high-finding.json:21-24`, `test_validate_review.py:37-42`의 `valid_review()`,
+   `test_quality_state.py:75-80`의 `valid_review()`에 `"verified": True/true`를 추가한다.
+   `verification-pass.json`은 **손대지 않는다**.
+   `test_validate_review.py:384`의 `for field in ("claim", "location")` 루프는
+   **그대로 둔다**(R3.5).
+5. **통과 기록.** 전체 스위트
+   `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s dot_claude/skills/quality-goal/tests -p 'test_*.py'`
+   → exit 0, 실패 0건, 총 개수 201 초과. T2가 남긴 red 테스트가 전부 녹색으로 바뀌었음을
+   기록한다.
+
+**실패 처리**: `SchemaDriftTests`가 실패하면 스키마와 `EVIDENCE_FIELDS`가 어긋난
+것이므로 두 곳을 맞춘다. `verified` boolean이 "비어 있지 않은 문자열" 오류를 받으면
+3b의 상수 분리가 누락된 것이다.
+
+### T4 — 문서 계약: `SKILL.md`와 `quality-reviewer.md` (R1.9·R1.10·R1.11, R2.9·R2.10·R2.11·R2.12, R3.6, R5.6)
+
+**대상**: `SKILL.md`, `dot_claude/agents/quality-reviewer.md`,
+`tests/test_content_contracts.py`
+
+1. **실패 기록.** AC-15·16·17·33·34·35·36·45·54의 계약 테스트를 먼저 추가한다.
+   `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s dot_claude/skills/quality-goal/tests -p 'test_content_contracts.py'`
+   → 실패.
+2. **구현 4a — `SKILL.md` Review invocation contract**(`:250-288` 구간).
+   - 라운드 2+ 리뷰어 입력을 "prior open finding IDs"에서 각 open finding의 **ID·심각도·
+     설명·증거 위치·요구 해소책 + 오케스트레이터의 해소 주장·해소 증거**로 확장하고,
+     해소 확인된 항목은 ID만 `resolved_finding_ids`로 보낸다고 명시한다(R1.9).
+   - 그 구조화된 prior를 `reviews[artifact][*].path`의 이전 라운드 리뷰 JSON에서 조립하고
+     `open_finding_ids`(blocker만 보존)에 의존하지 않는다고 명시한다(R1.10).
+   - 미검증 REVISE 정책 문단을 신설한다: 트리거 3조건(`REVISE`·`blockers == []`·
+     `verified == false` evidence 존재), 라운드 비소모, 같은 라운드 재기동, 폐기 리뷰
+     2건 상한(무료 재수행 1회), `exhausted`를 본 뒤 보고서 등록 → `BLOCKED`
+     `REVIEWER_UNVERIFIED_PERSISTS`, 그 종결이 리뷰어 역량 한계이며 코드·설계 실패가
+     아니라는 기록 지시(R2.9), 재수행 입력에 미검증 조건의 증거 경로와 폐기 리뷰의
+     비-blocking findings 전문을 담고 라운드 2+에서는 prior의 `open_findings`에도
+     포함(R2.11), 재수행 중 아티팩트·워크스페이스를 개정하지 않음(R2.12).
+   - frontmatter `version`은 T5에서 바꾼다.
+   - **500행 미만을 유지한다**(현재 342행, 여유 157행).
+3. **구현 4b — `quality-reviewer.md`.**
+   - 라운드 2+에서 전달받은 각 open finding의 해소 여부를 판정해 `evidence`에 기록하고,
+     새 finding이 전달받은 항목의 재진술이면 기존 ID를 재사용한다(R1.11).
+   - 모든 evidence 항목에 `verified`를 채우고 `false`일 때 이유를 `claim`에 적는다.
+     BLOCKED payload의 단일 evidence 항목도 같은 규칙을 따른다(R2.10·R3.6).
+   - `:61`의 기존 no-PASS 문장은 `test_content_contracts.py:657-660`이 **문자열 전체를
+     고정**하므로, 그 문장을 바꾸려면 같은 테스트의 기대 문자열도 함께 바꾼다. 바꿀
+     필요가 없다면 문장을 보존하고 `verified` 규칙을 별도 문장으로 추가한다.
+   - frontmatter(`name`·`tools`·`model`·`effort`·`maxTurns: 24`)는 불변이다.
+4. **통과 기록.** targeted 명령 → exit 0.
+   `wc -l dot_claude/skills/quality-goal/SKILL.md` → 500 미만.
+
+**실패 처리**: SKILL.md가 500행을 넘으면 신설 문단을 압축한다. 기존 계약 테스트가 깨지면
+문구를 바꾼 것이므로 원문을 복원하고 추가 문장으로 표현한다.
+
+### T5 — 버전과 유지보수 문서 (R4.1~R4.3, 근거 D11)
+
+**대상**: `SKILL.md` frontmatter, `tests/test_content_contracts.py`,
+`docs/quality-goal-maintenance.md`
+
+1. **실패 기록.** `test_content_contracts.py`의 frontmatter 기대값을 `4.0.0`으로 바꾸고
+   targeted 명령 실행 → 실패(소스가 아직 `3.0.0`).
+2. **구현.** `SKILL.md` frontmatter의 `version: 3.0.0` → `version: 4.0.0`
+   (`docs/quality-goal-maintenance.md:54` "게이트 규칙이나 상태 머신 계약 변경: MAJOR").
+   frontmatter 키 집합은 불변이다.
+3. **구현.** `docs/quality-goal-maintenance.md`의 "추적 중인 후속 작업" 절(`:41-46`)을
+   갱신한다 — 현재 목록은 `#36`·`#37`·`#38`·`#39` 4개다.
+   - `#37`·`#38` 항목을 제거한다(이 PR이 해소).
+   - `#44` 항목은 만들지 않는다(이 PR이 해소).
+   - `#43`을 "이 작업이 의도적으로 손대지 않은 인접 결함"으로 명시 추가한다.
+   - "권위 목록은 GitHub의 열린 이슈"라는 문장과 조회 명령
+     `gh issue list --state open --search 'quality-goal in:title'`를 추가한다.
+4. **통과 기록.** targeted 명령 → exit 0. AC-48의 grep 판정을 수행한다.
+
+**실패 처리**: frontmatter 키 집합이 바뀌면 되돌린다 — AC-47이 집합 동등을 요구한다.
+
+### T6 — 통합 검증·변이 검증·범위 확인 (R5.1·R5.4·R5.5, Non-goal 1·7·8·11)
+
+**대상**: 소스 변경 없음. 검증 실행과 산출물 문서만.
+
+1. **전체 스위트.** `find`로 `__pycache__` 제거 후
+   `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s dot_claude/skills/quality-goal/tests -p 'test_*.py'`
+   → exit 0, 201 초과, 실패 0건(AC-50).
+2. **정적 검사.** `python3 -m json.tool` 스키마, `python3 -m py_compile` 두 스크립트,
+   `grep -rn 'output-schema'`에 `review.schema.json` 부재(AC-53),
+   `wc -l SKILL.md` < 500(AC-54).
+3. **변이 검증 13건 (AC-55).** 목록은 AC-55의 (1)~(13)이 권위다 — Spec의 Test strategy
+   절이 적은 "11개"는 라운드 2 개정 전 숫자이며 SPEC-006으로 기록됐다.
+   각 항목마다: 해당 구현을 임시 무력화 → 대응 테스트 실패 관찰 → 즉시 복원 →
+   `__pycache__` 제거 → 전체 스위트 재확인. 사이클마다
+   `git diff --stat`이 무력화 전 상태로 돌아왔음을 확인한다.
+4. **범위·불변 확인.** 커밋 후 PR 생성 전에 AC-56(allow-list), AC-57(#43 블록 앵커),
+   AC-58(`references/` 무변경 + `ROUND_LIMITS` 값), AC-59(보고서 배포 명령 표)를
+   실행한다.
+5. **추적표 자기 감사.** AC-60의 파이썬 절차를 `spec.md`에 대해 실행한다.
+6. **산출물.** `report.md`를 렌더링하고 터미널 전이 **이전에**
+   `set-artifact --kind report`로 등록한다(#43 회피 — SKILL.md가 요구하는 순서).
+
+**실패 처리**: 변이 후 복원했는데 같은 테스트가 계속 실패하면 `__pycache__` 오염이므로
+`find ... -name '__pycache__' -prune -exec rm -rf {} +` 후 재실행한다. allow-list 위반이
+나오면 해당 파일 변경을 되돌린다.
+
+## Verification commands
+
+실행 순서와 기대 결과. `$SK` = `dot_claude/skills/quality-goal`,
+`$BASE` = `5ed7b57387d6a271e8e014091ff8143f488e0d29`.
+모든 Python 호출 앞에 `PYTHONDONTWRITEBYTECODE=1`을 붙인다.
+
+| # | 명령 | 기대 |
+|---:|---|---|
+| 1 | `find $SK -name '__pycache__' -type d -prune -exec rm -rf {} +` | exit 0 |
+| 2 | `python3 -m unittest discover -s $SK/tests -p 'test_validate_review.py'` | exit 0, `OK` |
+| 3 | `python3 -m unittest discover -s $SK/tests -p 'test_quality_state.py'` | exit 0, `OK` |
+| 4 | `python3 -m unittest discover -s $SK/tests -p 'test_content_contracts.py'` | exit 0, `OK` |
+| 5 | `python3 -m unittest discover -s $SK/tests -p 'test_*.py'` | exit 0, `Ran N tests` with N > 201, `OK` |
+| 6 | `python3 -m json.tool $SK/schemas/review.schema.json` | exit 0 |
+| 7 | `python3 -m py_compile $SK/scripts/validate_review.py $SK/scripts/quality_state.py` | exit 0 |
+| 8 | `wc -l $SK/SKILL.md` | 500 미만 |
+| 9 | `grep -rn 'output-schema' $SK` | `review.schema.json` 미등장 |
+| 10 | `grep -n 'ROUND_LIMITS = ' $SK/scripts/quality_state.py` | `{"spec": 3, "plan": 2, "code": 3}` |
+| 11 | `git diff $BASE...HEAD -- $SK/references/` | 빈 출력 |
+| 12 | `git diff $BASE...HEAD -- $SK/tests/fixtures/verification-pass.json` | 빈 출력 |
+| 13 | `git diff --name-only $BASE...HEAD \| grep -vE '^(dot_claude/skills/quality-goal/\|dot_claude/agents/quality-reviewer\.md$\|docs/)'` | grep exit 1 (빈 출력) |
+| 14 | `git show $BASE:$SK/scripts/quality_state.py \| sed -n '/^    recurring = next/,/REVIEW_LIMIT_EXHAUSTED/p' > /tmp/base-block.txt; sed -n '/^    recurring = next/,/REVIEW_LIMIT_EXHAUSTED/p' $SK/scripts/quality_state.py > /tmp/head-block.txt; diff /tmp/base-block.txt /tmp/head-block.txt` | exit 0, 양쪽 9줄 |
+| 15 | `python3 $SK/scripts/quality_state.py record-review-unverified --help` | `--prior` 미등장 |
+| 16 | `grep -n 'chezmoi apply' docs/development/2026-09-03-quality-goal-review-loop/report.md` | 매치 행마다 경로 인자 1개 이상, 인자 없는 행 0건 |
+
+명령 1~10은 구현 직후 오케스트레이터의 독립 검증에서 실행한다. 명령 11~16은 커밋 후
+PR 생성 전에 실행한다.
+
+**검증 카테고리 (저장소 실측).** 이 저장소에는 `package.json`·`Makefile`·`justfile`·
+`tsconfig.json`·`.github/workflows`가 없다(실측 확인). 타입 체크·린트·빌드는
+`not configured`로 기록하며 통과로 기록하지 않는다. `.pre-commit-config.yaml`은 gitleaks
+훅 하나뿐이라 린트가 아니다. E2E는 스킬 번들 성격상 해당 없으며, 명령 11~16과 변이 검증
+13건이 그 역할을 한다.
+
+## Rollout and rollback
+
+**롤아웃.**
+
+1. Codex 구현 라운드 1회(`gpt-5.6-terra`, effort `high`, `--sandbox workspace-write`,
+   `--ephemeral`). 프롬프트는 `.claude/quality-state/<task-id>/` 안에 두고 승인된
+   Spec·Plan 절대 경로, allow-list, 정확한 검증 명령, 테스트 우선 요구, 초기 dirty 경로
+   제외(없음), 결과 스키마 경로를 담는다.
+2. 오케스트레이터 독립 검증: `git status`·`git diff`와 Codex가 보고한 `changed_files`
+   대조, 명령 1~10 실행, 워크스페이스 지문 계산, `record-verification`.
+3. 코드 리뷰 라운드(최대 3). 남은 2라운드는 bounded fix용으로 예약한다.
+4. 사용자 승인 후 커밋 → 브랜치 push → PR 생성. **머지하지 않는다.**
+5. **배포는 사용자 결정 사항이다.** 수행한다면 변경 파일 경로를 명시한
+   `chezmoi apply <path>...`만 쓴다. 인자 없는 `chezmoi apply`는 금지다. 다른 세션이
+   배포본 v3.0.0을 실행 중일 수 있으므로, 배포 시점부터 그 세션의 다음 리뷰 라운드에 새
+   계약이 적용된다는 점을 보고서에 남긴다.
+
+**롤백 트리거와 조치.**
+
+| 트리거 | 조치 |
+|---|---|
+| 전체 스위트가 exit 0을 못 냄 | 원인이 fixture 형태면 T3-3c로 복귀. 계약 모순이면 해당 태스크 변경을 `git checkout -- <path>`로 되돌리고 Spec 개정 필요 여부를 판단 |
+| allow-list 위반(명령 13) | 위반 파일을 `git checkout $BASE -- <path>`로 복원하고 재검증 |
+| #43 블록 변경(명령 14) | `git show $BASE:...`에서 해당 9줄을 복원 |
+| `references/` 변경(명령 11) | `git checkout $BASE -- $SK/references/` |
+| 커밋 후 결함 발견 | `git revert <commit>`. 브랜치 폐기가 필요하면 `git branch -D 44-fix/quality-goal-review-loop` |
+| 배포 후 결함 발견 | `git revert` 후 **같은 파일 경로를 지정한** `chezmoi apply <path>...`를 다시 실행 |
+| Codex 모델 거부·미가용 | `BLOCKED_MODEL_UNAVAILABLE`. 현재 스테이지 유지, 사용자에게 대체 모델 승인 요청. 무단 대체 금지 |
+
+**호환성.** 상태 파일 `schema_version`은 1 그대로다. 기존 상태 파일에
+`review_unverified_retry`가 없어도 `state.get(...)` 관용 읽기로 동작한다. 파괴적 작업·
+데이터 마이그레이션·외부 상태 변경은 없다.
+
+**모니터링.** 이 변경에는 런타임 관측 대상이 없다. 관측 지점은 결정적 명령의 종료 코드와
+`.claude/quality-state/<task-id>/state.json`뿐이다.
+
+## Acceptance-criteria traceability
+
+명령 축약: `$SUITE` = `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s $SK/tests -p 'test_*.py'`,
+`$TVR` = 같은 형식에 `-p 'test_validate_review.py'`, `$TQS` = `-p 'test_quality_state.py'`,
+`$TCC` = `-p 'test_content_contracts.py'`.
+
+| Criterion | Task | Verification command | Expected outcome |
+|---|---|---|---|
+| AC-1 | T1 | `$TVR` | 확장 prior + 라운드 2 리뷰 검증이 exit 0, `{"valid":true,"errors":[]}` |
+| AC-2 | T1 | `$TVR` | 7필드 각각 제거 시 exit 2, errors에 필드명 (subTest 7회) |
+| AC-3 | T1 | `$TVR` | `severity="Trivial"` → exit 2 |
+| AC-4 | T1 | `$TVR` | `open_findings[0].extra` → exit 2, errors에 `'extra'` |
+| AC-5 | T1 | `$TVR` | `open_findings` id 중복 → exit 2 |
+| AC-6 | T1 | `$TVR` | 커버리지 위반 → exit 2 |
+| AC-7 | T1 | `$TVR` | 상위집합(blocker+Medium) → exit 0 |
+| AC-8 | T1 | `$TVR` | resolved ∩ open ≠ ∅ → exit 2 |
+| AC-9 | T1 | `$TVR` | resolved 중복 → exit 2, 원소 정수 → exit 2 |
+| AC-10 | T1 | `$TVR` | 문자열 5필드 각각 `""`·`"   "` → exit 2 (subTest 10회) |
+| AC-11 | T1 | `$TVR` | `resolution_*` null → exit 0, 정수 1 → exit 2 |
+| AC-12 | T1 | `$TVR` | `{"open_finding_ids": []}`만 담은 prior → exit 0 |
+| AC-13 | T1 | `$TQS` | `record-review` 라운드 2 경로 exit 0 |
+| AC-14 | T1 | `$TVR` | prior 최상위 `open_finding` 키 → exit 2, errors에 키 이름 |
+| AC-15 | T4 | `$TCC` | SKILL.md가 라운드 2+ 입력으로 설명·증거 위치·요구 해소책·해소 주장을 지시하고 해소분은 ID만 보낸다고 명시 |
+| AC-16 | T4 | `$TCC` | SKILL.md가 prior를 `reviews[artifact][*].path`에서 조립하라고 지시 |
+| AC-17 | T4 | `$TCC` | quality-reviewer.md가 라운드 2+ 해소 판정과 ID 재사용을 규정 |
+| AC-18 | T2 | `$TQS` | 1번째 호출 exit 0, `attempts=1`·`exhausted=false`·`artifact_digest=D`, `rounds` 불변 |
+| AC-19 | T2 | `$TQS` | blockers 비어 있지 않음 → exit 2 |
+| AC-20 | T2 | `$TQS` | 모든 evidence `verified=true` → exit 2 |
+| AC-21 | T2 | `$TQS` | verdict PASS/BLOCKED → exit 2 |
+| AC-22 | T2 | `$TQS` | 스테이지 불일치 → exit 2 |
+| AC-23 | T2 | `$TQS` | 라운드 불일치 → exit 2; 라운드 불일치 ∧ 한도 초과 → **exit 2** |
+| AC-24 | T2 | `$TQS` | 스키마 위반 → exit 2, 상태 바이트 동일 |
+| AC-25 | T2 | `$TQS` | `--artifact-digest` 누락 → argparse exit 2; spec digest 불일치 → exit 2, 상태 불변 |
+| AC-26 | T2 | `$TQS` | `rounds==limit` ∧ `round==limit+1` → exit 3, 상태 불변 |
+| AC-27 | T2 | `$TQS` | 2번째 호출 exit 0, `attempts=2`·`exhausted=true`·`discarded_reviews=[R,R2]`, `rounds` 불변 |
+| AC-28 | T2 | `$TQS` | 3번째 호출 exit 3, stderr에 `REVIEWER_UNVERIFIED_PERSISTS`, 상태 바이트 동일 |
+| AC-29 | T2 | `$TQS` | 이후 `set-artifact --kind report` exit 0, `transition --to BLOCKED --reason REVIEWER_UNVERIFIED_PERSISTS:spec` exit 0 |
+| AC-30 | T2 | `$TQS` | 동일 digest `record-review` exit 0, `review_unverified_retry` null |
+| AC-31 | T2 | `$TQS` | 다른 digest `record-review` exit 2, `rounds` 불변; 2번째 unverified도 다른 digest면 exit 2 |
+| AC-32 | T2 | `$TQS` | spec 파일 개정 후 digest 재계산 제시 → `record-review` exit 2 |
+| AC-33 | T4 | `$TCC` | SKILL.md가 트리거 3조건·라운드 비소모·같은 라운드 재기동·폐기 2건 상한·`exhausted` 후 BLOCKED 경로를 명시 |
+| AC-34 | T4 | `$TCC` | SKILL.md가 그 BLOCKED가 리뷰어 역량 한계임을 기록하도록 지시 |
+| AC-35 | T4 | `$TCC` | SKILL.md가 재수행 입력의 증거 경로·비-blocking findings 승계·무개정을 명시 |
+| AC-36 | T4 | `$TCC` | quality-reviewer.md가 미검증을 `verified: false`로 표시하도록 규정 |
+| AC-37 | T3 | `$TVR` | 스키마 evidence `required`가 `{claim,location,verified}`, `verified.type=="boolean"`, `additionalProperties` false |
+| AC-38 | T3 | `$TVR` | `verified` 누락 → exit 2, errors에 `verified` |
+| AC-39 | T3 | `$TVR` | `verified="false"` 또는 `0` → exit 2 |
+| AC-40 | T3 | `$TVR` | PASS ∧ `verified:false` → exit 2, errors가 미검증 존재를 명시 |
+| AC-41 | T3 | `$TVR` | REVISE ∧ `verified:false` → exit 0 |
+| AC-42 | T3 | `$TVR` | `verified:true` 통과, 같은 항목 `claim=""` → exit 2 |
+| AC-43 | T3 | `$TVR` | `SchemaDriftTests` 통과 |
+| AC-44 | T3 | `$TQS` | PASS+미검증으로 `record-review` → exit 2, `rounds` 불변 |
+| AC-45 | T4 | `$TCC` | quality-reviewer.md가 모든 evidence에 `verified` 기입·`false` 사유·BLOCKED payload 동일 적용을 규정 |
+| AC-46 | T5 | `grep '^version:' $SK/SKILL.md` | `version: 4.0.0` |
+| AC-47 | T5 | `$TCC` | frontmatter 테스트 통과, 키 집합 7개 불변 |
+| AC-48 | T5 | `grep -n '#3[6-9]\|#4[34]\|gh issue list' docs/quality-goal-maintenance.md` | `#37`·`#38`·`#44` 부재, `#43` 존재, 권위 문장과 조회 명령 존재 |
+| AC-49 | T6 | `ls docs/development/2026-09-03-quality-goal-review-loop/` | `spec.md`·`plan.md`·`report.md` 존재 |
+| AC-50 | T6 | `$SUITE` | exit 0, `Ran N tests` with N > 201, 실패 0건 |
+| AC-51 | T3 | 파이썬 단정 + `git diff $BASE...HEAD -- $SK/tests/fixtures/verification-pass.json` | 4곳의 evidence 객체가 모두 `claim`·`location`·`verified` 보유; verification-pass diff 빈 출력 |
+| AC-52 | T2 | `$TQS` | 상태 키 집합에 `review_unverified_retry` 포함, `init`이 null로 생성 |
+| AC-53 | T6 | `grep -rn 'output-schema' $SK` | `review.schema.json` 미등장 |
+| AC-54 | T4 | `wc -l $SK/SKILL.md` | 500 미만 |
+| AC-55 | T6 | 변이 13회 × (무력화 → `$SUITE` → 복원 → `find __pycache__` 제거 → `$SUITE`) | 무력화 시 대응 테스트 실패, 복원 시 exit 0 |
+| AC-56 | T6 | 검증 명령 13 | grep exit 1 (빈 출력) |
+| AC-57 | T6 | 검증 명령 14 | `diff` exit 0, 양쪽 9줄 |
+| AC-58 | T6 | 검증 명령 11 + 10 | `references/` diff 빈 출력, `ROUND_LIMITS`가 `{"spec": 3, "plan": 2, "code": 3}` |
+| AC-59 | T6 | 검증 명령 16 | `chezmoi apply` 행이 모두 경로 인자 보유, 인자 없는 행 0건(0매치도 통과) |
+| AC-60 | T6 | AC-60의 파이썬 절차를 `spec.md`에 실행 | 요구사항 ID 집합 == 추적표 행 집합, 각 행이 실재 AC를 1개 이상 인용 |
+| AC-61 | T2 | `$TQS` | spec 라운드 1 기록 후 라운드 2 미검증 REVISE → exit 0, `rounds.spec` 1 유지, `--prior` 없이 성공 |
+| AC-62 | T2 | 검증 명령 15 + `$TQS` | `--help`에 `--prior` 부재, `--prior` 전달 시 argparse exit 2 |
+| AC-63 | T2 | `$TQS` | (a) 낡은 기록 → 대체·exit 0, (b) 다른 digest `record-review` → exit 0, (c) 이후 `review_unverified_retry` null |

--- a/docs/development/2026-09-03-quality-goal-review-loop/report.md
+++ b/docs/development/2026-09-03-quality-goal-review-loop/report.md
@@ -1,0 +1,313 @@
+# Quality Goal Report
+
+- Task ID: 20260903T092537Z-44-37-38-quality-goal-리뷰-루프-결함-3건-수정-라운드-33f2fb89
+- Mode: standard
+- Status: COMPLETED
+- Created: 2026-09-03T09:25:37Z
+- Updated: 2026-09-04T00:10:00Z
+- Source goal: #44 #37 #38 quality-goal 리뷰 루프 결함 3건 수정 — 라운드 2+ prior findings 전문 전달, 미검증 사유 REVISE의 라운드 소모 방지, no-PASS-when-unverified 결정적 게이트 승격
+- Base revision: `5ed7b57387d6a271e8e014091ff8143f488e0d29`
+- Implementation commit: `2336d23`
+
+## Classification
+
+선택 모드: **standard** (사용자 명시 모드도 standard이므로 다운그레이드 확인 불필요).
+
+**strict 트리거 없음.** 인증·인가·테넌시, 결제·정산 회계, PII·보안통제·시크릿,
+DB·영속 스키마 마이그레이션·파괴적 작업·어려운 롤백, 공개·외부 API·웹훅·큐·동시성,
+프로덕션 인프라 중 어느 것도 해당하지 않는다. `review.schema.json`은 JSON 검증 계약이지
+영속 데이터 스키마가 아니고, 롤백은 `git revert`와 경로 지정 배포 재실행으로 단순하다.
+
+**standard 조건 성립.**
+
+1. **다중 파일·모듈** — `SKILL.md`, `scripts/validate_review.py`,
+   `scripts/quality_state.py`, `schemas/review.schema.json`,
+   `dot_claude/agents/quality-reviewer.md`, `tests/` 3개 파일과 fixture 2개,
+   `docs/quality-goal-maintenance.md`가 함께 바뀐다.
+2. **비자명한 공유 인터페이스** — `--prior` 페이로드 형태와 `review.schema.json`의
+   evidence 항목 형태는 오케스트레이터·리뷰어·검증기·픽스처가 공유하는 계약이며,
+   `SchemaDriftTests`가 스키마와 Python 상수의 일치를 강제한다.
+3. **상태 전이 변경** — #37이 미검증 사유 REVISE가 `ROUND_LIMITS`를 소모하지 않도록
+   리뷰 라운드 회계를 바꾼다.
+4. **대안·비목표·수용 기준의 명시 필요** — #38이 `verified` 불리언과 `status` enum 두
+   대안을 제시했고 스키마 버전 처리를 미결로 남겼다.
+
+**이슈 라벨 증거** — #44 `bug`, #37 `enhancement`, #38 `enhancement`. 라벨은 상향
+근거로만 쓰였고 risk 스캔 결과를 대체하지 않았다.
+
+**착수 전 확인(#57).** 배포본 `SKILL.md`의 라운드 수 서술(spec 3 / plan 2 / code 3)이
+`quality_state.py:69`의 `ROUND_LIMITS`와 일치함을 확인했다. 불일치가 없어 조치 대상이
+없었다.
+
+**선행 실행과의 관계.** 이 실행은 `docs/development/2026-08-27-quality-goal-review-loop/`
+의 Spec(952행, `NEEDS_REDESIGN`)을 초안으로 재사용했다. 그 Spec이 담았던 R6(spec 라운드
+한도 2→3)과 R7(루브릭 라운드 수 단언)은 이후 v3.0.0으로 출시됐으므로 이번 범위에서
+제외했다. 선행 실행의 미해소 findings 중 R6에 종속했던 SPEC-012·013·015는 함께
+소멸했고, 남은 SPEC-006·SPEC-011은 이번 Spec의 D3·D9로 선반영해 해소했다.
+
+## Review history
+
+| 아티팩트 | 라운드 | 점수 | 판정 | 블로커 | Critical/High | 게이트 |
+|---|---|---|---|---|---|---|
+| Spec | 1 | 84 | REVISE | SPEC-001 | 1 | 실패 — `score_below_85`, `verdict_not_pass`, `blockers_present`, `critical_or_high_finding`, `check_failed:acceptance_criteria_objective` |
+| Spec | 2 | 93 | **PASS** | 없음 | 0 | **통과** — `{"passed":true,"reasons":[]}` |
+| Plan | 1 | 89 | **PASS** | 없음 | 0 | **통과** — `{"passed":true,"reasons":[]}` |
+| Code | 1 | 62 | REVISE | CODE-001 | 1 | 실패 — `verdict_not_pass`, `blockers_present`, `critical_or_high_finding`, `check_failed:acceptance_criteria_met` |
+| Code | 2 | 90 | **PASS** | 없음 | 0 | **통과** — `{"passed":true,"reasons":[]}` |
+
+소모 라운드: spec 2/3, plan 1/2, code 2/3.
+
+**라운드 간 변화 — Spec.** 라운드 1의 5건(High 1 · Medium 2 · Low 2)을 전부 개정했고,
+라운드 2 리뷰어가 5건 전부의 해소를 개별 증거와 함께 확인했다. 점수 84 → 93.
+라운드 2가 남긴 것은 Low 2건(SPEC-006·007)뿐이며 게이트를 막지 않았다.
+
+**라운드 간 변화 — Code.** 라운드 1의 4건(High 1 · Medium 1 · Low 2)을 bounded Codex
+수정 라운드로 전부 개정했다. 테스트 208 → 229개. 라운드 2 리뷰어가 4건 전부의 해소를
+확인하고 Low 3건(CODE-005·006·007)을 새로 남겼다. 점수 62 → 90.
+
+**리뷰어 산출물 미전달 1건.** Spec 라운드 1의 첫 리뷰어가 24턴 한도에서 JSON을 내지
+못하고 종료했다. 계약에 따라 `record-review-error`로 기록하고(라운드 미소모 —
+`rounds.spec`은 0 유지) 새 리뷰어를 1회 재시도해 산출물을 받았다. 이것은 이 작업이
+고치려는 #37이 대상으로 하는 리뷰어 예산 소진 현상의 실측이다.
+
+## Blocking-finding resolutions
+
+| ID | 아티팩트 | 심각도 | 해소 내용 | 검증 증거 |
+|---|---|---|---|---|
+| SPEC-001 | Spec | High | `validate_review`는 `round >= 2`에 prior가 없으면 무조건 거부하는데(`validate_review.py:272`) I3의 CLI에 `--prior`가 없어 **라운드 2 이상의 미검증 REVISE 경로가 통째로 도달 불가**였다. R2.4b를 신설해 `record_review`(`quality_state.py:599-607`)와 동일하게 내부에서 prior를 조립하도록 규정하고, `--prior` 인자 추가를 금지했다. AC-61(라운드 2 종단)·AC-62(`--prior` 부재)와 D14(기각 대안 2건)를 추가했다 | 라운드 2 리뷰어 확인: R2.4b가 근거하는 두 코드 사실(`validate_review.py:270-273`, `quality_state.py:599-607`)을 직접 대조하고 AC-61·62·D14·I3 전문·추적표 행의 존재를 확인. 구현 후 `test_round_two_unverified_review_assembles_prior_from_state`가 실행 단언으로 고정 |
+| CODE-001 | Code | High | Codex 구현 라운드가 실행 판정 대상 약 50개 AC에 테스트 메서드를 7개만 넣어, AC-19~AC-29·AC-32·AC-44·AC-61·AC-63이 전혀 검증되지 않았고 AC-3·10·11·37·39·40·42·52가 부분 커버였다. bounded 수정 라운드에서 테스트 메서드 21개를 추가해 각 기준에 대응 단언을 붙이고, 모든 부정 케이스가 **특정 오류 문자열**을 단언하도록 바꿨다 | 스위트 208 → 229개 통과(exit 0), 파일별 46/131/52로 합계 일치. 라운드 2 리뷰어가 기준별 테스트 메서드 대응을 전수 확인. 변이 검증 13/13 검출 |
+
+## Plan approval
+
+- Approval timestamp: `2026-09-03T14:20:12Z`
+- Plan digest: `a4ee164fce17f2c63999d8752790fd8de53e2d8d25eb9bad5a784a9eec1380c4`
+
+승인 게이트에서 Plan 전문과 라운드 1이 남긴 advisory 4건, 그리고 `approve_plan`이 Plan
+digest를 통과 리뷰의 digest에 고정하므로 승인 후에는 Plan을 고칠 수 없다는 제약을 함께
+제시했다. 사용자는 그 상태로 승인하고 Plan 라운드 2를 예비로 남기는 쪽을 택했다.
+`approve_plan`이 기록한 digest는 Plan 리뷰 라운드 1이 통과시킨 digest와 동일하다.
+
+## Changed files
+
+`git diff --name-only 5ed7b57...HEAD` 기준 13개. 전부 allow-list(`dot_claude/skills/quality-goal/`,
+`dot_claude/agents/quality-reviewer.md`, `docs/`) 안이다.
+
+| 경로 | 의도한 변경 |
+|---|---|
+| `dot_claude/skills/quality-goal/scripts/validate_review.py` | prior에 `open_findings`·`resolved_finding_ids` 검증 추가, 최상위 unknown 키 거부, `EVIDENCE_FIELDS`에 `verified` 추가 + `EVIDENCE_STRING_FIELDS` 분리 + boolean 타입 검사, PASS+미검증 금지. `evaluate_gate`는 불변 |
+| `dot_claude/skills/quality-goal/scripts/quality_state.py` | `record_review_unverified` 함수와 `record-review-unverified` 서브파서 신설, 초기 상태에 `review_unverified_retry: None`, `record_review`에 재수행 digest 바인딩 검사와 초기화 1줄 추가. 자동 전이 블록·`ROUND_LIMITS`·`ALLOWED_TRANSITIONS`·`TERMINAL_STATES`는 불변 |
+| `dot_claude/skills/quality-goal/schemas/review.schema.json` | evidence 항목에 `verified`(boolean) 필수 추가. `additionalProperties: false`와 `uniqueItems` 2곳은 유지 |
+| `dot_claude/skills/quality-goal/SKILL.md` | 리뷰 호출 계약을 구조화 prior로 확장, 미검증 REVISE 정책 신설, `version` 3.0.0 → 4.0.0. 342 → 358행(한도 500) |
+| `dot_claude/agents/quality-reviewer.md` | 라운드 2+ open finding 해소 판정과 ID 재사용 규칙, 모든 evidence에 `verified` 기입 규칙. frontmatter·도구 목록·BLOCKED payload 규칙은 불변 |
+| `dot_claude/skills/quality-goal/tests/test_validate_review.py` | prior 확장·`verified`·PASS 금지 회귀 테스트, `valid_review()` 헬퍼에 `verified` 추가. `:444`의 `for field in ("claim", "location")` 루프는 불변 |
+| `dot_claude/skills/quality-goal/tests/test_quality_state.py` | `record-review-unverified` 수용·거부 전수, digest 바인딩, 상태 키, PASS+미검증 거부 테스트. 39 → 131개 |
+| `dot_claude/skills/quality-goal/tests/test_content_contracts.py` | `version` 기대값 4.0.0, SKILL.md·리뷰어 계약 정규식 단언, 에이전트 파일 공용 헬퍼 |
+| `dot_claude/skills/quality-goal/tests/fixtures/review-valid-plan.json` | evidence에 `"verified": true` |
+| `dot_claude/skills/quality-goal/tests/fixtures/review-high-finding.json` | evidence에 `"verified": true` |
+| `docs/quality-goal-maintenance.md` | 추적 목록에서 #37·#38 제거, #43을 의도적 비범위로 명시, 권위 목록이 GitHub 열린 이슈임을 밝히는 문장과 조회 명령 추가 |
+| `docs/development/2026-09-03-quality-goal-review-loop/spec.md` | 산출물 |
+| `docs/development/2026-09-03-quality-goal-review-loop/plan.md` | 산출물 |
+
+**변경하지 않은 것** (결정적으로 확인): `dot_claude/skills/quality-goal/references/` 5개
+파일, `tests/fixtures/verification-pass.json`, `ROUND_LIMITS`,
+`record_review`의 자동 전이 블록 9줄, `.gitignore`, 그 밖의 모든 저장소 파일.
+
+**초기 dirty 경로는 0건**이었고 보존할 사전 변경이 없었다.
+
+## Verification evidence
+
+### 실행한 명령
+
+| 명령 | 종료 코드 | 증거 |
+|---|---|---|
+| `git rev-parse --is-inside-work-tree` / `rev-parse HEAD` | 0 | base `5ed7b57387d6a271e8e014091ff8143f488e0d29` |
+| `codex --version` | 0 | `codex-cli 0.152.1` |
+| `codex exec --sandbox read-only --ephemeral --model gpt-5.6-terra -c model_reasoning_effort="low"` (preflight) | 0 | 비어 있지 않은 응답 — 선택 모델 확인 |
+| `git check-ignore -v .claude/quality-state/` | 0 | `.gitignore:25` — 런타임 상태가 이미 무시됨 |
+| `gh issue view 44/37/38` | 0 | 요구사항 입력 확보 |
+| `quality_state.py select-resume` | 0 | `{"match":null}` — 재개 대상 없음 |
+| `quality_state.py init` / `classify` / `capture-baseline` | 0 | standard, 근거 7건, base 기록, dirty 0건 |
+| **기준선** `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s dot_claude/skills/quality-goal/tests -p 'test_*.py'` | 0 | **`Ran 201 tests` / `OK`** |
+| 정적 교차 확인: 세 테스트 파일의 `def test_` 개수 | — | 50 + 112 + 39 = 201 |
+| `validate_review.py validate` (spec r1) | 0 | `{"valid":true,"errors":[]}` |
+| `validate_review.py gate` (spec r1) | 3 | 사유 5건 |
+| `quality_state.py record-review-error --artifact spec --round 1` | 0 | 리뷰어 산출물 미전달 기록, `rounds.spec` 0 유지 |
+| `quality_state.py record-review` (spec r1) | 0 | `rounds.spec: 1`, `open_finding_ids.spec: ["SPEC-001"]` |
+| `validate_review.py validate --prior` (spec r2) | 0 | `{"valid":true,"errors":[]}` |
+| `validate_review.py gate --prior` (spec r2) | 0 | `{"passed":true,"reasons":[]}` |
+| `quality_state.py transition` SPEC_PASSED → PLAN_REVIEW | 0 | 가드 통과 |
+| `validate_review.py validate` / `gate` (plan r1) | 0 / 0 | `{"passed":true,"reasons":[]}` |
+| `quality_state.py approve-plan` | 0 | digest `a4ee164f…`, 리뷰 digest와 동일 |
+| `codex exec --sandbox workspace-write --ephemeral --model gpt-5.6-terra -c model_reasoning_effort="high"` (구현) | 0 | `status: completed`, 11개 파일 |
+| `codex exec …` (bounded fix) | 0 | `status: completed`, 4개 파일, `plan_deviations` 1건 |
+| **최종** `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s dot_claude/skills/quality-goal/tests -p 'test_*.py'` | 0 | **`Ran 229 tests` / `OK`** (기준선 201 → 구현 후 208 → 최종 229) |
+| 파일별 discover (`test_validate_review.py` / `test_quality_state.py` / `test_content_contracts.py`) | 0 | 46 / 131 / 52 = 229 |
+| `python3 -m json.tool …/schemas/review.schema.json` | 0 | 스키마 파싱 |
+| `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile …/validate_review.py …/quality_state.py` | 0 | 두 스크립트 컴파일 |
+| `wc -l …/SKILL.md` | 0 | **358** (한도 500 미만, AC-54) |
+| `grep '^version:' …/SKILL.md` | 0 | `version: 4.0.0` (AC-46) |
+| `grep -n 'ROUND_LIMITS = ' …/quality_state.py` | 0 | `{"spec": 3, "plan": 2, "code": 3}` 불변 (AC-58) |
+| `git diff --name-only $BASE...HEAD -- …/references/` | 0 | 빈 출력 — 5개 파일 불변 (AC-58) |
+| `git diff --name-only $BASE...HEAD -- …/tests/fixtures/verification-pass.json` | 0 | 빈 출력 — 불변 (AC-51 둘째 절) |
+| **AC-57** `git show $BASE:…/quality_state.py \| sed -n '/^    recurring = next/,/REVIEW_LIMIT_EXHAUSTED/p'` vs 작업 트리 동일 `sed`, 이후 `diff` | 0 | **양쪽 9줄 동일** — #43 블록 불변 |
+| **AC-56** `git diff --name-only $BASE...HEAD \| grep -vE '^(dot_claude/skills/quality-goal/\|dot_claude/agents/quality-reviewer\.md$\|docs/)'` | 1 (grep) | 빈 출력 — allow-list 위반 없음 |
+| **AC-53** `grep -rn 'output-schema' …/quality-goal \| grep -c 'review.schema.json'` | 1 (grep) | 0건 — `review.schema.json`은 Codex에 전달되지 않는다 |
+| **AC-62** `quality_state.py record-review-unverified --state x --review y --artifact-digest z --prior w` | 2 | argparse가 `--prior`를 거부 |
+| **AC-51** 파이썬 판정 — fixture 2개 `json.load` + 헬퍼 2개 호출 | 0 | 4곳의 evidence 객체가 모두 `{claim, location, verified}` |
+| **AC-60** 파이썬 판정 — `spec.md`의 요구사항 ID 집합 vs 추적표 행 집합 | 0 | 42건 동등, 인용된 AC 전부 실재 |
+| `quality_state.py record-verification` (r1, r2) | 0 / 0 | 지문 기록, `valid: true` |
+| `validate_review.py validate` / `gate` (code r1) | 0 / 3 | 사유 4건 — `check_failed:acceptance_criteria_met` 포함 |
+| `validate_review.py validate --prior` / `gate --prior` (code r2) | 0 / 0 | `{"passed":true,"reasons":[]}` |
+| `git status --porcelain` (Codex 라운드마다) | 0 | Codex가 보고한 `changed_files`와 정확히 일치 |
+| `git commit` | 0 | `2336d23` |
+
+### AC-55 변이 검증 (신규 규칙 13건 전수)
+
+각 항목마다 해당 규칙을 소스에서 무력화 → `__pycache__` 제거 → 전체 스위트 실행 →
+소스 복원 → 백업과 바이트 비교의 순서로 수행했다. **13건 전부 대응 테스트가 검출했다.**
+
+| # | 무력화 대상 | 변이 시 종료 코드 | 검출 |
+|---:|---|---:|---|
+| 1 | R1.5 `open_finding_ids` 커버리지 | 1 (failures=1) | ✅ |
+| 2 | R1.8 prior 최상위 unknown 키 | 1 (failures=1) | ✅ |
+| 3 | R1.2 `resolution_*` 문자열-또는-null | 1 (failures=2) | ✅ |
+| 4 | R1.6 resolved ∩ open 교집합 | 1 (failures=1) | ✅ |
+| 5 | R2.3 미검증 REVISE 트리거 조건 | 1 (failures=4) | ✅ |
+| 6 | R2.4-4 현재-파일 digest 교차 검사 | 1 (failures=2) | ✅ |
+| 7 | R2.5 폐기 2건 상한 | 1 (failures=2) | ✅ |
+| 8 | R2.12 재수행 digest 바인딩 | 1 (failures=3) | ✅ |
+| 9 | R3.3 PASS+미검증 금지 | 1 (failures=2) | ✅ |
+| 10 | R3.2 `verified` boolean 타입 검사 | 1 (failures=1) | ✅ |
+| 11 | R2.8 재수행 기록 초기화 | 1 (failures=2) | ✅ |
+| 12 | R2.4b 내부 prior 조립 | 1 (errors=2) | ✅ |
+| 13 | R2.13 (아티팩트, 라운드) 일치 술어 | 1 (errors=1) | ✅ |
+
+복원 후 전체 스위트 재실행: `Ran 229 tests` / `OK`, exit 0.
+
+### 검증 카테고리
+
+| 카테고리 | 상태 | 근거 |
+|---|---|---|
+| 표적 테스트 | **실행됨** | 파일별 46 / 131 / 52, exit 0 |
+| 전체 스위트 | **실행됨** | 229개, exit 0 |
+| 타입 체크 | `not configured` | `tsconfig.json`·`package.json`·`Makefile`·`justfile` 부재 확인 |
+| 린트 | `not configured` | `.pre-commit-config.yaml`에 gitleaks 훅만 존재(시크릿 스캔 전용) |
+| 빌드 | `not configured` | `package.json`·`.github/workflows` 부재 확인 |
+| E2E / 수동 검증 | **해당 없음** | 스킬 번들 성격상 E2E 대상이 없다. 그 역할은 위 변이 검증 13건과 범위·불변 명령(AC-56·57·58)이 수행했다. 통과로 기록하지 않는다 |
+
+### 배포
+
+**배포를 실행하지 않았다.** 사용자가 승인 게이트 이후 명시적으로 배포하지 않기로
+결정했다. 배포본 `~/.claude/skills/quality-goal/SKILL.md`는 `version: 3.0.0`으로 남아
+있으며, 이 실행 전체에서 경로 인자를 생략한 형태의 배포 명령을 실행한 적이 없다.
+배포를 하게 되면 변경 파일 경로를 명시한 `chezmoi apply <경로>...` 형태만 사용한다.
+
+**AC-59 판정과 그 기준 자체의 결함(기록).** 이 절의 초판은 배포 부재를 서술하면서
+경로 인자가 없는 형태의 명령을 문장 안에 그대로 적었고, 그 **서술 문장 자체가**
+AC-59의 판정 정규식에 걸려 기준이 실패했다. 문구만 고쳐 통과시켰고, 코드나 배포
+사실은 바뀌지 않았다. 근본 원인은 AC-59의 판정 명령이 보고서 **전체**를 grep하도록
+쓰였다는 점이다 — 기준의 의도는 "실행한 명령 표의 배포 행"만 보는 것이므로 명령이
+의도보다 넓다. 후속 이슈 후보로 남긴다.
+
+**터미널 전이 이후 보고서 편집(기록).** 위 문구 수정은 상태가 `COMPLETED`로 전이된
+뒤에 이루어졌다. `set_artifact`는 report에 digest를 바인딩하지 않으므로
+(`artifact_digests`의 report 슬롯은 `record_review`만 채운다) 기록된 어떤 digest도
+무효화되지 않았고, `artifacts.report` 경로도 그대로다. 그럼에도 순서가 이상적이지
+않았음을 밝힌다 — AC-59를 판정한 뒤에 전이했어야 했다.
+
+## Remaining advisory findings
+
+### Spec (라운드 2, Low 2건 — 통과한 Spec을 동결하고 Plan이 권위 서술을 제공했다)
+
+| ID | 요약 | 처리 |
+|---|---|---|
+| SPEC-006 | Spec의 Test strategy 절이 변이 대상을 "신규 규칙 11개"로 적었으나 AC-55는 13개를 열거한다 | Plan이 13개를 권위로 확정했고, 실제로 13건을 수행했다. **해소** |
+| SPEC-007 | Decision 인용 2건 오류 — R4.3의 `(D9)`는 D11이어야 하고, Non-goal 1의 `(D3)`는 D4여야 한다. 라운드 2 개정에서 D3을 끼워넣으며 밀린 번호를 본문에서 고치지 않은 결과다 | Plan이 두 곳 모두 정정해 권위 서술을 제공했다. Spec 본문의 인용은 그대로 남아 있다. **문서상 잔여** |
+
+### Code (라운드 2, Low 3건)
+
+| ID | 요약 | 영향 | 처리 |
+|---|---|---|---|
+| CODE-005 | 바인딩 검사를 `record_review`에서 앞으로 옮긴 결과, `record_review`와 `record_review_unverified`가 바인딩 대 한도 검사의 상대 순서가 달라졌다. `rounds[artifact] == ROUND_LIMITS[artifact]`이고 그 라운드에 다른 digest의 낡은 재수행 기록이 있는 입력에서 전자는 exit 2, 후자는 exit 3을 낸다 | Spec R2.4가 "같은 입력이 두 서브커맨드에서 다른 종료 코드를 내지 않게 한다"고 요구한 것과 어긋난다. **CLI로는 도달 불가** — `record_review_unverified`가 한도 초과 라운드에 재수행 기록을 저장하지 않고, `record_review`는 라운드를 기록할 때마다 그 키를 비운다. AC-23·26·31은 모두 충족된다 | 아래 "Plan 이탈" 항목에 잔여 발산을 명시해 기록으로 남긴다. 코드는 바꾸지 않는다 |
+| CODE-006 | AC-25의 두 절 중 `--artifact-digest` 생략 거부에 실행 단언이 없다 | 동작 자체는 구성상 보장된다(`required=True` → `_ArgumentParser.error` → `StateError` → exit 2). 실행으로도 확인했다 | **AC-25의 argparse 절은 파서 선언과 1회 실측(exit 2)으로 판정했고 단위 테스트 단언은 없다**고 여기에 기록한다 |
+| CODE-007 | `_prior_open_finding_ids`가 `prior.open_finding_ids`의 중복 항목을 거부한다. 어떤 요구사항도 이 규칙을 요구하지 않았고(R1.4는 `open_findings` 내부, R1.6은 `resolved_finding_ids`) 대응 테스트가 없다 | fail-closed 방향이고 `record_review`가 내부 조립하는 prior는 이미 중복이 걸러진 blocker 목록이라 실질 위험이 없다 | **R1 범위를 넘어선 의도적 fail-closed 추가**로 여기에 기록한다. 코드는 바꾸지 않는다 |
+
+### Plan 이탈 1건 (승인 후, 기록된 이탈)
+
+`record_review`의 재수행 digest 바인딩 검사를 **spec/plan 아티팩트 digest 교차 검사
+앞으로 이동**했다. 승인된 Plan의 T2-2c는 라운드·한도 검사 뒤에 두라고 규정했으나, 그
+위치에서는 등록된 spec/plan 아티팩트의 파일이 그대로인 경우 옛 오류
+(`spec artifact digest mismatch`)가 먼저 발생해 **Spec AC-31의 메시지 보장이 도달
+불가**였다. Spec이 수용 계약이고 Plan의 단계 순서는 수단이므로 Spec을 충족시켰다.
+라운드 일치·한도 검사는 원래 위치에 두어 AC-23·AC-26의 순서와 종료 코드는 불변이고,
+두 검사 모두 `StateError`라 종료 코드 변화도 없다. 이 이탈은 Plan 리뷰가 PLAN-001로
+이미 지적했던 지점이며, Codex 결과의 `plan_deviations`와 검증 JSON의 `plan_deviation`에
+기록되어 있다. **잔여 발산**은 위 CODE-005에 적은 대로이며 CLI로는 도달 불가다.
+
+### Plan 라운드 1이 남긴 advisory (승인 게이트에서 사용자에게 제시함)
+
+PLAN-001(바인딩 검사 위치)은 위 이탈로 해소됐다. PLAN-002(T6의 수행 주체·롤아웃 내
+위치 미지정)는 오케스트레이터가 T6 전체를 커밋 이전에 수행하는 것으로 실행했고 그
+결과가 위 검증 증거다. PLAN-003(행 범위 2건 미세 오차)·PLAN-004(대체 기록 필드 shape
+미열거)는 구현에 영향을 주지 않았다. Plan 라운드 2는 사용하지 않고 예비로 남겼다.
+
+## 이번 실행에서 발현한 quality-goal 스킬 자체의 결함 (실측)
+
+이 실행은 수정 대상인 배포본 v3.0.0으로 돌았다. 우회하지 않고 기록한 관찰이다.
+
+### #37의 재현 — 리뷰어 예산 소진
+
+Spec 리뷰 라운드 1의 첫 리뷰어가 **24턴 한도에서 최종 JSON 없이 종료**했다.
+`record-review-error`로 기록했고 `rounds.spec`은 0으로 유지되어 라운드는 소모되지
+않았다. 다만 이 경로는 계약상 재시도가 1회뿐이며, 재시도도 실패했다면
+`BLOCKED`/`REVIEW_OUTPUT_INVALID`로 종결됐을 것이다. 재시도 프롬프트에 턴 예산을
+명시하고 증거 경로를 우선순위별로 정렬해 넘긴 뒤에는 8~26턴 안에서 모든 리뷰어가
+산출물을 냈다. 이번 수정이 도입한 `record-review-unverified`는 well-formed 미검증
+REVISE를 다루므로 이 사례(출력 자체가 없는 경우)와는 다른 경로이며, 두 경로가 별도
+상태 키로 분리되어 종결 사유가 섞이지 않는다.
+
+### #44의 재현 — 우회를 유지했다
+
+라운드 2 이상에서 배포본 계약(`SKILL.md:256`)이 finding ID만 전달하므로, 계약대로면
+Spec 라운드 2에는 blocker 1건(SPEC-001)의 ID만 갔을 것이고 Medium·Low 4건은 상태의
+`open_finding_ids`가 blocker만 보존하는 탓에 전달 수단이 없었다. 우회로 **이전 라운드
+findings 전문(설명·증거 위치·요구 해소책 + 오케스트레이터의 해소 주장·증거)을 리뷰어
+프롬프트에 직접 포함**했다. 결과: Spec 라운드 2 리뷰어가 5건 전부의 해소를 개별 증거와
+함께 확인했고, 코드 라운드 2 리뷰어도 4건 전부를 확인했다. 계약용 prior 파일은
+`{"open_finding_ids": [...]}`로 최소 유지했다 — 배포본
+`_prior_open_finding_ids`가 unknown 키를 검사하지 않는다는 성질(이번 수정의 R1.8이
+닫는 구멍)에 의존하지 않기 위해서다.
+
+### #38의 재현 — 미검증 표시가 산문뿐이다
+
+모든 리뷰어가 미검증 항목을 `claim` 문자열 안의 산문(`NOT VERIFIED:` 등)으로만
+표시했다. 배포본 스키마의 evidence 항목이 `{claim, location}`뿐이라 구조화된 필드가
+없고 `evaluate_gate`는 evidence를 읽지 않는다. 리뷰어들이 정직해서 규칙이 작동했을
+뿐이며, 이번 수정의 `verified` 필수 필드가 그 상태를 고친다.
+
+### #43은 발현하지 않았다
+
+`record_review`의 자동 터미널 전이는 라운드 한도 소진이나 recurring blocker에서만
+발동한다. 이번 실행은 spec 2/3, plan 1/2, code 2/3으로 모두 한도 이전에 통과했고
+recurring blocker도 없어 자동 전이 경로에 진입하지 않았다. 따라서 보고서 등록 시점이
+사라지는 현상은 관측되지 않았다. **보고서 파일 경로**:
+`docs/development/2026-09-03-quality-goal-review-loop/report.md`.
+
+### 위생 항목
+
+`.claude/quality-state/`는 `.gitignore:25`에 이미 등록되어 있어 런타임 상태가
+`git status`에 노출되지 않는다. 별도 조치가 필요 없다.
+
+변이 검증 중 `__pycache__` 오염이 오판을 만들 수 있어 모든 사이클에
+`PYTHONDONTWRITEBYTECODE=1`과 `__pycache__` 제거를 넣었다. `.gitignore`가
+`__pycache__/`를 덮어 `git status`에 보이지 않는다.
+
+## Final status
+
+- Status: `COMPLETED`
+- Machine-readable reason: 없음 (`status_reason: null`) — 코드 리뷰 라운드 2가 PASS,
+  블로커 0건, Critical/High 0건이고 오케스트레이터의 결정적 체크 4개가 모두 참이며,
+  기록된 검증 워크스페이스 지문이 마지막 통과 코드 리뷰의 아티팩트 digest와 같다
+  (`0d6f8b6f9fca4d5d2d5bce0441856e373fdfd46ce4d687af9ad66179776604f4`).
+
+머지는 수행하지 않았다. 배포도 수행하지 않았다(배포본은 v3.0.0으로 유지).

--- a/docs/development/2026-09-03-quality-goal-review-loop/spec.md
+++ b/docs/development/2026-09-03-quality-goal-review-loop/spec.md
@@ -1,0 +1,1025 @@
+# Quality Goal Specification
+
+- Task ID: 20260903T092537Z-44-37-38-quality-goal-리뷰-루프-결함-3건-수정-라운드-33f2fb89
+- Mode: standard
+- Status: SPEC_REVIEW (round 2)
+- Created: 2026-09-03T09:25:37Z
+- Updated: 2026-09-03T10:05:00Z
+- Source goal: #44 #37 #38 quality-goal 리뷰 루프 결함 3건 수정 — 라운드 2+ prior findings 전문 전달, 미검증 사유 REVISE의 라운드 소모 방지, no-PASS-when-unverified 결정적 게이트 승격
+- Base revision: `5ed7b57387d6a271e8e014091ff8143f488e0d29` (상태 파일의 `base_revision`)
+
+이 Spec은 선행 실행(`docs/development/2026-08-27-quality-goal-review-loop/spec.md`, 952행,
+`NEEDS_REDESIGN`)을 초안으로 재사용한다. 그 실행이 다룬 R6(spec 라운드 한도 2→3)과
+R7(루브릭 라운드 수 단언 강화)은 **이후 v3.0.0으로 이미 출시됐으므로 이번 범위에서
+제외한다**(실측: `scripts/quality_state.py:69`가 `{"spec": 3, "plan": 2, "code": 3}`,
+`references/spec-rubric.md:33`이 `After round 3`, `tests/test_content_contracts.py`의 세
+루브릭 단언이 `re.findall(r"after round (\d+) without a passing gate", lower)` 형태).
+선행 실행의 미해소 findings 중 R6에 종속했던 SPEC-012·SPEC-013·SPEC-015는 함께 소멸했고,
+남은 SPEC-006·SPEC-011은 이 Spec이 D3·D4에서 선반영해 해소한다.
+
+## Problem and context
+
+`quality-goal` 스킬 v3.0.0의 리뷰 루프에 서로 맞물린 결함 3건이 실전 사용에서 드러났다.
+세 결함은 모두 **"리뷰어가 무엇을 검증했는지를 시스템이 알 수 없다"**는 하나의 공백에서
+파생한다.
+
+**#44 — 라운드 2+ 리뷰 계약이 finding ID만 전달한다.**
+`SKILL.md:256`은 라운드 2 이상에서 리뷰어에게 보낼 입력을 "prior open finding IDs"로
+규정한다. 설명 원문·증거 위치·오케스트레이터가 취한 조치가 전달되지 않으므로 리뷰어는
+이전 finding이 해소됐는지 판정할 수 없다. 실측(2026-08-27, 실행
+`20260827T080329Z-28-35-create-worktree-…`): Spec 라운드 2 리뷰어가
+SPEC-005·006·007·008·010을 검증하지 못했고, 자신의 새 findings가 이전 항목의 재진술인지
+배제할 수 없다고 기록했다. 근거는 이슈 #44 본문이 인용하는
+`docs/development/2026-08-27-create-worktree-pr-session/report.md`의 "프로세스 관찰" 절이며,
+그 문서는 해당 실행이 `NEEDS_REDESIGN`으로 끝나 이 저장소에 커밋되지 않았다.
+
+더 나쁜 것은 **오케스트레이터가 보낼 수 있는 정보 자체가 blocker로 한정된다**는 점이다.
+`quality_state.py:649`가 `open_finding_ids[artifact] = list(blockers)`로 blocker만
+보존한다. 위 실측에서 검증되지 못한 5건은 모두 Medium·Low여서 애초에 blocker가 아니었고
+따라서 상태에서 완전히 사라졌다.
+
+**#37 — 미검증 사유 REVISE가 리뷰 라운드를 소모한다.**
+`dot_claude/agents/quality-reviewer.md:61`은 "적용 가능한 게이트 조건이나 루브릭 항목을
+검증하지 못했다면 verdict는 PASS가 아니어야 한다"를 요구한다. 그 규칙 자체는 필요했다 —
+없으면 턴 소진된 리뷰가 PASS로 게이트를 통과한다(fail-open). 그런데 **오케스트레이터 측
+처리가 없다.** `SKILL.md:283-288`은 malformed 출력과 리뷰어 기동 실패만 다룬다. 실체가
+결함이 아니라 "X를 검증하지 못했다"뿐인 well-formed REVISE는 스키마 검증을 통과해
+`record-review`로 기록되고(`quality_state.py:645-649`) 라운드를 1개 소모한다. 반복되면
+`ROUND_LIMITS`(`quality_state.py:69`)에 걸려 `NEEDS_REDESIGN`으로 종결되고, **리뷰어 역량
+실패가 코드·설계 실패로 귀속된다.**
+
+**#38 — no-PASS-when-unverified가 지시문 준수에만 의존한다.**
+`evaluate_gate`(`validate_review.py:292-334`)는 `verdict`·`blockers`·severity·checks만 읽고
+`evidence` 배열을 전혀 보지 않는다. `review.schema.json`의 evidence 항목은
+`{claim, location}`뿐이라(`review.schema.json:46-66`) "이건 검증 못 했다"를 기계가 알 수단이 없다. code
+아티팩트는 점수 임계도 없으므로(`validate_review.py:309` — spec/plan만 임계 적용) 게이트의
+실질은 리뷰어 verdict + 오케스트레이터 자기 체크 4개가 전부다. 리뷰어가 미검증 조건을
+"적용되지 않음"으로 재분류하면 검증과 게이트를 모두 통과한다.
+
+**이 결함들은 계속 발현하고 있다.** 선행 실행(2026-08-27)의 라운드 1·2 리뷰어 모두
+미검증 항목을 `claim` 문자열 안의 산문 `"NOT VERIFIED:"`로만 표시했다 — 구조화된 필드가
+없어서다(#38의 직접 실증). 같은 실행에서 라운드 2 prior를 계약대로 보내면 라운드 1의
+10건 중 blocker 1건의 ID만 전달됐을 것이므로, 오케스트레이터가 구조화된 prior를 파일로
+만들어 프롬프트에 직접 넣는 우회를 썼고 그 결과 라운드 2 리뷰어가 10건 중 9건의 해소를
+개별 증거와 함께 확인했다(#44 수정의 효과 실증). **이번 실행도 같은 우회를 유지한다** —
+수정이 배포되기 전까지 배포본 v3.0.0의 계약은 그대로이기 때문이다.
+
+세 결함은 상호작용한다. #44가 중복 findings를 만들고, #37이 그 중복으로 라운드를
+소모하며, #38이 그 어느 것도 결정적으로 잡지 못한다.
+
+## Goals
+
+1. 라운드 2 이상의 리뷰어가 이전 라운드 open findings의 **설명 원문·증거 위치·요구
+   해소책과 오케스트레이터의 해소 주장**을 받아 각 항목의 해소 여부를 판정할 수 있다.
+   blocker가 아닌 open finding도 전달 가능하다.
+2. 실체가 결함이 아니라 미검증 사유뿐인 REVISE가 리뷰 라운드를 소모하지 않고, 범위를
+   좁힌 재수행으로 처리되며, 반복 시 리뷰어 역량 한계를 명시한 `BLOCKED`로 종결된다.
+   이 경로가 남용될 수 없도록 결정적으로 강제되고, 폐기된 리뷰의 advisory findings와
+   두 번의 시도 기록이 모두 상태 파일에 남는다.
+3. "미검증 조건이 있으면 PASS 금지"가 지시문이 아니라 `validate_review.py`의 결정적
+   규칙이 된다. 미검증 표시가 스키마에 구조화되어 기계가 읽을 수 있다.
+4. 위 변경이 스킬 번들의 게이트 규칙과 상태 머신 계약을 바꾸므로 SemVer MAJOR
+   (3.0.0 → 4.0.0)로 표기되고, 기존 201개 결정적 테스트가 계속 통과하며 신규 회귀
+   테스트가 각 변경의 비공허성을 증명한다.
+
+## Non-goals
+
+1. **#43(record-review의 자동 터미널 전이)은 고치지 않는다.** 같은 파일
+   (`quality_state.py`)을 만지지만 `record_review`의 자동 전이 블록
+   (`recurring = next(...)`부터 `REVIEW_LIMIT_EXHAUSTED`까지)은 base revision과 바이트
+   동일해야 한다(AC-57). 다만 이 작업이 새로 추가하는 실패 경로는 같은 결함을 재생산하지
+   않아야 한다(D3).
+2. **인자 없는 `chezmoi apply`를 실행하지 않는다.** 다른 세션이 배포본
+   `~/.claude/skills/quality-goal`을 실행 중일 수 있다. 배포는 변경 파일 경로를 지정한
+   `chezmoi apply <path>...`만 허용하며, 사용자 승인 후 최종 단계에서만 수행한다.
+3. **커밋 후 머지하지 않는다.** PR 생성까지만 수행하고 URL을 보고한다.
+4. **`evaluate_gate`에 `unverified_evidence_present` 게이트 사유를 추가하지 않는다**
+   (D2 — 검증 단계에서 이미 거부되므로 도달 불가 코드가 된다).
+5. **리뷰어 프롬프트 전달 내용 자체의 기계 검증은 하지 않는다.** 서브에이전트 프롬프트는
+   외부에서 검사할 수 없다. 결정적 강제는 `--prior` 파일 형태와 검증 규칙에 둔다(D5).
+6. **상태 파일 `schema_version`을 올리지 않는다.** 추가되는 상태 키는 관용적 읽기
+   (`state.get(...)`)로 접근하므로 기존 상태 파일이 계속 로드된다.
+7. **`ROUND_LIMITS` 값을 바꾸지 않는다.** spec 3·plan 2·code 3은 불변이다. plan 한도
+   상향은 별건(#60 OPEN)이다.
+8. **루브릭 파일을 변경하지 않는다.** `spec-rubric.md`·`plan-rubric.md`·`code-rubric.md`
+   는 전부 불변이다.
+9. **`SKILL.md`의 라운드 수 서술과 코드의 드리프트 검출 강화(#57)는 넣지 않는다.**
+   이번 실행 시작 시 서술과 `ROUND_LIMITS`가 일치함을 확인했으므로 조치 대상이 없다.
+10. **#49·#50·#51·#55·#58·#59·#61은 범위 밖이다.** 이 작업은 #44·#37·#38만 다룬다.
+11. **변경 파일 allow-list.** 변경은 `dot_claude/skills/quality-goal/`,
+    `dot_claude/agents/quality-reviewer.md`, `docs/` **세 경로 아래로만** 허용한다.
+    `.gitignore`, 다른 스킬, chezmoi 소스의 다른 파일은 건드리지 않는다.
+12. **리뷰어에게 오케스트레이터 checks JSON을 공급하지 않는다**(D10).
+13. **`review.schema.json`에 `$id`·`version` 필드를 도입하지 않는다.** 이 스키마는 로컬
+    `validate_review.py` 전용이고 소비자가 번들 내부뿐이라 별도 스키마 버전 축이 필요
+    없다. 번들 SemVer(R4.1)가 그 역할을 한다.
+
+## Requirements
+
+### R1. #44 — `--prior` 입력 확장 (구조화된 이전 라운드 findings)
+
+- **R1.1** `validate_review.py`의 prior 입력이 기존 필수 필드 `open_finding_ids`
+  (문자열 배열) 외에 선택 필드 `open_findings`(객체 배열)와
+  `resolved_finding_ids`(문자열 배열)를 받는다.
+- **R1.2** `open_findings`의 각 항목은 다음 7개 필드를 모두 가진다:
+  `id`, `severity`, `description`, `evidence_location`, `required_resolution`,
+  `resolution_claim`, `resolution_evidence`.
+  - 앞 5개는 **비어 있지 않은 문자열**이어야 한다. 공백만인 문자열도 거부한다.
+  - `severity`는 `Critical|High|Medium|Low` 중 하나여야 한다.
+  - `resolution_claim`과 `resolution_evidence`는 **문자열 또는 `null`**이다. `null`은
+    "해소 주장이 없다"는 유효한 값이다. 그 밖의 타입(정수·불리언·배열·객체)은 거부한다.
+- **R1.3** `open_findings`의 각 항목에 위 7개 외의 키가 있으면 검증 오류다(기존
+  payload·finding·evidence의 unknown-key 처리와 동일한 fail-closed 방향).
+- **R1.4** `open_findings`의 `id`는 중복될 수 없다.
+- **R1.5** `open_findings`가 존재하면 `open_finding_ids`의 모든 ID가 `open_findings`에
+  나타나야 한다(커버리지). **역방향은 요구하지 않는다** — blocker가 아닌 open
+  finding(Medium·Low)도 전달하는 것이 이 요구사항의 목적이므로 `open_findings`는
+  상위집합일 수 있다(D6).
+- **R1.6** `resolved_finding_ids`가 존재하면 **문자열 배열**이어야 하고, **중복이 없어야
+  하며**, `open_finding_ids`와 **교집합이 없어야 한다**.
+- **R1.7** 위 확장은 하위 호환이어야 한다. `{"open_finding_ids": []}`만 담은 기존 형태와,
+  `record_review`가 내부적으로 만드는 `{"open_finding_ids": [...]}`
+  (`quality_state.py:607`)가 계속 유효해야 한다.
+- **R1.8** prior 객체의 **최상위 unknown 키는 검증 오류**다. 현재
+  `_prior_open_finding_ids`(`validate_review.py:70-93`)는 unknown-key 검사를 하지 않으므로
+  `open_finding`·`openFindings` 같은 오타가 구조화된 prior 검증을 **조용히 전부
+  무력화**하고 검증은 valid를 반환한다 — 리뷰어는 ID만 받는 #44 상태로 되돌아간다.
+  오류 메시지는 문제된 키 이름을 포함한다.
+- **R1.9** `SKILL.md`의 Review invocation contract가 라운드 2 이상에서 리뷰어에게 보내는
+  입력을 "prior open finding IDs"에서 **"각 open finding의 ID·심각도·설명·증거 위치·요구
+  해소책과 오케스트레이터의 해소 주장·해소 증거"**로 확장한다. 해소가 확인된 항목은 ID만
+  `resolved_finding_ids`로 전달한다(리뷰어 컨텍스트 비용 절충 — 이슈 #44 "수정 방향").
+- **R1.10** `SKILL.md`가 그 구조화된 prior의 출처를 지시한다: 상태의
+  `reviews[artifact][*].path`에 기록된 이전 라운드 리뷰 JSON에서 findings를 읽고, 거기에
+  오케스트레이터 자신의 해소 주장을 더해 조립한다. blocker만 남기는 `open_finding_ids`에
+  의존하지 않는다.
+- **R1.11** `quality-reviewer.md`가 라운드 2 이상에서 전달받은 각 open finding의 해소
+  여부를 판정하고 그 판정을 `evidence`에 기록하도록 계약을 갱신한다. 새 finding이
+  전달받은 open finding의 재진술이면 기존 ID를 재사용하고 새 ID를 만들지 않는다.
+
+### R2. #37 — 미검증 사유 REVISE의 라운드 비소모 재수행
+
+- **R2.1** `SKILL.md`가 **미검증 사유 REVISE**를 기계 판정 가능한 조건으로 정의한다:
+  `verdict == "REVISE"` **이고** `blockers == []` **이고** `evidence`에
+  `verified == false` 항목이 1개 이상 있다.
+- **R2.2** 그 조건을 만족하는 리뷰는 `record-review`로 기록하지 않는다. 대신
+  `quality_state.py`의 신규 서브커맨드 `record-review-unverified`로 시도를 기록하고,
+  **같은 라운드 번호로** 새 quality-reviewer를 기동한다. 라운드는 소모되지 않는다.
+  재수행 입력은 기존 계약 입력에 다음 두 가지를 추가한 것이다:
+  - 미검증으로 표시된 각 조건을 해소할 **증거 경로**(이슈 #37이 요구하는 "범위를 좁힌 입력");
+  - 폐기되는 리뷰의 **비-blocking findings 전문**(R2.11).
+- **R2.3** `record-review-unverified`는 전달된 리뷰가 R2.1 조건을 실제로 만족하는지 스스로
+  검증한다. 만족하지 않으면 `StateError`로 거부한다(exit 2). 실체 있는 REVISE를 무료
+  재수행으로 세탁할 수 없어야 한다.
+- **R2.4** `record-review-unverified`의 전제 조건을 **명시적으로 열거하고 평가 순서를
+  고정한다.** 순서는 `record_review`(`quality_state.py:561-664`)와 동일하게 맞춰, 같은
+  입력이 두 서브커맨드에서 다른 종료 코드를 내지 않게 한다. 먼저 만나는 실패가 종료 코드를
+  결정한다:
+  1. `--artifact-digest`가 소문자 SHA-256 hexdigest 형식이다. **필수 인자다.** 위반 시
+     `StateError`(exit 2).
+  2. `--review` 경로가 JSON 객체로 로드된다. 위반 시 `StateError`(exit 2).
+  3. 리뷰의 `artifact`가 알려진 값이고 그에 대응하는 리뷰 스테이지가 현재 스테이지다.
+     위반 시 `StateError`(exit 2).
+  4. spec·plan 아티팩트인 경우, 등록된 아티팩트 파일의 현재 digest가 `--artifact-digest`와
+     일치한다(`record_review`의 `quality_state.py:580-586`과 동일한 교차 검사). code
+     아티팩트는 `record_review`와 같이 이 비교를 하지 않는다(공급값이 워크스페이스
+     지문이므로). 위반 시 `StateError`(exit 2).
+  5. `round == rounds[artifact] + 1`(아직 기록되지 않은 라운드). 위반 시
+     `StateError`(exit 2). **라운드 일치 검사가 한도 검사보다 먼저다** —
+     `record_review`의 `quality_state.py:591-598`과 같은 순서이므로, 라운드가 불일치이면서 동시에 한도를
+     초과하는 입력은 exit 2를 낸다.
+  6. `round`가 `ROUND_LIMITS[artifact]`를 초과하면 `TransitionError`(exit 3)다.
+  7. 리뷰 payload가 `validate_review` 스키마 검증을 통과한다. 위반 시 `StateError`
+     (exit 2) — malformed 응답은 무료 재수행이 아니라 기존 `record-review-error` 경로로
+     가야 한다.
+  8. R2.1의 트리거 조건을 만족한다(R2.3). 위반 시 `StateError`(exit 2).
+  9. R2.5의 재수행 회계와 R2.12의 digest 바인딩을 통과한다.
+- **R2.4b** **`validate_review` 호출 시 prior를 내부적으로 조립한다.**
+  `validate_review`는 `round >= 2`이고 prior가 `None`이면 무조건
+  `"prior is required for round >= 2"` 오류를 낸다(`validate_review.py:270-273`). 따라서
+  R2.4-7의 검증 호출은 `record_review`(`quality_state.py:599-607`)와 **동일하게**
+  `round >= 2`일 때 상태에서 `{"open_finding_ids": list(state["open_finding_ids"][artifact])}`
+  를 만들어 넘긴다. **`record-review-unverified`에 `--prior` 인자를 추가하지 않는다** —
+  구조화된 prior는 리뷰어 프롬프트로 가는 입력이지 상태 기록 경로의 입력이 아니며
+  (D5), CLI에 인자를 늘리면 `record_review`와 검증 입력이 갈라진다. 이 규칙이 없으면
+  라운드 2 이상의 미검증 REVISE가 전부 exit 2로 거부되어 #37이 만들려는 경로 자체가
+  도달 불가가 된다.
+- **R2.5** **재수행 상한은 (아티팩트, 라운드)당 폐기 리뷰 2건이다** — 즉 무료 재수행은
+  정확히 1회다.
+  - 1번째 호출: exit 0, `attempts = 1`, `exhausted = false`. 오케스트레이터는 같은
+    라운드로 리뷰어를 재기동한다.
+  - 2번째 호출: **exit 0**, `attempts = 2`, `exhausted = true`, 두 번째 폐기 리뷰 경로가
+    `discarded_reviews`에 append된다. 재기동하지 않는다.
+  - 3번째 호출: `TransitionError`(exit 3)로 거부되고 오류 메시지가
+    `REVIEWER_UNVERIFIED_PERSISTS`를 명시한다. 상태는 불변이다.
+  2번째 호출을 성공으로 두는 이유는 D3에 기록한다 — 실패로 두면 `_mutating_result`가
+  예외 경로에서 상태를 저장하지 않아(`quality_state.py:1144-1156`, `ApprovalMismatchError`
+  만 예외적으로 저장) 두 번째 시도가 상태에 남지 않는다.
+- **R2.6** `record-review-unverified`는 **스스로 터미널 상태로 전이하지 않는다.**
+  `exhausted == true`를 본 오케스트레이터가 보고서를 렌더링·등록한 뒤 명시적으로
+  `transition --to BLOCKED --reason REVIEWER_UNVERIFIED_PERSISTS:<artifact>`를 호출한다.
+- **R2.7** 시도 기록은 상태의 신규 키 `review_unverified_retry`에 저장한다:
+  `{artifact, round, attempts, exhausted, artifact_digest, unverified_claims,
+  discarded_reviews}`.
+  - `attempts`는 정수 1 또는 2다. `exhausted`는 불리언이며 `attempts >= 2`와 동치다.
+  - `artifact_digest`는 첫 호출이 수용한 digest다(R2.12).
+  - `unverified_claims`는 폐기된 각 리뷰에서 `verified == false`였던 evidence 항목의
+    `claim` 문자열 목록이며 시도마다 append된다.
+  - `discarded_reviews`는 폐기된 리뷰 JSON의 **경로 목록**이며 시도마다 append된다.
+    `record-review`를 건너뛰므로 `reviews[artifact]`에 항목이 추가되지 않아, 이 필드가
+    없으면 `REVIEWER_UNVERIFIED_PERSISTS` 종결 시 상태 파일이 폐기된 리뷰를 전혀 가리키지
+    못한다 — `SKILL.md`가 상태 파일을 권위 기록으로 선언하는 것과 모순된다.
+- **R2.8** `review_unverified_retry`는 `record_review`가 해당 아티팩트의 라운드를 정상
+  기록할 때 `None`으로 초기화된다(`review_validation_retry`와 동일한 수명).
+- **R2.9** `SKILL.md`가 R2.1~R2.6의 정책과 `BLOCKED` 종결 사유를 명시하고, 그 종결이
+  코드·설계 실패가 아니라 리뷰어 역량 한계임을 기록하도록 지시한다.
+- **R2.10** `quality-reviewer.md`가 미검증 조건을 알릴 때 `verified == false` evidence
+  항목을 사용하도록 계약을 갱신한다(R3와 연결).
+- **R2.11** 폐기되는 리뷰의 **비-blocking findings는 유실되지 않는다.** R2.1의 트리거가
+  `blockers == []`이므로 advisory findings(Medium·Low)만으로 정당화된 REVISE도 이 경로를
+  탄다. `SKILL.md`가 재수행 입력에 그 findings 전문을 담도록 지시하고, 라운드 2 이상이면
+  추가로 prior의 `open_findings`에 포함하도록 지시한다(R1.5의 상위집합 허용이 이를
+  가능하게 한다).
+- **R2.12** **재수행 중 아티팩트·워크스페이스 개정을 결정적으로 차단한다.** 첫
+  `record-review-unverified` 호출이 수용한 `--artifact-digest`를
+  `review_unverified_retry.artifact_digest`에 저장하고, **같은 (아티팩트, 라운드)에 대한
+  이후의 `record-review-unverified`와 `record-review`가 동일한 digest를 제시하지 않으면
+  거부한다**(`StateError`, exit 2). 그 결과 재수행 중 개정은 어느 쪽으로도 통과하지
+  못한다 — 개정 후 옛 digest를 제시하면 spec·plan은 R2.4-4의 현재-파일 교차 검사에
+  걸리고, 새 digest를 제시하면 이 바인딩 검사에 걸린다. code 아티팩트는 digest가
+  워크스페이스 지문이므로 이 바인딩만으로 개정이 차단된다. 개정이 정당하면 다음 라운드로
+  넘어가야 하며, 그 경로는 `record-review`가 정상 라운드를 기록한 뒤 열린다(R2.8).
+- **R2.13** **`review_unverified_retry`의 일치 술어와 불일치 시 동작을 고정한다.**
+  저장된 기록이 들어오는 호출과 "같은 시도"인지는 **`artifact`와 `round`가 모두 같을
+  때에만** 성립한다(형제 함수 `record_review_validation_failure`의
+  `quality_state.py:687-691` 가드와 동일한 술어).
+  - **일치할 때**: `attempts`를 누적하고(R2.5), R2.12의 digest 바인딩을 적용한다.
+  - **불일치할 때**(`artifact`가 다르거나 `round`가 다름): 저장된 기록은 **낡은 것으로
+    보고 통째로 대체한다** — 새 `{artifact, round, attempts: 1, exhausted: false,
+    artifact_digest: <이번 호출의 digest>, unverified_claims: [...],
+    discarded_reviews: [...]}`로 초기화하고 exit 0으로 성공한다. 오류가 아니다.
+  - **`record_review`의 R2.12 바인딩 검사도 같은 술어를 쓴다**: 저장된 기록의
+    `artifact`가 이번 리뷰의 artifact와 같고 `round`가 `rounds[artifact] + 1`과 같을
+    때에만 digest 일치를 요구하고, 그 밖에는 검사를 건너뛴다. 이 조항이 없으면 이전
+    라운드에 남은 낡은 기록이 정당한 `record-review`를 영구히 차단한다.
+  - `record_review` 성공 시의 `None` 초기화(R2.8)는 이 술어와 무관하게 항상 수행한다 —
+    라운드가 기록되면 그 아티팩트의 재수행 회계는 어느 라운드의 것이든 의미를 잃는다.
+
+### R3. #38 — no-PASS-when-unverified의 결정적 승격
+
+- **R3.1** `review.schema.json`의 evidence 항목에 `verified`(boolean)를 추가하고 **필수
+  필드**로 만든다. `additionalProperties: false`는 유지한다.
+- **R3.2** `validate_review.py`의 `EVIDENCE_FIELDS`에 `"verified"`를 추가한다. 단 현재
+  `EVIDENCE_FIELDS`는 세 개의 루프를 동시에 구동한다 — 필수 키 검사(`:245`), unknown 키
+  검사(`:248`), **비어 있지 않은 문자열 검사**(`:251`). 세 번째 루프를 그대로 두면 boolean
+  `verified`가 항상 검증 오류가 된다. 따라서:
+  - 필수 키 검사와 unknown 키 검사는 `EVIDENCE_FIELDS` 전체를 대상으로 한다.
+  - 비어 있지 않은 문자열 검사는 **문자열 타입 필드에만** 적용한다. 이를 위해
+    `EVIDENCE_STRING_FIELDS = ("claim", "location")` 상수를 도입한다.
+  - `verified`는 별도로 **boolean 타입 검사**를 받는다. 문자열 `"false"`나 정수 `0`은
+    거부한다(`isinstance(x, bool)` 판정).
+- **R3.3** `verdict == "PASS"`이면서 `verified == false`인 evidence 항목이 1개 이상 있으면
+  **검증 오류**다. 오류 메시지는 미검증 항목이 존재함을 명시한다.
+- **R3.4** `verdict != "PASS"`인 리뷰의 미검증 evidence는 오류가 아니다(#37이 요구하는
+  정상 신호다).
+- **R3.5** `SchemaDriftTests`가 계속 성립해야 한다 — 스키마의 evidence 필수 필드 집합과
+  Python 상수 `EVIDENCE_FIELDS`가 일치해야 한다. 그 테스트의 `minLength` 루프는
+  `("claim", "location")`을 하드코딩하므로(`test_validate_review.py:384`) boolean 필드
+  추가와 충돌하지 않는다.
+- **R3.6** `quality-reviewer.md`가 모든 evidence 항목에 `verified`를 채우고, `false`일 때
+  그 이유를 `claim`에 적도록 계약을 갱신한다. BLOCKED payload의 단일 evidence 항목도 같은
+  규칙을 따른다.
+- **R3.7** `record_review`는 `validate_review`를 이미 호출하므로
+  (`quality_state.py:609-613`) R3.3이 상태 기록 경로에도 자동 적용된다. 별도 코드 추가
+  없이 이 성질이 성립함을 테스트로 고정한다.
+
+### R4. 버전·문서 요구사항
+
+- **R4.1** `SKILL.md` frontmatter의 `version`을 `3.0.0` → `4.0.0`으로 바꾼다
+  (`docs/quality-goal-maintenance.md`의 "게이트 규칙이나 상태 머신 계약 변경: MAJOR").
+- **R4.2** `test_content_contracts.py`의 frontmatter 고정 기대값을 `4.0.0`으로 갱신한다.
+  frontmatter 키 집합은 바뀌지 않는다.
+- **R4.3** `docs/quality-goal-maintenance.md`의 "추적 중인 후속 작업" 목록을 갱신한다.
+  **현재 목록은 `#36`, `#37`, `#38`, `#39` 4개이며 나머지 열린 quality-goal 이슈는 전혀
+  들어 있지 않다**(실측). 조치는 (a) 이번에 해소되는 `#37`·`#38`을 제거하고, (b) 손으로
+  유지하는 열거를 영구 최신으로 만들 수 없다는 사실을 인정해 **권위 목록이 GitHub의 열린
+  이슈임을 명시하는 한 줄과 조회 명령을 추가**하며, (c) 이 작업이 의도적으로 손대지 않는
+  인접 결함 `#43`을 명시적으로 남긴다. `#44`는 해소되므로 항목을 만들지 않는다(D9).
+- **R4.4** 이 작업의 산출물 문서 3개(`spec.md`, `plan.md`, `report.md`)를
+  `docs/development/2026-09-03-quality-goal-review-loop/`에 만든다.
+
+### R5. 호환성·회귀 요구사항
+
+- **R5.1** 기존 201개 테스트가 계속 통과한다. evidence 형태를 고정한 지점은 정확히
+  **4곳**이며(전수 실측: `grep -rn '"claim"' tests/`) 새 필수 필드를 반영해 갱신한다:
+  `tests/fixtures/review-valid-plan.json:9-12`,
+  `tests/fixtures/review-high-finding.json:21-24`,
+  `tests/test_validate_review.py:37-42`의 `valid_review()`,
+  `tests/test_quality_state.py:75-80`의 `valid_review()`.
+  `tests/fixtures/verification-pass.json`은 **evidence 배열이 없으므로 영향받지 않는다.**
+- **R5.2** `tests/test_quality_state.py:191-215`의 상태 키 집합 고정 테스트에
+  `review_unverified_retry`를 추가한다.
+- **R5.3** `review.schema.json`은 `codex exec --output-schema`에 전달되지 않는다. 실측:
+  `--output-schema` 인자로 쓰이는 유일한 스키마는 `references/model-routing.md`의
+  `codex-result.schema.json`이다. 따라서 OpenAI structured-output 제약(`uniqueItems`·정규식
+  lookaround의 HTTP 400 거부, `docs/development/2026-08-25-quality-goal/deviations.md`
+  D-15에 실측 기록)은 이 스키마 확장에 적용되지 않는다. 그럼에도 이번 확장은
+  `uniqueItems`를 새로 도입하지 않고 정규식을 쓰지 않는다.
+- **R5.4** 각 신규 규칙에 회귀 테스트를 붙인다.
+- **R5.5** 신규 규칙 각각에 **변이 검증**을 수행한다 — 해당 구현을 되돌리면 대응 테스트가
+  실패해야 한다. 대상은 AC-55가 열거하는 목록과 정확히 일치한다.
+- **R5.6** `SKILL.md`는 500행 미만을 유지한다
+  (`test_content_contracts.py:901-904`의 `assertLess(len(text.splitlines()), 500)`).
+  현재 342행이므로 여유는 157행이다.
+
+## Acceptance criteria
+
+각 기준은 명시된 명령의 종료 코드 또는 출력으로 판정한다. `$SK`는
+`dot_claude/skills/quality-goal`, `$V`는 `$SK/scripts/validate_review.py`, `$Q`는
+`$SK/scripts/quality_state.py`, `$BASE`는 `5ed7b57387d6a271e8e014091ff8143f488e0d29`를
+가리킨다. 모든 Python 호출에 `PYTHONDONTWRITEBYTECODE=1`을 붙인다.
+
+### #44 (R1)
+
+- **AC-1** [실행] `open_findings` 7필드를 모두 갖춘 유효한 prior와 라운드 2 리뷰로
+  `python3 $V validate --input <r2> --artifact plan --prior <prior>` → exit 0,
+  `{"valid":true,"errors":[]}`.
+- **AC-2** [실행] `open_findings[0]`에서 7필드 중 하나를 제거하면 exit 2이고 errors에 그
+  필드명이 나타난다. 7필드 각각에 대해 반복한다(`subTest`).
+- **AC-3** [실행] `open_findings[0].severity`를 `"Trivial"`로 바꾸면 exit 2.
+- **AC-4** [실행] `open_findings[0]`에 `extra` 키를 넣으면 exit 2이고 errors에 `'extra'`가
+  나타난다 (R1.3).
+- **AC-5** [실행] `open_findings`에 같은 `id`가 2개면 exit 2 (R1.4).
+- **AC-6** [실행] `open_finding_ids: ["PLAN-001"]`인데 `open_findings`에 `PLAN-001`이
+  없으면 exit 2 (R1.5 커버리지).
+- **AC-7** [실행] `open_finding_ids: ["PLAN-001"]`이고 `open_findings`가
+  `PLAN-001`(blocker) + `PLAN-002`(Medium, 비-blocker)를 담으면 exit 0 — 상위집합 허용
+  (R1.5 역방향 비요구).
+- **AC-8** [실행] `resolved_finding_ids`가 `open_finding_ids`와 ID를 공유하면 exit 2
+  (R1.6 교집합).
+- **AC-9** [실행] `resolved_finding_ids`에 같은 ID가 2개면 exit 2, 원소가 정수면 exit 2
+  (R1.6 중복·타입).
+- **AC-10** [실행] `open_findings[0]`의 앞 5개 문자열 필드 각각을 `""`와 `"   "`로 두면
+  exit 2 (R1.2, `subTest` 10회).
+- **AC-11** [실행] `resolution_claim`·`resolution_evidence`를 `null`로 두면 exit 0이고,
+  정수 `1`로 두면 exit 2 (R1.2 문자열-또는-null).
+- **AC-12** [실행] `{"open_finding_ids": []}`만 담은 prior로 라운드 2 리뷰 검증 → exit 0
+  (R1.7 하위 호환).
+- **AC-13** [실행] `record-review` 라운드 2 경로(내부 prior가 ID만 담는 경로)가 계속
+  성공한다 (R1.7).
+- **AC-14** [실행] prior에 최상위 unknown 키(`open_finding`)를 넣으면 exit 2이고 errors에
+  `'open_finding'`이 나타난다 (R1.8).
+- **AC-15** [문서+테스트] `SKILL.md` 본문이 라운드 2+ 리뷰어 입력으로 open finding의
+  설명·증거 위치·요구 해소책·해소 주장을 보내라고 지시하고, 해소된 항목은 ID만 보낸다고
+  명시하며, `test_content_contracts.py`의 계약 테스트가 이를 단정한다 (R1.9).
+- **AC-16** [문서+테스트] `SKILL.md`가 구조화된 prior를 `reviews[artifact][*].path`의 이전
+  리뷰 JSON에서 조립하라고 지시하고, 계약 테스트가 이를 단정한다 (R1.10).
+- **AC-17** [문서+테스트] `quality-reviewer.md`가 라운드 2+에서 전달받은 각 open finding의
+  해소 여부를 판정해 `evidence`에 기록하고 재진술 시 기존 ID를 재사용하도록 규정하며,
+  계약 테스트가 이를 단정한다 (R1.11).
+
+### #37 (R2)
+
+- **AC-18** [실행] `verdict=REVISE`, `blockers=[]`, `verified:false` evidence 1개를 담은
+  리뷰로 `python3 $Q record-review-unverified --state S --review R --artifact-digest D`
+  → exit 0. 결과 상태의 `review_unverified_retry`가
+  `{artifact, round, attempts: 1, exhausted: false, artifact_digest: D,
+  unverified_claims: [...], discarded_reviews: [R]}`이고 `rounds[artifact]`가
+  **증가하지 않는다** (R2.2, R2.7).
+- **AC-19** [실행] 같은 입력에서 `blockers`가 비어 있지 않으면 exit 2 (R2.3).
+- **AC-20** [실행] 같은 입력에서 모든 evidence의 `verified`가 `true`면 exit 2 (R2.3).
+- **AC-21** [실행] `verdict`가 `PASS` 또는 `BLOCKED`면 exit 2 (R2.3).
+- **AC-22** [실행] 잘못된 스테이지(예: `IMPLEMENTING`)에서 호출하면 exit 2 (R2.4-3).
+- **AC-23** [실행] `round`가 `rounds[artifact] + 1`이 아니면 exit 2다. 아울러 **라운드가
+  불일치이면서 동시에 `ROUND_LIMITS[artifact]`를 초과하는** 리뷰(예: spec에서
+  `rounds.spec = 0`인데 리뷰의 `round`가 `9`)를 넘기면 **exit 2**(exit 3이 아님)이다 —
+  R2.4의 고정된 평가 순서에서 라운드 일치 검사가 한도 검사보다 먼저이기 때문이다
+  (R2.4-5, R2.4-6 순서).
+- **AC-24** [실행] 스키마 위반 리뷰(예: evidence 항목에서 `claim` 제거)를
+  `record-review-unverified`에 넘기면 exit 2이고 상태 파일이 바이트 동일하게 유지된다
+  (R2.4-7).
+- **AC-25** [실행] `--artifact-digest`를 생략하면 argparse가 exit 2로 거부한다. spec
+  아티팩트에서 등록된 파일의 실제 digest와 다른 값을 넘기면 exit 2이고 상태가 불변이다
+  (R2.4-1, R2.4-4).
+- **AC-26** [실행] `rounds[artifact] == ROUND_LIMITS[artifact]`이고 리뷰의 `round`가
+  `rounds[artifact] + 1`(= 한도 + 1)인 입력으로 호출하면 **exit 3**이다 — 라운드 일치
+  검사를 통과한 뒤 한도 검사에 걸리는 유일한 조합이다. 상태는 불변이다 (R2.4-5, R2.4-6).
+- **AC-27** [실행] AC-18 성공 직후 **두 번째** 미검증 리뷰(다른 경로 `R2`)로 같은
+  (아티팩트, 라운드)에 다시 호출하면 **exit 0**이고, 상태의
+  `review_unverified_retry.attempts == 2`, `exhausted == true`,
+  `discarded_reviews == [R, R2]`이며 `unverified_claims`가 두 리뷰의 claim을 모두 담고,
+  `rounds[artifact]`는 여전히 증가하지 않는다 (R2.5, R2.7).
+- **AC-28** [실행] AC-27 직후 **세 번째** 호출은 exit 3이고 stderr가
+  `REVIEWER_UNVERIFIED_PERSISTS`를 담으며 상태 파일이 바이트 동일하게 유지된다 (R2.5).
+- **AC-29** [실행] AC-27·AC-28 이후에도 상태 `stage`는 리뷰 스테이지 그대로이며 터미널이
+  아니다 → 이어서 `set-artifact --kind report`가 exit 0으로 성공하고, 그 다음
+  `transition --to BLOCKED --reason REVIEWER_UNVERIFIED_PERSISTS:spec`이 exit 0이다
+  (R2.6, #43 재생산 방지). 근거: `set_artifact`는 `_require_active`를 호출해 터미널
+  스테이지에서 `TransitionError`를 던진다(`quality_state.py:107-113`, `:286-311`).
+- **AC-30** [실행] AC-18 후 **동일한 digest**를 제시한 정상 리뷰로 `record-review`를
+  호출하면 exit 0이고 결과 상태의 `review_unverified_retry`가 `null`이다 (R2.8).
+- **AC-31** [실행] AC-18 후 **다른 digest**를 제시한 리뷰로 `record-review`를 호출하면
+  exit 2이고 `rounds[artifact]`가 증가하지 않으며 오류 메시지가 재수행 digest 바인딩을
+  명시한다. 같은 상황에서 두 번째 `record-review-unverified`가 다른 digest를 제시해도
+  exit 2다 (R2.12).
+- **AC-32** [실행] AC-31의 spec 시나리오 변형 — 재수행 중 spec 파일을 실제로 개정하고
+  digest를 재계산해 제시하면, `record-review`가 R2.12 바인딩 검사로 exit 2를 낸다. 즉
+  "digest를 다시 계산하면 통과한다"는 우회가 닫혀 있다 (R2.12).
+- **AC-33** [문서+테스트] `SKILL.md`가 R2.1의 세 조건(REVISE·blockers 비어 있음·미검증
+  evidence 존재)과 "라운드를 소모하지 않는다"·"같은 라운드로 재기동"·"폐기 리뷰 2건
+  상한(무료 재수행 1회)"·"`exhausted`를 본 뒤 보고서 등록 → `BLOCKED`
+  `REVIEWER_UNVERIFIED_PERSISTS`"를 명시하고, 계약 테스트가 이를 단정한다 (R2.9).
+- **AC-34** [문서+테스트] `SKILL.md`가 그 BLOCKED 종결이 리뷰어 역량 한계이며 코드·설계
+  실패가 아님을 기록하도록 지시하고, 계약 테스트가 이를 단정한다 (R2.9).
+- **AC-35** [문서+테스트] `SKILL.md`가 재수행 입력에 (a) 미검증 조건을 해소할 증거 경로,
+  (b) 폐기 리뷰의 비-blocking findings 전문을 담고 라운드 2+에서는 prior의
+  `open_findings`에도 포함하도록 지시하며, (c) 재수행 중 아티팩트·워크스페이스를 개정하지
+  않는다고 명시하고, 계약 테스트가 이를 단정한다 (R2.2, R2.11, R2.12).
+- **AC-36** [문서+테스트] `quality-reviewer.md`가 미검증 조건을 `verified: false`
+  evidence로 표시하도록 규정하고, 계약 테스트가 이를 단정한다 (R2.10).
+- **AC-61** [실행] **라운드 2 이상의 미검증 REVISE가 실제로 통한다.** spec 라운드 1을
+  blocker `SPEC-A` 1건과 함께 `record-review`로 기록한 뒤(`rounds.spec = 1`,
+  `open_finding_ids.spec = ["SPEC-A"]`), `round: 2`이고 `verdict=REVISE`,
+  `blockers=[]`, `verified:false` evidence 1건인 리뷰로 `record-review-unverified`를
+  호출하면 **exit 0**이고 `rounds.spec`이 **1로 유지**된다. `--prior`를 넘기지 않았음에도
+  성공해야 하며, 이는 서브커맨드가 R2.4b대로 내부에서 prior를 조립했음을 증명한다
+  (R2.4b).
+- **AC-62** [실행] **`--prior` 인자는 존재하지 않는다.**
+  `python3 $Q record-review-unverified --help` 출력에 `--prior`가 없고, `--prior`를
+  넘기면 argparse가 exit 2로 거부한다 (R2.4b).
+- **AC-63** [실행] **낡은 `review_unverified_retry` 기록이 정당한 호출을 막지 않는다.**
+  이것은 **방어적 가드**다 — R2.8의 초기화 때문에 정상 CLI 흐름만으로는 불일치 기록이
+  거의 남지 않지만, 상태 파일은 외부에서 편집될 수 있고 미래의 새 경로가 그런 기록을
+  남길 수 있으므로 동작이 정의되어 있어야 한다. 테스트는 상태 dict에 낡은 기록을
+  **직접 심어** 판정한다. `{artifact: "spec", round: 1, attempts: 2,
+  exhausted: true, artifact_digest: X, …}`를 심고 `rounds.spec = 1`인 상태에서:
+  (a) `round: 2` 미검증 리뷰로 `record-review-unverified`를 호출하면 **exit 0**이고
+  기록이 `{artifact: "spec", round: 2, attempts: 1, exhausted: false,
+  artifact_digest: <이번 digest>, …}`로 **대체**된다(누적이 아니다);
+  (b) 대신 `round: 2` 정상 리뷰로 `record-review`를 `X`와 **다른** digest와 함께
+  호출하면 **exit 0**이다 — 저장된 기록의 `round`가 `rounds.spec + 1`과 다르므로
+  R2.12 바인딩 검사를 건너뛴다;
+  (c) 그 성공 후 `review_unverified_retry`가 `null`이다 (R2.13, R2.8).
+
+### #38 (R3)
+
+- **AC-37** [실행] `review.schema.json`을 로드해 evidence 항목의 `required`가
+  `{claim, location, verified}`(집합 동등)이고 `properties.verified.type == "boolean"`이며
+  `additionalProperties`가 `false`임을 단정 → 성공 (R3.1).
+- **AC-38** [실행] evidence 항목에서 `verified`를 뺀 리뷰 검증 → exit 2, errors에
+  `verified`가 나타난다 (R3.2).
+- **AC-39** [실행] `verified`를 문자열 `"false"` 또는 정수 `0`으로 두면 exit 2 (R3.2).
+- **AC-40** [실행] `verdict=PASS`이고 evidence에 `verified:false`가 1개 있으면 exit 2이고
+  errors가 미검증 항목 존재를 명시한다 (R3.3).
+- **AC-41** [실행] `verdict=REVISE`이고 evidence에 `verified:false`가 있으면 exit 0 (R3.4).
+- **AC-42** [실행] `verified: true`(boolean)가 정상 통과하는 동시에 같은 evidence 항목의
+  `claim`을 `""`로 두면 exit 2다 — 비어 있지 않은 문자열 검사가 문자열 필드에만 적용되고
+  boolean 필드에는 적용되지 않음을 증명한다 (R3.2 `EVIDENCE_STRING_FIELDS`).
+- **AC-43** [실행] `SchemaDriftTests`가 통과한다 — 스키마 evidence 필수 필드 집합 ==
+  `EVIDENCE_FIELDS` (R3.5).
+- **AC-44** [실행] `verdict=PASS` + `verified:false` 리뷰로 `record-review`를 호출하면
+  exit 2로 거부되고 `rounds[artifact]`가 증가하지 않는다 (R3.7).
+- **AC-45** [문서+테스트] `quality-reviewer.md`가 모든 evidence 항목에 `verified`를 채우고
+  `false`일 때 이유를 `claim`에 적도록, BLOCKED payload에도 같은 규칙이 적용되도록
+  규정하며, 계약 테스트가 이를 단정한다 (R3.6).
+
+### 버전·문서 (R4)
+
+- **AC-46** [실행] `SKILL.md` frontmatter의 `version`이 `4.0.0`이다 (R4.1).
+- **AC-47** [실행] `test_content_contracts.py`의 frontmatter 고정 테스트가 통과하고,
+  기대 키 집합이 `{name, version, description, argument-hint, disable-model-invocation,
+  model, effort}` 그대로다 (R4.2).
+- **AC-48** [실행] `docs/quality-goal-maintenance.md`의 "추적 중인 후속 작업" 절이
+  `#37`·`#38`·`#44`를 담지 않고, `#43`을 담으며, GitHub 열린 이슈가 권위 목록임을 밝히는
+  문장과 조회 명령을 담는다 (R4.3).
+- **AC-49** [실행] `docs/development/2026-09-03-quality-goal-review-loop/`에 `spec.md`,
+  `plan.md`, `report.md`가 존재한다 (R4.4).
+
+### 호환성·회귀 (R5)
+
+- **AC-50** [실행] `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s
+  dot_claude/skills/quality-goal/tests -p 'test_*.py'` → exit 0, 실패 0건, 총 테스트 수가
+  **201 초과** (R5.1, R5.4).
+- **AC-51** [실행] evidence 형태를 고정한 **4곳**이 모두 `verified`를 갖는다:
+  `tests/fixtures/review-valid-plan.json`, `tests/fixtures/review-high-finding.json`,
+  `tests/test_validate_review.py`의 `valid_review()`,
+  `tests/test_quality_state.py`의 `valid_review()`.
+  `tests/fixtures/verification-pass.json`은 evidence 배열이 없어 변경 대상이 아니며
+  변경되지 않았음을 확인한다.
+  판정 명령(파이썬 단정): 위 4개 파일을 로드해 각 파일의 evidence 객체가 모두
+  `claim`·`location`·`verified` 세 키를 갖는지 확인한다. 두 fixture는 `json.load` 후
+  `payload["evidence"]`를, 두 헬퍼는 `valid_review()`를 호출해 반환 dict의
+  `["evidence"]`를 본다. 아울러 `git diff $BASE...HEAD --
+  $SK/tests/fixtures/verification-pass.json`이 빈 출력이다.
+  **grep 기반 판정을 쓰지 않는다** — `grep -rn '"claim"' $SK/tests/`는 5행을 내며
+  다섯 번째(`tests/test_validate_review.py:384`)는 `for field in ("claim", "location")`
+  튜플이라 evidence 객체가 아니고, R3.5가 그 줄을 그대로 두라고 요구하므로 결코
+  `verified`를 가질 수 없다 (R5.1).
+- **AC-52** [실행] `tests/test_quality_state.py`의 상태 키 집합 단언에
+  `review_unverified_retry`가 포함되고, `init`이 그 키를 `null`로 만든다 (R5.2).
+- **AC-53** [실행] `grep -rn 'output-schema' $SK` 결과에 `review.schema.json`이 나타나지
+  않는다 (R5.3).
+- **AC-54** [실행] `wc -l $SK/SKILL.md`가 500 미만이다 (R5.6).
+- **AC-55** [실행] **변이 검증을 신규 규칙 전수에 수행한다.** 대상 목록(R5.5와 동일):
+  (1) R1.5 커버리지, (2) R1.8 prior 최상위 unknown 키, (3) R1.2 문자열-또는-null,
+  (4) R1.6 교집합, (5) R2.3 트리거 조건 검사, (6) R2.4-4 digest 현재-파일 교차 검사,
+  (7) R2.5 폐기 2건 상한, (8) R2.12 재수행 digest 바인딩, (9) R3.3 PASS 금지,
+  (10) R3.2 boolean 타입 검사, (11) R2.8 `review_unverified_retry` 초기화,
+  (12) R2.4b 내부 prior 조립(제거하면 AC-61이 실패해야 한다),
+  (13) R2.13 (아티팩트, 라운드) 일치 술어(항상 일치로 바꾸면 AC-63이 실패해야 한다).
+  각 항목을 소스에서 무력화하면 대응 테스트가 실패해야 하고, 확인 후 즉시 복원한다.
+  복원 후 `git diff --stat`이 해당 파일에 대해 변이 이전 상태와 동일해야 하며,
+  `find $SK -name '__pycache__' -prune -exec rm -rf {} +`로 바이트코드 캐시를 지운 뒤
+  전체 스위트를 재실행한다.
+- **AC-56** [실행] **변경 파일 allow-list 준수.** 최종 커밋 후 PR 생성 전에
+  `git diff --name-only $BASE...HEAD`를 실행하고 그 출력을
+  `grep -vE '^(dot_claude/skills/quality-goal/|dot_claude/agents/quality-reviewer\.md$|docs/)'`
+  로 거른 결과가 **비어 있다**(grep exit 1) (Non-goal 11).
+- **AC-57** [실행] **#43 블록 불변.** 최종 커밋 후 다음이 exit 0이다 — 행 번호가 아니라
+  내용으로 앵커한다:
+  ```
+  git show $BASE:dot_claude/skills/quality-goal/scripts/quality_state.py \
+    | sed -n '/^    recurring = next/,/REVIEW_LIMIT_EXHAUSTED/p' > /tmp/base-block.txt
+  sed -n '/^    recurring = next/,/REVIEW_LIMIT_EXHAUSTED/p' \
+    dot_claude/skills/quality-goal/scripts/quality_state.py > /tmp/head-block.txt
+  diff /tmp/base-block.txt /tmp/head-block.txt
+  ```
+  (Non-goal 1).
+- **AC-58** [실행] **`ROUND_LIMITS`·루브릭 불변.**
+  `git diff $BASE...HEAD -- $SK/references/` 가 빈 출력이고,
+  `grep -n 'ROUND_LIMITS = ' $SK/scripts/quality_state.py`가
+  `{"spec": 3, "plan": 2, "code": 3}`를 낸다 (Non-goal 7, 8).
+- **AC-59** [실행] **배포 규율.** `report.md`의 "실행한 명령" 표가 이 실행의 배포 기록
+  전체이며, 그 표에서 `chezmoi apply`를 담은 모든 행이 정규식
+  `chezmoi apply (?:--[^\s]+ )*[^\s]+` 에 매치한다 — 즉 경로 인자가 최소 1개 있다.
+  판정 명령: `grep -n 'chezmoi apply' docs/development/2026-09-03-quality-goal-review-loop/report.md`
+  의 각 행이 위 정규식을 만족하는지 확인하고, 인자 없이 끝나는 `chezmoi apply` 행이
+  0건임을 단정한다.
+  **한계를 명시한다**: 세션의 실제 명령 이력은 어떤 명령으로도 감사할 수 없으므로 이
+  기준은 보고서라는 산출물만 판정한다. 배포 자체를 하지 않은 경우 매치 행이 0건이며
+  이 역시 통과다 (Non-goal 2).
+- **AC-60** [실행] **추적표 전수성.** 아래 "요구사항 전수 대응 확인" 표가 이 Spec이
+  정의한 모든 요구사항을 하나 이상의 AC에 대응시킨다. 판정 명령(파이썬 단정):
+  `spec.md`에서 `^- \*\*(R\d+\.\d+[a-z]?)\*\*` 로 요구사항 ID 집합을 뽑고, 추적표에서
+  `^\| (R\d+\.\d+[a-z]?) \|` 로 행 ID 집합을 뽑아 **두 집합이 같은지** 단정한다. 이어서
+  표의 각 행이 `AC-\d+` 를 최소 1개 인용하고 그 번호가 모두 실제 정의된 AC인지
+  단정한다. 이 기준은 AC 쪽 전수성(모든 AC가 표에 인용됨)은 요구하지 않는다 —
+  Non-goal을 판정하는 AC-56~AC-59와 이 AC-60 자신은 요구사항 행을 갖지 않기
+  때문이다.
+
+## 요구사항 전수 대응 확인
+
+| 요구사항 | 대응 AC |
+|---|---|
+| R1.1 | AC-1 |
+| R1.2 | AC-2, AC-3, AC-10, AC-11, AC-55(3) |
+| R1.3 | AC-4 |
+| R1.4 | AC-5 |
+| R1.5 | AC-6, AC-7, AC-55(1) |
+| R1.6 | AC-8, AC-9, AC-55(4) |
+| R1.7 | AC-12, AC-13 |
+| R1.8 | AC-14, AC-55(2) |
+| R1.9 | AC-15 |
+| R1.10 | AC-16 |
+| R1.11 | AC-17 |
+| R2.1 | AC-18, AC-19, AC-20, AC-21, AC-33 |
+| R2.2 | AC-18, AC-35 |
+| R2.3 | AC-19, AC-20, AC-21, AC-55(5) |
+| R2.4 | AC-22, AC-23, AC-24, AC-25, AC-26, AC-55(6) |
+| R2.4b | AC-61, AC-62, AC-55(12) |
+| R2.5 | AC-27, AC-28, AC-55(7) |
+| R2.6 | AC-29 |
+| R2.7 | AC-18, AC-27 |
+| R2.8 | AC-30, AC-63, AC-55(11) |
+| R2.9 | AC-33, AC-34 |
+| R2.10 | AC-36 |
+| R2.11 | AC-35, AC-7 |
+| R2.12 | AC-31, AC-32, AC-35, AC-55(8) |
+| R2.13 | AC-63, AC-55(13) |
+| R3.1 | AC-37 |
+| R3.2 | AC-38, AC-39, AC-42, AC-55(10) |
+| R3.3 | AC-40, AC-55(9) |
+| R3.4 | AC-41 |
+| R3.5 | AC-43 |
+| R3.6 | AC-45 |
+| R3.7 | AC-44 |
+| R4.1 | AC-46 |
+| R4.2 | AC-47 |
+| R4.3 | AC-48 |
+| R4.4 | AC-49 |
+| R5.1 | AC-50, AC-51 |
+| R5.2 | AC-52 |
+| R5.3 | AC-53 |
+| R5.4 | AC-50 |
+| R5.5 | AC-55 |
+| R5.6 | AC-54 |
+
+모든 요구사항이 하나 이상의 실행 가능한 AC에 대응한다. 부정 요구사항(Non-goal)은
+AC-56·AC-57·AC-58·AC-59가 결정적으로 판정한다.
+
+## Architecture
+
+세 항목은 **하나의 데이터 흐름**을 공유한다.
+
+```
+quality-reviewer (fresh, unnamed one-shot task)
+   │ review JSON (review.schema.json)
+   ▼
+validate_review.py validate --prior ──┐
+   │                                   │ (#44) prior 입력 형태 + 최상위 unknown 키
+   │ (#38) evidence[].verified 규칙     │
+   ▼                                   │
+validate_review.py gate                │  ← 변경 없음 (Non-goal 4)
+   │                                   │
+   ▼                                   │
+quality_state.py record-review ────────┘  (라운드 소모, 한도 = ROUND_LIMITS, 불변)
+   또는
+quality_state.py record-review-unverified (#37, 라운드 비소모, 폐기 2건 상한)
+```
+
+**#38이 기반이다.** `evidence[].verified`가 "무엇을 검증하지 못했는가"를 기계가 읽을 수
+있는 유일한 신호이며 #37의 트리거 조건(R2.1)이 그 신호를 소비한다. 스키마 확장이 없으면
+#37은 지시문 수준에 머문다. 반대로 **구현 순서는 사용자가 지정한 #44 → #37 → #38**이며
+이는 파일 충돌 최소화 순서다 — #44가 prior 검증 함수를, #37이 상태 머신을, #38이
+스키마·evidence 검증을 각각 만져 세 지점이 겹치지 않는다. #37의 트리거 조건이 #38의 필드를
+참조하는 역방향 의존이 있으므로 #37 단계에서는 그 필드를 전제로 코드를 쓰고, #38 단계에서
+필드를 실제로 도입한 뒤 전체 스위트로 결합을 검증한다(D8).
+
+### 책임 경계
+
+| 컴포넌트 | 이 작업에서의 책임 | 바뀌지 않는 것 |
+|---|---|---|
+| `review.schema.json` | evidence에 `verified` 필수 필드 추가 | 나머지 필드·enum·`additionalProperties: false`·기존 `uniqueItems` 2곳 |
+| `validate_review.py` | prior 확장 검증과 최상위 unknown 키(R1), `verified` 검증·PASS 금지·문자열 필드 분리(R3) | `evaluate_gate`의 게이트 사유 목록, 점수 임계, `REQUIRED_CHECKS` |
+| `quality_state.py` | `record-review-unverified` 서브커맨드(내부 prior 조립 포함) + `review_unverified_retry` 상태 키 + `record_review`의 재수행 digest 바인딩 검사·초기화 | `record_review`의 자동 전이 블록(#43), `ALLOWED_TRANSITIONS`, `TERMINAL_STATES`, `ROUND_LIMITS` |
+| `SKILL.md` | 리뷰 호출 계약 확장(R1.9·R1.10), 미검증 REVISE 정책 신설(R2.9·R2.11·R2.12), version 4.0.0 | 스테이지 표, 라운드 한도 서술, 승인 게이트, Codex 계약, 안전 규칙 |
+| `quality-reviewer.md` | prior 소비 규칙(R1.11), `verified` 기입 규칙(R3.6) | frontmatter, 도구 목록, BLOCKED payload 8필드 규칙 |
+| `references/*.md` | 없음 | 전부 (Non-goal 8) |
+| `tests/` | 기존 evidence 형태·상태 키 단언 갱신 + 신규 회귀 테스트 | 기존 테스트의 의도 |
+| `docs/quality-goal-maintenance.md` | 추적 목록 갱신(R4.3) | 나머지 절 |
+
+### 왜 `record-review-unverified`가 자체 서브커맨드인가
+
+기존 `record_review_validation_failure`(`quality_state.py:666`)가 malformed 출력에 대해
+같은 모양(1회 재시도 → 종결)을 이미 구현한다. 그러나 두 경로는 의미가 다르다. malformed은
+**스키마 위반**이고 미검증 REVISE는 **스키마를 통과한 유효한 리뷰**다. 같은 상태 키를
+공유하면 `REVIEW_OUTPUT_INVALID`와 `REVIEWER_UNVERIFIED_PERSISTS`가 섞여 종결 사유가
+부정확해지고, 이는 #37이 고치려는 바로 그 문제(잘못된 종결 사유 귀속)를 재생산한다.
+
+## Interfaces and data flow
+
+### I1. prior 파일 (확장 후)
+
+```json
+{
+  "open_finding_ids": ["PLAN-001"],
+  "open_findings": [
+    {
+      "id": "PLAN-001",
+      "severity": "High",
+      "description": "AC-7이 어떤 구현 태스크에도 매핑되지 않았다.",
+      "evidence_location": "plan.md#Traceability",
+      "required_resolution": "AC-7을 태스크와 검증 명령에 매핑하라.",
+      "resolution_claim": "Task 3에 AC-7 매핑과 검증 명령을 추가했다.",
+      "resolution_evidence": "plan.md#Task-3"
+    },
+    {
+      "id": "PLAN-004",
+      "severity": "Medium",
+      "description": "롤백 절차의 실패 처리가 미정의다.",
+      "evidence_location": "plan.md#Rollback",
+      "required_resolution": "롤백 실패 시 행동을 규정하라.",
+      "resolution_claim": null,
+      "resolution_evidence": null
+    }
+  ],
+  "resolved_finding_ids": ["PLAN-002", "PLAN-003"]
+}
+```
+
+- `open_finding_ids`: 필수. 기존 의미 그대로(상태가 보존하는 직전 라운드 blocker).
+- `open_findings`: 선택. 존재하면 `open_finding_ids`를 커버해야 하고 상위집합일 수 있다.
+- `resolved_finding_ids`: 선택. `open_finding_ids`와 교집합 없음, 중복 없음.
+- **최상위 unknown 키는 오류다**(R1.8).
+- 하위 호환: 두 선택 필드가 없으면 기존 동작과 동일.
+
+### I2. `review.schema.json` evidence 항목 (확장 후)
+
+```json
+{ "claim": "…", "location": "…", "verified": true }
+```
+
+`verified == false`는 그 claim을 확인하지 못했다는 뜻이며 이유는 `claim` 안에 적는다.
+`claim`·`location`은 비어 있지 않은 문자열, `verified`는 boolean이다.
+
+### I3. `record-review-unverified` CLI
+
+```
+python3 quality_state.py record-review-unverified \
+  --state <state.json> --review <review.json> --artifact-digest <sha256>
+```
+
+인자는 정확히 이 셋이다. **`--prior`는 없다** — `round >= 2`의 스키마 검증에 필요한
+prior는 `record_review`와 동일하게 상태에서 내부 조립된다(R2.4b, AC-62).
+
+아래 표는 **R2.4의 고정된 평가 순서대로** 읽는다. 먼저 만나는 실패가 종료 코드를
+결정하므로, 여러 조건을 동시에 위반하는 입력의 결과는 표의 위쪽 행이 이긴다.
+
+| # | 조건 | 종료 코드 | 효과 |
+|---:|---|---|---|
+| — | `--artifact-digest` 누락 | 2 | argparse 거부, 상태 불변 |
+| 1 | digest 형식 오류 | 2 | 상태 불변 |
+| 2 | `--review`가 JSON 객체로 로드되지 않음 | 2 | 상태 불변 |
+| 3 | 알 수 없는 artifact / 스테이지 불일치 | 2 | 상태 불변 |
+| 4 | spec·plan 등록 아티팩트의 현재 파일 digest 불일치 | 2 | 상태 불변 |
+| 5 | `round != rounds[artifact] + 1` | 2 | 상태 불변 (한도 초과를 겸해도 이 행이 이긴다) |
+| 6 | `round > ROUND_LIMITS[artifact]` | 3 | 상태 불변 |
+| 7 | 스키마 검증 실패 (`round >= 2`면 내부 조립 prior 포함) | 2 | 상태 불변 |
+| 8 | R2.1 불만족(blockers 있음 / 미검증 evidence 없음 / verdict 부적합) | 2 | 상태 불변 |
+| 9a | 재수행 바인딩 불일치 — 같은 (아티팩트, 라운드)인데 digest가 저장값과 다름 | 2 | 상태 불변 |
+| 9b | 같은 (아티팩트, 라운드) 3번째 시도 | 3 | 상태 불변, stderr에 `REVIEWER_UNVERIFIED_PERSISTS` |
+| ✓ | 전부 통과, 저장 기록이 없거나 (아티팩트, 라운드)가 불일치 | 0 | 기록을 `attempts=1`, `exhausted=false`, `artifact_digest=<이번 값>`로 **새로 쓴다**(R2.13) |
+| ✓ | 전부 통과, 같은 (아티팩트, 라운드) 2번째 시도 | 0 | `attempts=2`, `exhausted=true`, `discarded_reviews`·`unverified_claims` append. 라운드 불변. 재기동하지 않는다 |
+
+성공 시 갱신된 상태 JSON을 stdout에 출력하며, 어느 경우에도 `rounds[artifact]`는 바뀌지
+않는다.
+
+종료 코드는 기존 매핑(`StateError` → 2, `TransitionError` → 3)을 그대로 따른다
+(`quality_state.py:1264-1270`). 예외 경로에서 상태가 저장되지 않는 성질은
+`_mutating_result`(`:1144-1156`)에서 온다 — `ApprovalMismatchError`만 예외적으로 저장한다.
+
+### I4. 상태 키 (추가)
+
+```json
+"review_unverified_retry": null
+```
+
+또는
+
+```json
+"review_unverified_retry": {
+  "artifact": "code",
+  "round": 2,
+  "attempts": 2,
+  "exhausted": true,
+  "artifact_digest": "b1946ac9…",
+  "unverified_claims": [
+    "결정적 명령을 재실행하지 못했다 — Read/Grep/Glob만 보유.",
+    "재수행 후에도 같은 조건을 확인하지 못했다."
+  ],
+  "discarded_reviews": [
+    ".claude/quality-state/<task-id>/code-review-round2-a.json",
+    ".claude/quality-state/<task-id>/code-review-round2-b.json"
+  ]
+}
+```
+
+`record_review` 성공 시 `None`으로 초기화된다(R2.8).
+
+### I5. 오케스트레이터 흐름 (라운드 2 이상)
+
+1. 이전 라운드 리뷰 JSON들을 `reviews[artifact][*].path`에서 읽는다. 폐기된 리뷰가 있으면
+   `review_unverified_retry.discarded_reviews`도 읽는다.
+2. open findings(blocker + 미해소 advisory + 폐기 리뷰의 비-blocking findings)를 골라 I1의
+   `open_findings`를 조립하고 각 항목에 자신의 해소 주장·증거를 붙인다. 해소 확인된 ID는
+   `resolved_finding_ids`로 보낸다.
+3. 그 내용을 리뷰어 프롬프트에 넣어 **이름 없는** 새 quality-reviewer를 기동한다.
+4. 반환 JSON을 태스크 상태 디렉터리에 저장한다.
+5. R2.1 조건이면 → `record-review-unverified`.
+   - `exhausted == false`면 (3)으로 같은 라운드 재기동. 이때 미검증 조건의 증거 경로와
+     폐기 리뷰의 비-blocking findings를 추가하고, 아티팩트·워크스페이스는 개정하지 않는다.
+   - `exhausted == true`면 보고서를 렌더링·등록한 뒤
+     `transition --to BLOCKED --reason REVIEWER_UNVERIFIED_PERSISTS:<artifact>`.
+6. 아니면 → `validate`(I1 prior 전달) → `gate` → `record-review`(재수행이 있었다면 동일
+   digest 제시).
+
+## Failure behavior
+
+| 실패 | 발현 | 처리 |
+|---|---|---|
+| prior의 `open_findings` 형태 위반 | `validate` exit 2, errors에 경로·필드명 | 오케스트레이터가 prior 조립을 고쳐 재실행. 리뷰어 응답 문제가 아니므로 `record-review-error` 대상이 아니다 |
+| prior 최상위 unknown 키 | `validate` exit 2, errors에 키 이름 | 같음. 오타로 구조화 prior가 조용히 무력화되는 것을 막는다 |
+| `open_finding_ids` 커버리지 위반 | `validate` exit 2 | 같음. 상태가 보존한 blocker를 prior에서 빠뜨렸다는 신호 |
+| 리뷰에 `verified` 누락 또는 비-boolean | `validate` exit 2 / `record-review` exit 2 | 리뷰어 응답 계약 위반 → `record-review-error` → 1회 재시도 → `BLOCKED`/`REVIEW_OUTPUT_INVALID`(기존 경로) |
+| PASS + 미검증 evidence | `validate` exit 2, `record-review` exit 2 | 같음. 라운드는 소모되지 않는다 |
+| 미검증 사유 REVISE 1회 | `record-review-unverified` exit 0, `exhausted=false` | 같은 라운드로 범위 좁힌 재기동. 라운드 불변. 폐기 리뷰 경로와 비-blocking findings 보존 |
+| 미검증 사유 REVISE 2회 | `record-review-unverified` exit 0, `exhausted=true` | 재기동 없음. 보고서 렌더링·등록 후 `transition --to BLOCKED --reason REVIEWER_UNVERIFIED_PERSISTS:<artifact>`. 리뷰어 역량 한계로 기록 |
+| 3회째 호출(오케스트레이터가 `exhausted`를 무시) | `record-review-unverified` exit 3 | 결정적 상한. 상태 불변이며 stderr가 종결 사유를 명시한다 |
+| 라운드 2+ 미검증 REVISE인데 prior 미조립 | `record-review-unverified` exit 2, errors에 `prior is required for round >= 2` | 구현 결함이다. R2.4b가 내부 조립을 의무화하므로 이 오류가 나오면 서브커맨드가 잘못 구현된 것이다 |
+| 낡은 `review_unverified_retry` 기록이 남아 있음 | 없음 | (아티팩트, 라운드) 불일치이므로 R2.13에 따라 새 기록으로 대체되고 `record_review`의 바인딩 검사는 건너뛴다 |
+| 실체 있는 REVISE를 재수행으로 세탁 시도 | `record-review-unverified` exit 2 | 정상 `record-review` 경로로 되돌린다 |
+| 재수행 중 아티팩트·워크스페이스 개정 | `record-review-unverified`/`record-review` exit 2 (바인딩 또는 현재-파일 digest 불일치) | 개정을 되돌린다. 개정이 정당하면 재수행을 포기하고 정상 라운드로 기록한 뒤 다음 라운드에서 다룬다 |
+| 신규 테스트가 기존 201개를 깨뜨림 | `unittest` 실패 | 원인이 fixture 형태면 갱신(R5.1), 원인이 계약 모순이면 되돌리고 Spec 개정 |
+| 기존 상태 파일에 `review_unverified_retry` 없음 | 없음 | `state.get(...)`으로 관용적 읽기. `schema_version`은 1 유지 |
+| 변이 검증 후 `__pycache__` 오염으로 오판 | 복원했는데도 같은 테스트가 실패 | `find $SK -name '__pycache__' -prune -exec rm -rf {} +` 후 재실행. `.gitignore`가 `__pycache__/`를 덮어 `git status`에 안 보인다 |
+
+**롤백.** 커밋 단위 `git revert` 또는 `git branch -D 44-fix/quality-goal-review-loop`.
+배포를 이미 했다면 `git revert` 후 같은 파일 경로로 `chezmoi apply <path>...`를 다시
+실행한다. 파괴적 작업·마이그레이션·외부 상태 변경이 없다.
+
+## Security and risk
+
+- **시크릿 없음.** 변경 파일은 Markdown 지침·JSON 스키마·Python 검증기·테스트다.
+  자격증명을 읽거나 쓰지 않는다. Non-goal 11의 allow-list가 `.gitignore` 자체를 변경
+  대상에서 제외한다.
+- **신뢰 경계.** 리뷰어 출력은 신뢰하지 않는 입력으로 계속 취급한다. 이번 변경은 그
+  불신을 **강화**한다(#38: PASS 주장을 evidence와 교차 검증). prior 입력은 오케스트레이터가
+  만드는 내부 데이터이나, 형태 검증과 최상위 unknown 키 거부(R1.8)를 붙여 조립 오류를
+  조용히 넘기지 않는다.
+- **최대 위험 — fail-open 도입.** `record-review-unverified`가 라운드를 소모하지 않으므로
+  잘못 설계하면 무한 재수행이 된다. 완화: (a) 폐기 리뷰 2건 상한을 상태에 기록해 결정적
+  강제하고 3회째는 `TransitionError`로 거부(R2.5), (b) 트리거 조건을 서브커맨드가 스스로
+  검사해 세탁을 차단(R2.3), (c) 재수행 digest 바인딩으로 개정 차단(R2.12).
+- **두 번째 위험 — #43 재생산.** 새 실패 경로가 스스로 터미널 전이하면 보고서 등록 시점이
+  다시 사라진다. 완화: R2.6이 자동 전이를 금지하고 AC-29가 보고서 등록과 명시적 전이
+  가능성을 실증한다.
+- **세 번째 위험 — advisory finding 유실.** R2.1의 트리거가 `blockers == []`이므로
+  advisory findings만으로 정당화된 REVISE도 폐기 경로를 탄다. 완화: R2.7의
+  `discarded_reviews`와 R2.11의 재수행 입력 승계.
+- **네 번째 위험 — `verified` 필수화의 파급.** 기존 fixture·헬퍼가 evidence 형태를
+  고정한다. 완화: R5.1이 정확히 4곳을 전수 실측으로 열거하고 AC-50·AC-51이 판정한다.
+  필수 대신 선택 필드로 두는 대안은 fail-open이므로 기각한다(D1).
+- **다섯 번째 위험 — 배포본과의 동시 사용.** 이 실행 자체가 배포된 v3.0.0으로 돌고 다른
+  세션도 같은 배포본을 쓸 수 있다. 소스 변경은 배포 전까지 이번 실행에 적용되지 않는다.
+  완화: 인자 없는 `chezmoi apply` 금지(Non-goal 2), 배포는 변경 파일 경로를 명시한
+  `chezmoi apply <path>...`로만 하고 사용자 승인 후 최종 단계에서 수행하며, AC-59가
+  이를 판정한다. 배포 시점에 다른 세션이 실행 중이면 그 세션의 다음 리뷰 라운드부터 새
+  계약이 적용되므로, 배포 여부와 시점은 사용자 결정 사항으로 보고서에 남긴다.
+- **여섯 번째 위험 — 이번 실행에서 #44가 그대로 재현된다.** 배포본 v3.0.0의 리뷰 계약이
+  라운드 2+에 finding ID만 보내도록 규정하므로, 이번 실행은 선행 실행과 같은 우회를
+  유지한다 — 이전 라운드 리뷰 JSON 전문과 구조화된 prior를 리뷰 컨텍스트에 직접 포함한다.
+  이 우회는 보고서에 기록한다.
+- **프로덕션 변경 없음.** 이 워크플로는 프로덕션 자원을 변경하지 않는다. `git push`는
+  브랜치 push와 PR 생성으로 한정되며 머지하지 않는다.
+
+## Test strategy
+
+### 결정적 명령 (단일 기준선)
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover \
+  -s dot_claude/skills/quality-goal/tests -p 'test_*.py'
+```
+
+현재 기준선: **201개 통과**(2026-09-03 실측, exit 0). 정적 교차 확인: 세 테스트 파일의
+`def test_` 개수 합이 201(`test_content_contracts.py` 50 + `test_quality_state.py` 112 +
+`test_validate_review.py` 39). 완료 시 이 값을 초과하며 실패 0건.
+
+### 테스트 배치
+
+| 파일 | 추가·수정 |
+|---|---|
+| `tests/test_validate_review.py` | prior 확장 수용·거부(AC-1~AC-14), `verified` 검증(AC-38·39·42), PASS 금지(AC-40)·REVISE 허용(AC-41), `SchemaDriftTests` evidence 필수 필드(AC-37·43), `valid_review()` 헬퍼 갱신 |
+| `tests/test_quality_state.py` | `record-review-unverified` 수용·거부 경로(AC-18~AC-32), 상태 키 집합(AC-52), `record-review`의 PASS+미검증 거부(AC-44), 재수행 digest 바인딩(AC-31·32), `valid_review()` 헬퍼 갱신 |
+| `tests/test_content_contracts.py` | frontmatter version 4.0.0(AC-47), SKILL.md 계약(AC-15·16·33·34·35), 리뷰어 계약(AC-17·36·45), SKILL.md 행 수(AC-54) |
+| `tests/fixtures/*.json` | 두 리뷰 fixture의 evidence에 `verified` 추가(AC-51). `verification-pass.json`은 불변 |
+
+### 보조 검증 (테스트 외)
+
+- 스키마 JSON 파싱: `python3 -m json.tool $SK/schemas/review.schema.json`.
+- 문법: `python3 -m py_compile` 두 스크립트.
+- **범위 확인은 base revision 기준으로 한다** — `git diff --name-only $BASE...HEAD`
+  (AC-56)와 `git show $BASE:… | sed -n …` 블록 비교(AC-57). 작업 트리 대비 명령
+  (`git status --porcelain`, 인자 없는 `git diff`)은 커밋 후 공허해지므로 범위 기준으로
+  쓰지 않는다.
+- 불변 확인: `git diff $BASE...HEAD -- $SK/references/`(AC-58).
+- 변이 검증(AC-55): 신규 규칙 11개를 각각 임시로 무력화해 대응 테스트가 실패함을
+  관찰하고 즉시 복원한다. 각 사이클 전후로 `__pycache__`를 제거한다.
+
+### 검증 카테고리 (저장소 실측)
+
+이 저장소에는 `package.json`·`Makefile`·`justfile`·`.github/workflows`가 없다. 타입
+체크·린트·빌드는 `not configured`로 기록한다(`.pre-commit-config.yaml`은 gitleaks 시크릿
+스캔 전용). E2E는 스킬 번들 성격상 해당 없으며, 대신 위 보조 검증과 변이 검증이 그
+역할을 한다.
+
+## Decisions
+
+**D1 — `verified`를 evidence의 필수 필드로 만든다(선택 필드 기각).**
+선택 필드로 두고 "없으면 검증됨"으로 해석하면, 새 계약을 무시하는 리뷰어가 기존 fail-open
+동작을 그대로 얻는다 — #38이 고치려는 결함이 그대로 남는다. 필수화하면 누락이 검증 오류가
+되어 기존 malformed 경로(1회 재시도 → BLOCKED)로 fail-closed하게 흘러간다. 비용은 두 리뷰
+fixture와 두 헬퍼(총 4곳, R5.1) 갱신이며 SemVer MAJOR가 이미 예정되어 있으므로 파괴적
+변경이 허용된다.
+
+**D2 — #38의 강제를 `validate_review`(검증)에 두고 `evaluate_gate`(게이트)에 두지 않는다.**
+검증 오류로 두면 `record-review`가 리뷰를 아예 기록하지 않으므로 **라운드가 소모되지
+않는다**. 게이트 실패로 두면 리뷰가 먼저 기록되어(라운드 소모) 게이트가 실패한다 — 즉
+리뷰어의 계약 위반 비용을 라운드로 지불하게 되고, 이는 #37이 없애려는 바로 그 현상이다.
+또한 `evaluate_gate`는 `validate_review`를 먼저 호출해 오류 시 예외를 던지므로
+(`validate_review.py:294-296`), 게이트에 별도 사유를 추가하면 도달할 수 없는 코드가 된다
+(Non-goal 4).
+
+**D3 — 두 번째 `record-review-unverified`는 exit 0으로 성공하고 3번째가 exit 3으로
+거부된다(선행 실행 SPEC-006의 해소).**
+선행 Spec은 두 번째 호출을 exit 3 + "상태 불변"으로 규정했는데, 그러면
+`REVIEWER_UNVERIFIED_PERSISTS`를 실제로 유발한 리뷰 JSON이 `discarded_reviews`에 남지
+않고 `attempts`가 2에 도달할 수 없다 — 상태 파일이 권위 기록이라는 `SKILL.md` 선언과
+어긋난다. 형제 함수 `record_review_validation_failure`는 차단 전에 `attempts: 2`를
+기록하지만(`quality_state.py:679-694`) 그 함수는 **스스로 BLOCKED로 전이**하기 때문에 그럴
+수 있다. 우리는 D4(#43 재생산 금지)에 따라 자동 전이를 하지 않으므로 같은 패턴을 쓸 수
+없고, `_mutating_result`는 `ApprovalMismatchError`를 제외한 예외 경로에서 상태를 저장하지
+않는다(`:1144-1156`). 따라서 **성공 응답에 `exhausted: true`를 실어 보내는 것이 두 시도를
+모두 기록하면서 자동 전이를 피하는 유일한 형태**다. 대안으로 검토하고 기각한 것: (a) 새
+예외 타입을 만들어 `_mutating_result`에서 저장 후 재전파 — `ApprovalMismatchError`의
+특수 처리를 복제해 상태 저장 규칙이 둘로 갈라진다, (b) 두 번째 리뷰를 `report.md`에서만
+참조 — 상태 파일이 여전히 불완전하다. fail-open 우려는 3회째 `TransitionError`가 결정적
+상한으로 막는다(AC-28).
+
+**D4 — `record-review-unverified`는 자동 터미널 전이를 하지 않는다.**
+기존 `record_review_validation_failure`는 두 번째 실패에서 스스로 `BLOCKED`로 전이한다.
+그 패턴이 #43의 결함 — 전이 후 `set-artifact --kind report`가 `_require_active`의 터미널
+검사에 막혀 보고서 포인터가 유실된다(`quality_state.py:107-113`, `:286-311`). 새 경로에서
+그 패턴을 복제하면 결함을 확산시키므로 상태만 기록하고 전이는 오케스트레이터에게 맡긴다.
+이는 #43의 권장 수정 방향과 정합하며 #43 자체는 건드리지 않는다(Non-goal 1).
+
+**D5 — `open_findings`는 선택 필드이며 커버리지만 요구한다(필수화 기각).**
+필수화하면 `record_review`가 내부적으로 만드는 prior(`{"open_finding_ids": [...]}`,
+`quality_state.py:607`)가 즉시 무효가 된다. 이를 살리려면 `record_review`가 이전 라운드
+리뷰 파일들을 로드해 구조화된 prior를 조립해야 하는데, (a) 리뷰 파일 부재라는 새 실패
+모드가 생기고, (b) 변경이 `record_review` 내부로 확장되어 #43과 인접한 코드의 위험이
+커진다. 대신 선택 필드 + 커버리지 제약 + 최상위 unknown 키 거부(R1.8)로 두고, "리뷰어에게
+반드시 구조화된 prior를 보낸다"는 요구는 `SKILL.md` 계약과 계약 테스트로 고정한다.
+**한계를 명시한다**: 서브에이전트 프롬프트의 실제 내용은 외부에서 기계 검증할 수 없으므로
+이 지점의 강제는 지시문 수준이다(Non-goal 5).
+
+**D6 — `open_findings`는 `open_finding_ids`의 상위집합일 수 있다.**
+집합 동등을 요구하면 blocker만 전달 가능해지고, #44의 실측 피해자(Medium·Low 5건)를 여전히
+전달할 수 없다. 상태의 `open_finding_ids`가 blocker만 보존하기 때문이다
+(`quality_state.py:649`). 따라서 커버리지만 요구하고 추가 항목을 허용한다. 이 허용이
+R2.11의 폐기 리뷰 findings 승계도 가능하게 한다.
+
+**D7 — #37의 트리거 조건에 `blockers == []`를 넣는다.**
+`verified == false`만으로 트리거하면 실체 있는 blocker를 가진 리뷰도 미검증 항목이 하나
+있으면 무료 재수행을 얻는다. blocker가 있으면 그 라운드는 정당하게 소모되어야 한다.
+반대로 blocker가 없는데 REVISE인 경우, 그 REVISE를 정당화하는 것은 미검증 조건 또는
+Medium·Low findings뿐이며, 전자라면 라운드를 소모할 이유가 없다. 후자가 섞여 있을 수
+있으므로 R2.11이 그 findings를 승계한다.
+
+**D8 — 구현 순서는 #44 → #37 → #38을 유지한다.**
+사용자 지시이며 파일 충돌 최소화 순서다. #37의 트리거 조건이 #38의 `verified` 필드를
+참조하는 역방향 의존이 있으므로, #37 단계에서는 그 필드를 전제로 코드를 쓰고 #38 단계
+직후 전체 스위트로 두 변경의 결합을 검증한다. #37 단계 종료 시점에는 `verified`가 아직
+없어 #37 신규 테스트가 실패할 수 있으며, 이는 예상된 중간 상태다 — 완료 판정은 모든
+단계가 끝난 뒤의 AC-50으로만 한다.
+
+**D9 — 재수행 digest를 상태에 바인딩해 개정을 결정적으로 차단한다(서술 축소 기각).**
+선행 실행 SPEC-011이 지적한 대로, `--artifact-digest`를 **현재** 파일과만 비교하면
+아티팩트를 개정하고 digest를 재계산한 호출자는 검사를 통과한다 — 무개정 보장은 지시문
+수준에 머문다. 대안 (a) "결정적"이라는 서술을 실제 보장 수준으로 축소하는 것은 정직하지만
+#37의 핵심 불변(같은 라운드의 재수행은 같은 대상을 본다)을 기계가 지키지 못하게 남긴다.
+대안 (b) 첫 호출이 수용한 digest를 `review_unverified_retry.artifact_digest`에 저장하고
+같은 (아티팩트, 라운드)의 이후 `record-review-unverified`·`record-review`가 동일 digest를
+요구하게 하면, 개정 후 어떤 digest를 제시해도 거부된다. 비용은 상태 필드 1개와
+`record_review` 진입부의 검사 1개이며, 그 검사는 Non-goal 1이 동결한 자동 전이 블록과
+겹치지 않는다(AC-57이 블록 바이트 동일성을 판정). **(b)를 채택한다.**
+
+**D10 — 리뷰어에게 checks JSON을 공급하지 않는다.**
+선행 실행의 라운드 1 리뷰어가 "오케스트레이터 checks JSON이 공급되지 않아
+`material_decisions_resolved`와 `acceptance_criteria_objective`를 교차 확인할 수 없었다"를
+미검증 사유로 기록했다. 이는 설계상 정확한 관찰이나 계약 위반은 아니다 — `SKILL.md`의 리뷰
+호출 계약이 열거하는 입력에 checks가 없고, checks는 오케스트레이터 자신의 결정적 판정이기
+때문이다. 리뷰어에게 그것을 보내면 리뷰어가 오케스트레이터의 판정을 재확인하는 순환이
+생긴다. 계약을 넓힐지는 별건의 후속 후보로 남긴다(Non-goal 12).
+
+**D11 — `docs/quality-goal-maintenance.md`의 추적 목록을 열거 + 권위 포인터로 바꾼다.**
+현재 목록은 `#36`·`#37`·`#38`·`#39` 4개인데 실제 열린 quality-goal 이슈는 그보다 훨씬
+많다(#43·#44·#49·#50·#51·#55·#57·#58·#59·#60·#61 등, 2026-09-03 `gh issue list` 실측).
+손으로 유지하는 열거는 다음 이슈가 열리는 순간 다시 낡는다. 대안 (a) 이번에 해소되는
+2건만 지우기 — 목록이 여전히 사실과 다르다. 대안 (b) 전체 동기화 — 다음 이슈에서 즉시
+낡는다. **채택: 해소 항목 제거 + 이 작업이 의도적으로 남기는 `#43` 명시 + "권위 목록은
+GitHub 열린 이슈"라는 문장과 조회 명령 추가.** 문서 변경만이라 코드 위험이 없고
+Non-goal 11의 allow-list 안이다.
+
+**D12 — strict-only 블록은 제거한다.**
+이 작업은 standard이며 인증·인가·테넌시, 마이그레이션·백필, 프로덕션 관측성, 고위험 E2E
+경로가 없다. 위협·신뢰 경계와 롤백은 위 "Security and risk"·"Failure behavior"에서
+비-strict 수준으로 다뤘고, 프로덕션 변경 없음도 같은 절에 명시했다.
+
+**D14 — `record-review-unverified`는 prior를 내부 조립하고 `--prior` 인자를 만들지
+않는다(라운드 1 SPEC-001의 해소).**
+`validate_review`가 `round >= 2`에서 prior 부재를 무조건 오류로 만들므로
+(`validate_review.py:270-273`), 서브커맨드가 prior를 공급하지 않으면 라운드 2 이상의
+미검증 REVISE가 전부 exit 2로 거부되고 #37이 만들려는 경로 자체가 도달 불가가 된다.
+대안 (a) `--prior` CLI 인자 추가 — 호출자가 그 파일을 만들어야 하고, `record_review`는
+내부 조립을 쓰므로 같은 리뷰가 두 서브커맨드에서 다른 검증 입력을 받는 분기가 생긴다.
+대안 (b) `round >= 2`일 때 검증을 건너뛰기 — R2.4-7의 fail-closed 방향을 깨고 malformed
+응답이 무료 재수행 경로로 새어 들어온다. **채택: (c) `record_review`
+(`quality_state.py:599-607`)와 바이트 동일한 내부 조립.** 두 경로의 검증 입력이 같아지고
+CLI 표면이 늘지 않는다. 구조화된 prior(R1)는 리뷰어 프롬프트로 가는 입력이지 상태 기록
+경로의 입력이 아니므로(D5) 여기에 들어올 이유가 없다.
+
+**D15 — 전제 조건 평가 순서를 `record_review`와 일치시킨다(라운드 1 SPEC-004의 해소).**
+전제 조건이 exit 2와 exit 3 두 가지로 갈리므로 순서가 정해지지 않으면 라운드 불일치와
+한도 초과를 동시에 만족하는 입력의 종료 코드가 구현자 재량이 된다. 대안 (a) 한도 검사를
+먼저 — 더 "엄격해 보이지만" `record_review`와 반대라 같은 리뷰가 두 서브커맨드에서 다른
+코드를 낸다. **채택: (b) `record_review`의 순서 그대로**(라운드 일치 → 한도,
+`quality_state.py:591-598`). 두 경로의 관측 가능한 동작이 일치하고, AC-23이 그 결과를
+결정적으로 고정한다.
+
+**D13 — 이 실행 자체의 결함 발현을 기록한다.**
+이 실행은 수정 대상인 배포본 v3.0.0으로 돈다. #44는 라운드 2+에서 그대로 재현되며 우회를
+유지한다(Security and risk 여섯 번째 항목). #43은 라운드 한도 소진이나 recurring blocker가
+발생할 때만 발현하며, 발현하면 우회하지 않고 보고서 파일 경로를 최종 보고에 남긴다.
+#38은 리뷰어가 미검증 항목을 산문으로만 표시하는 형태로 관측될 수 있으며, 관측되면
+보고서에 실증으로 기록한다.

--- a/docs/quality-goal-maintenance.md
+++ b/docs/quality-goal-maintenance.md
@@ -41,9 +41,14 @@ PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s dot_claude/skills/qual
 ## 추적 중인 후속 작업
 
 - #36 평가 이관
-- #37 CODE-009
-- #38 CODE-008
 - #39 Codex 모델 리네이밍 대비
+- #43은 이 작업이 의도적으로 손대지 않은 인접 결함이다.
+
+권위 목록은 GitHub의 열린 이슈다. 다음 명령으로 조회한다.
+
+```bash
+gh issue list --state open --search 'quality-goal in:title'
+```
 
 상세 근거는 `docs/development/2026-08-25-quality-goal/deviations.md`(D-1~D-16)와 같은 디렉터리의 `report.md`를 참고한다.
 

--- a/dot_claude/agents/quality-reviewer.md
+++ b/dot_claude/agents/quality-reviewer.md
@@ -18,7 +18,7 @@ The orchestrator supplies in the task prompt:
 - the target artifact path or supplied code diff;
 - the relevant rubric path;
 - repository evidence paths; and
-- prior open finding IDs on rounds 2 and later.
+- structured prior open findings and resolved finding IDs on rounds 2 and later.
 
 For missing artifact, missing rubric, or missing evidence input, return a BLOCKED JSON naming the missing input. Do not guess.
 
@@ -47,7 +47,7 @@ A blocker ID may be listed only when a matching Critical or High finding exists;
 BLOCKED payload therefore uses an empty `blockers` array. In all verdicts,
 `required_next_action` must be null for PASS and non-null for REVISE and BLOCKED.
 
-Round 1 is a full review against every applicable rubric item. On later rounds, use the prior open finding IDs to verify each finding and look for regressions introduced by revisions. Add a new
+Round 1 is a full review against every applicable rubric item. On later rounds, use the supplied prior open finding IDs and details to determine whether each supplied open finding is resolved and record that determination in evidence; reuse its ID when a new finding restates it. Look for regressions introduced by revisions. Add a new
 blocker only when it is Critical or High and its `new_blocker_evidence` is non-empty,
 showing that the issue was newly introduced or could not reasonably have been
 identified earlier.
@@ -59,6 +59,7 @@ not be blockers. Deterministic verification failures are never waivable.
 
 The JSON is the deliverable, so it must be produced as the final output even when not every check could be completed; any check the reviewer could not finish is recorded in `evidence` as explicitly not verified, with the reason. Stopping without emitting the JSON is never acceptable.
 If any applicable gate condition or rubric item could not be verified, the verdict must NOT be `PASS`; return `REVISE` with `required_next_action` naming the unverified condition and what would settle it. `BLOCKED` is not the vehicle for this because the BLOCKED payload rule requires empty `findings`; a condition that does not apply to the artifact is not unverified and does not trigger this rule.
+Every evidence item, including the single BLOCKED-payload item, must include `verified`. Use `verified == false` when a condition was not verified and put the reason in its `claim`; otherwise use `verified == true`.
 
 Never edit or create files. Never change or recommend changing severity to reach a
 target score. Never expose or reveal hidden reasoning. The JSON is the entire output:

--- a/dot_claude/skills/quality-goal/SKILL.md
+++ b/dot_claude/skills/quality-goal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quality-goal
-version: 3.0.0
+version: 4.0.0
 description: Use when the user explicitly requests a quality-gated, documented software change workflow.
 argument-hint: '[--mode=auto|light|standard|strict] <goal>'
 disable-model-invocation: true
@@ -253,7 +253,12 @@ Every review round launches a NEW quality-reviewer agent invocation in a
 fresh context; never resume or continue a prior reviewer context. Send only
 these contract inputs: artifact type, round, target artifact path or
 unified diff, the ABSOLUTE rubric path for that artifact, repository evidence
-paths, and prior open finding IDs on rounds >= 2. For code also send the base
+paths, and structured prior findings on rounds >= 2. Build `open_findings` from
+the prior review JSON at `reviews[artifact][*].path`: send each open finding's
+ID, severity, description, evidence location, required resolution, and the
+orchestrator's resolution claim and resolution evidence. Send confirmed
+resolutions as IDs only in `resolved_finding_ids`; do not depend on
+`open_finding_ids`, which preserves blockers only. For code also send the base
 revision, changed-file list, unified diff, and verification JSON path. For a
 code review, pass the CURRENT WORKSPACE FINGERPRINT from
 quality_state.py fingerprint --project-root ... as --artifact-digest; use the
@@ -279,6 +284,17 @@ validate_review.py gate --input <review> --artifact <artifact> --checks
 <checks>. The checks JSON records the orchestrator's own deterministic
 findings, using the gate-check keys annotated in each rubric. Never ask the
 reviewer to waive a failed deterministic command.
+
+For a well-formed unverified REVISE (`verdict == REVISE`, `blockers == []`, and
+any evidence has `verified == false`), call `record-review-unverified` rather
+than `record-review`. It does not consume a round: relaunch on the same round
+with evidence paths for each unverified condition and the discarded review's
+full non-blocking findings. On round 2+, include those findings in prior
+`open_findings`. Do not revise the artifact or workspace during this retry.
+At most two discarded reviews are allowed (one free retry); after `exhausted`,
+register the report then transition to BLOCKED with
+`REVIEWER_UNVERIFIED_PERSISTS`. Record that outcome as a reviewer capability
+limit, not a code or design failure.
 
 On validation failure, call quality_state.py record-review-error and retry
 once, sending only the validation errors added to the same contract inputs.

--- a/dot_claude/skills/quality-goal/schemas/review.schema.json
+++ b/dot_claude/skills/quality-goal/schemas/review.schema.json
@@ -49,7 +49,7 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["claim", "location"],
+        "required": ["claim", "location", "verified"],
         "properties": {
           "claim": {
             "type": "string",
@@ -58,6 +58,9 @@
           "location": {
             "type": "string",
             "minLength": 1
+          },
+          "verified": {
+            "type": "boolean"
           }
         }
       }

--- a/dot_claude/skills/quality-goal/scripts/quality_state.py
+++ b/dot_claude/skills/quality-goal/scripts/quality_state.py
@@ -205,6 +205,7 @@ def new_state(
         "reviews": {"spec": [], "plan": [], "code": []},
         "open_finding_ids": {"spec": [], "plan": [], "code": []},
         "review_validation_retry": None,
+        "review_unverified_retry": None,
         "plan_approval": None,
         "verification": {
             "path": None,
@@ -577,6 +578,16 @@ def record_review(state, review_path, artifact_digest):
             f"got {state.get('stage')}"
         )
 
+    rounds = state.get("rounds")
+    if not isinstance(rounds, dict) or not isinstance(rounds.get(artifact), int):
+        raise StateError(f"state rounds missing {artifact}")
+    expected_round = rounds[artifact] + 1
+
+    retry = state.get("review_unverified_retry")
+    if isinstance(retry, dict) and retry.get("artifact") == artifact and retry.get("round") == expected_round:
+        if retry.get("artifact_digest") != artifact_digest:
+            raise StateError("unverified review retry artifact digest mismatch")
+
     if artifact in {"spec", "plan"}:
         artifacts = state.get("artifacts")
         if not isinstance(artifacts, dict):
@@ -585,10 +596,6 @@ def record_review(state, review_path, artifact_digest):
         if artifact_path is not None and _file_digest(artifact_path) != artifact_digest:
             raise StateError(f"{artifact} artifact digest mismatch")
 
-    rounds = state.get("rounds")
-    if not isinstance(rounds, dict) or not isinstance(rounds.get(artifact), int):
-        raise StateError(f"state rounds missing {artifact}")
-    expected_round = rounds[artifact] + 1
     if review.get("round") != expected_round:
         raise StateError(
             f"review round must be {expected_round}, got {review.get('round')!r}"
@@ -649,6 +656,7 @@ def record_review(state, review_path, artifact_digest):
     open_finding_ids[artifact] = list(blockers)
     artifact_digests[artifact] = artifact_digest
     state["review_validation_retry"] = None
+    state["review_unverified_retry"] = None
     state["updated_at"] = _now_timestamp()
 
     recurring = next((blocker for blocker in blockers if blocker in earlier_blockers), None)
@@ -660,6 +668,70 @@ def record_review(state, review_path, artifact_digest):
     ):
         state["stage"] = "NEEDS_REDESIGN"
         state["status_reason"] = f"REVIEW_LIMIT_EXHAUSTED:{artifact}"
+    return state
+
+
+def record_review_unverified(state, review_path, artifact_digest):
+    """Record a bounded no-round-cost retry for unverified REVISE evidence."""
+    state = _require_state(state)
+    if not isinstance(artifact_digest, str) or re.fullmatch(r"[0-9a-f]{64}", artifact_digest) is None:
+        raise StateError("artifact_digest must be a lowercase SHA-256 hexdigest")
+    review = _load_review(review_path)
+    artifact = review.get("artifact")
+    expected_stage = _REVIEW_STAGES.get(artifact) if isinstance(artifact, str) else None
+    if expected_stage is None:
+        raise StateError(f"unknown review artifact: {artifact!r}")
+    if state.get("stage") != expected_stage:
+        raise StateError(f"review for {artifact} requires stage {expected_stage}, got {state.get('stage')}")
+    if artifact in {"spec", "plan"}:
+        artifacts = state.get("artifacts")
+        if not isinstance(artifacts, dict):
+            raise StateError("state artifacts storage is malformed")
+        artifact_path = artifacts.get(artifact)
+        if artifact_path is not None and _file_digest(artifact_path) != artifact_digest:
+            raise StateError(f"{artifact} artifact digest mismatch")
+    rounds = state.get("rounds")
+    if not isinstance(rounds, dict) or not isinstance(rounds.get(artifact), int):
+        raise StateError(f"state rounds missing {artifact}")
+    expected_round = rounds[artifact] + 1
+    if review.get("round") != expected_round:
+        raise StateError(f"review round must be {expected_round}, got {review.get('round')!r}")
+    if expected_round > ROUND_LIMITS[artifact]:
+        raise TransitionError(f"review round limit exhausted for {artifact}")
+    prior = None
+    if expected_round >= 2:
+        open_finding_ids = state.get("open_finding_ids")
+        if not isinstance(open_finding_ids, dict) or not isinstance(open_finding_ids.get(artifact), list):
+            raise StateError(f"state open_finding_ids missing {artifact}")
+        prior = {"open_finding_ids": list(open_finding_ids[artifact])}
+    validation_errors = validate_review(review, expected_artifact=artifact, prior=prior)
+    if validation_errors:
+        raise StateError(f"review validation failed: {'; '.join(str(error) for error in validation_errors)}")
+    if not (review["verdict"] == "REVISE" and not review["blockers"] and any(item.get("verified") is False for item in review["evidence"])):
+        raise StateError("review is not an unverified REVISE")
+    retry = state.get("review_unverified_retry")
+    if isinstance(retry, dict) and retry.get("artifact") == artifact and retry.get("round") == expected_round:
+        if retry.get("artifact_digest") != artifact_digest:
+            raise StateError("unverified review retry artifact digest mismatch")
+        if retry.get("attempts") == 2:
+            raise TransitionError("REVIEWER_UNVERIFIED_PERSISTS")
+        attempts = 2
+        exhausted = True
+        claims = list(retry.get("unverified_claims", []))
+        paths = list(retry.get("discarded_reviews", []))
+    else:
+        attempts = 1
+        exhausted = False
+        claims = []
+        paths = []
+    claims.extend(item["claim"] for item in review["evidence"] if item.get("verified") is False)
+    paths.append(str(review_path))
+    state["review_unverified_retry"] = {
+        "artifact": artifact, "round": expected_round, "attempts": attempts,
+        "exhausted": exhausted, "artifact_digest": artifact_digest,
+        "unverified_claims": claims, "discarded_reviews": paths,
+    }
+    state["updated_at"] = _now_timestamp()
     return state
 
 
@@ -1088,6 +1160,11 @@ def _build_parser():
     review_parser.add_argument("--review", required=True)
     review_parser.add_argument("--artifact-digest", required=True)
 
+    unverified_review_parser = subparsers.add_parser("record-review-unverified")
+    unverified_review_parser.add_argument("--state", required=True)
+    unverified_review_parser.add_argument("--review", required=True)
+    unverified_review_parser.add_argument("--artifact-digest", required=True)
+
     review_error_parser = subparsers.add_parser("record-review-error")
     review_error_parser.add_argument("--state", required=True)
     review_error_parser.add_argument("--artifact", required=True)
@@ -1204,6 +1281,13 @@ def main(argv=None):
                     state,
                     args.review,
                     args.artifact_digest,
+                ),
+            )
+        elif args.command == "record-review-unverified":
+            _mutating_result(
+                args.state,
+                lambda state: record_review_unverified(
+                    state, args.review, args.artifact_digest,
                 ),
             )
         elif args.command == "record-review-error":

--- a/dot_claude/skills/quality-goal/scripts/validate_review.py
+++ b/dot_claude/skills/quality-goal/scripts/validate_review.py
@@ -45,7 +45,16 @@ FINDING_FIELDS = (
     "required_resolution",
     "new_blocker_evidence",
 )
-EVIDENCE_FIELDS = ("claim", "location")
+EVIDENCE_FIELDS = ("claim", "location", "verified")
+EVIDENCE_STRING_FIELDS = ("claim", "location")
+PRIOR_FIELDS = ("open_finding_ids", "open_findings", "resolved_finding_ids")
+OPEN_FINDING_FIELDS = (
+    "id", "severity", "description", "evidence_location",
+    "required_resolution", "resolution_claim", "resolution_evidence",
+)
+OPEN_FINDING_STRING_FIELDS = (
+    "id", "severity", "description", "evidence_location", "required_resolution",
+)
 
 
 def _is_integer(value):
@@ -76,6 +85,8 @@ def _prior_open_finding_ids(prior, errors):
     if "open_finding_ids" not in prior:
         errors.append("prior is missing required field: open_finding_ids")
         return []
+    for key in _unknown_keys(prior, set(PRIOR_FIELDS)):
+        errors.append(f"prior has unknown field: {_format_key(key)}")
 
     open_ids = prior["open_finding_ids"]
     if not isinstance(open_ids, list):
@@ -83,6 +94,7 @@ def _prior_open_finding_ids(prior, errors):
         return []
 
     valid_ids = []
+    seen_ids = set()
     for index, finding_id in enumerate(open_ids):
         if not isinstance(finding_id, str):
             errors.append(
@@ -90,6 +102,58 @@ def _prior_open_finding_ids(prior, errors):
             )
         else:
             valid_ids.append(finding_id)
+            if finding_id in seen_ids:
+                errors.append(f"duplicate prior.open_finding_ids entry: {finding_id!r}")
+            seen_ids.add(finding_id)
+
+    open_findings = prior.get("open_findings")
+    if open_findings is not None:
+        if not isinstance(open_findings, list):
+            errors.append("prior.open_findings must be a list")
+        else:
+            finding_ids = set()
+            for index, finding in enumerate(open_findings):
+                prefix = f"prior.open_findings[{index}]"
+                if not isinstance(finding, dict):
+                    errors.append(f"{prefix} must be a dict")
+                    continue
+                for field in OPEN_FINDING_FIELDS:
+                    if field not in finding:
+                        errors.append(f"{prefix} missing required field: {field}")
+                for key in _unknown_keys(finding, set(OPEN_FINDING_FIELDS)):
+                    errors.append(f"{prefix} has unknown field: {_format_key(key)}")
+                for field in OPEN_FINDING_STRING_FIELDS:
+                    if field in finding and not _is_non_empty_string(finding[field]):
+                        errors.append(f"{prefix}.{field} must be a non-empty string")
+                if "severity" in finding and finding["severity"] not in SEVERITIES:
+                    errors.append(f"{prefix}.severity must be one of: Critical, High, Low, Medium")
+                for field in ("resolution_claim", "resolution_evidence"):
+                    if field in finding and finding[field] is not None and not isinstance(finding[field], str):
+                        errors.append(f"{prefix}.{field} must be a string or null")
+                finding_id = finding.get("id")
+                if isinstance(finding_id, str):
+                    if finding_id in finding_ids:
+                        errors.append(f"duplicate prior open finding ID: {finding_id!r}")
+                    finding_ids.add(finding_id)
+            for finding_id in valid_ids:
+                if finding_id not in finding_ids:
+                    errors.append(f"prior.open_finding_ids entry missing from open_findings: {finding_id!r}")
+
+    resolved_ids = prior.get("resolved_finding_ids")
+    if resolved_ids is not None:
+        if not isinstance(resolved_ids, list):
+            errors.append("prior.resolved_finding_ids must be a list")
+        else:
+            seen_resolved = set()
+            for index, finding_id in enumerate(resolved_ids):
+                if not isinstance(finding_id, str):
+                    errors.append(f"prior.resolved_finding_ids[{index}] must be a string")
+                    continue
+                if finding_id in seen_resolved:
+                    errors.append(f"duplicate prior.resolved_finding_ids entry: {finding_id!r}")
+                seen_resolved.add(finding_id)
+                if finding_id in valid_ids:
+                    errors.append(f"prior resolved finding overlaps open finding: {finding_id!r}")
     return valid_ids
 
 
@@ -248,11 +312,13 @@ def validate_review(payload, expected_artifact=None, prior=None):
             for key in _unknown_keys(item, set(EVIDENCE_FIELDS)):
                 errors.append(f"{prefix} has unknown field: {_format_key(key)}")
 
-            for field in EVIDENCE_FIELDS:
+            for field in EVIDENCE_STRING_FIELDS:
                 if field in item and not _is_non_empty_string(item[field]):
                     errors.append(
                         f"{prefix}.{field} must be a non-empty string"
                     )
+            if "verified" in item and not isinstance(item["verified"], bool):
+                errors.append(f"{prefix}.verified must be a boolean")
 
             if item in seen_evidence:
                 errors.append(f"duplicate evidence entry at {prefix}")
@@ -266,6 +332,10 @@ def validate_review(payload, expected_artifact=None, prior=None):
     if verdict == "PASS":
         if "required_next_action" in payload and required_next_action is not None:
             errors.append("PASS reviews must have no required_next_action")
+        if evidence_valid and any(
+            item.get("verified") is False for item in evidence if isinstance(item, dict)
+        ):
+            errors.append("PASS reviews must not contain unverified evidence")
 
     if round_valid and review_round >= 2:
         if prior is None:

--- a/dot_claude/skills/quality-goal/tests/fixtures/review-high-finding.json
+++ b/dot_claude/skills/quality-goal/tests/fixtures/review-high-finding.json
@@ -20,7 +20,8 @@
   "evidence": [
     {
       "claim": "The plan has a traceability gap despite its high numeric score.",
-      "location": "docs/development/quality-goal/plan.md#Traceability"
+      "location": "docs/development/quality-goal/plan.md#Traceability",
+      "verified": true
     }
   ],
   "required_next_action": "Add the missing acceptance-criterion mapping."

--- a/dot_claude/skills/quality-goal/tests/fixtures/review-valid-plan.json
+++ b/dot_claude/skills/quality-goal/tests/fixtures/review-valid-plan.json
@@ -8,7 +8,8 @@
   "evidence": [
     {
       "claim": "The plan traces acceptance criteria to implementation and verification tasks.",
-      "location": "docs/development/quality-goal/plan.md#Traceability"
+      "location": "docs/development/quality-goal/plan.md#Traceability",
+      "verified": true
     }
   ],
   "required_next_action": null

--- a/dot_claude/skills/quality-goal/tests/test_content_contracts.py
+++ b/dot_claude/skills/quality-goal/tests/test_content_contracts.py
@@ -608,13 +608,23 @@ def parse_yaml_frontmatter(text):
     return values, "\n".join(lines[fences[1] + 1 :])
 
 
+QUALITY_REVIEWER_AGENT_PATH = (
+    find_repo_root(Path(__file__).resolve())
+    / "dot_claude" / "agents" / "quality-reviewer.md"
+)
+
+
+def read_quality_reviewer_agent():
+    if not QUALITY_REVIEWER_AGENT_PATH.is_file():
+        raise AssertionError(f"missing agent file: {QUALITY_REVIEWER_AGENT_PATH}")
+    return QUALITY_REVIEWER_AGENT_PATH.read_text(encoding="utf-8")
+
+
 class QualityReviewerAgentContentTests(unittest.TestCase):
-    REPO_ROOT = find_repo_root(Path(__file__).resolve())
-    AGENT_PATH = REPO_ROOT / "dot_claude" / "agents" / "quality-reviewer.md"
+    AGENT_PATH = QUALITY_REVIEWER_AGENT_PATH
 
     def read_agent(self):
-        self.assertTrue(self.AGENT_PATH.is_file(), f"missing agent file: {self.AGENT_PATH}")
-        return self.AGENT_PATH.read_text(encoding="utf-8")
+        return read_quality_reviewer_agent()
 
     def test_frontmatter_contract(self):
         frontmatter, _ = parse_yaml_frontmatter(self.read_agent())
@@ -721,6 +731,61 @@ class QualityGoalSkillContentTests(unittest.TestCase):
         )
         return self.SKILL_PATH.read_text(encoding="utf-8")
 
+    def test_structured_prior_and_unverified_retry_contract(self):
+        _, body = parse_yaml_frontmatter(self.read_skill())
+        lower = body.casefold()
+        self.assertRegex(
+            lower,
+            r"build `open_findings` from\s+the prior review json at "
+            r"`reviews\[artifact\]\[\*\]\.path`",
+        )
+        self.assertRegex(
+            lower,
+            r"send each open finding's\s+id, severity, description, evidence location,\s+"
+            r"required resolution, and the\s+orchestrator's resolution claim and resolution evidence",
+        )
+        self.assertRegex(
+            lower,
+            r"send confirmed\s+resolutions as ids only in `resolved_finding_ids`",
+        )
+        self.assertRegex(
+            lower,
+            r"well-formed unverified revise \(`verdict == revise`, `blockers == \[\]`, and\s+"
+            r"any evidence has `verified == false`\)[\s\S]{0,220}does not consume a round: "
+            r"relaunch on the same round",
+        )
+        self.assertRegex(
+            lower,
+            r"at most two discarded reviews are allowed \(one free retry\); after `exhausted`,\s+"
+            r"register the report then transition to blocked with\s+`reviewer_unverified_persists`",
+        )
+        self.assertRegex(
+            lower,
+            r"record that outcome as a reviewer capability\s+limit, not a code or design failure",
+        )
+        self.assertRegex(
+            lower,
+            r"evidence paths for each unverified condition and the discarded review's\s+"
+            r"full non-blocking findings\. on round 2\+, include those findings in prior\s+"
+            r"`open_findings`",
+        )
+        self.assertRegex(lower, r"do not revise the artifact or workspace during this retry")
+
+    def test_reviewer_records_verified_evidence_and_reuses_prior_ids(self):
+        _, body = parse_yaml_frontmatter(read_quality_reviewer_agent())
+        lower = body.casefold()
+        self.assertRegex(
+            lower,
+            r"on later rounds.{0,260}each supplied open finding is resolved and "
+            r"record that determination in evidence; reuse its id when a new finding restates it",
+        )
+        self.assertRegex(
+            lower,
+            r"every evidence item, including the single blocked-payload item, must include "
+            r"`verified`\. use `verified == false` when a condition was not verified and put "
+            r"the reason in its `claim`",
+        )
+
     @staticmethod
     def normalize(text):
         return " ".join(text.casefold().split())
@@ -729,7 +794,7 @@ class QualityGoalSkillContentTests(unittest.TestCase):
         frontmatter, _ = parse_yaml_frontmatter(self.read_skill())
         expected = {
             "name": "quality-goal",
-            "version": "3.0.0",
+            "version": "4.0.0",
             "description": "Use when the user explicitly requests a quality-gated, documented software change workflow.",
             "argument-hint": "[--mode=auto|light|standard|strict] <goal>",
             "disable-model-invocation": "true",

--- a/dot_claude/skills/quality-goal/tests/test_quality_state.py
+++ b/dot_claude/skills/quality-goal/tests/test_quality_state.py
@@ -76,10 +76,20 @@ def valid_review(artifact="plan", round_number=1, verdict="PASS", blockers=None)
             {
                 "claim": "The reviewed artifact is traceable to its acceptance criteria.",
                 "location": "artifact.md#Traceability",
+                "verified": True,
             }
         ],
         "required_next_action": None,
     }
+
+
+def unverified_review(artifact="plan", round_number=1, claim=None):
+    review = valid_review(artifact, round_number, "REVISE")
+    review["evidence"][0]["verified"] = False
+    if claim is not None:
+        review["evidence"][0]["claim"] = claim
+    review["required_next_action"] = "Supply the missing evidence."
+    return review
 
 
 def state_at(stage, mode="standard", project_root=None, goal="Build the quality workflow"):
@@ -208,6 +218,7 @@ class NewStateTests(unittest.TestCase):
                 "reviews",
                 "open_finding_ids",
                 "review_validation_retry",
+                "review_unverified_retry",
                 "plan_approval",
                 "verification",
                 "status_reason",
@@ -242,6 +253,7 @@ class NewStateTests(unittest.TestCase):
             state["open_finding_ids"],
         )
         self.assertIsNone(state["review_validation_retry"])
+        self.assertIsNone(state["review_unverified_retry"])
         self.assertIsNone(state["plan_approval"])
         self.assertEqual(
             {"path": None, "workspace_fingerprint": None, "valid": False},
@@ -1008,6 +1020,349 @@ class RecordReviewTests(unittest.TestCase):
 
             with self.assertRaises(StateError):
                 quality_state.record_review(state_at("PLAN_REVIEW"), review_path, VALID_DIGEST)
+
+
+class RecordReviewUnverifiedTests(unittest.TestCase):
+    def test_unverified_revise_is_accounted_without_consuming_a_round(self):
+        with tempfile.TemporaryDirectory() as directory:
+            review = valid_review(verdict="REVISE")
+            review["evidence"][0]["verified"] = False
+            review["required_next_action"] = "Supply the missing evidence."
+            review_path = write_json(directory, "review.json", review)
+            state = state_at("PLAN_REVIEW")
+
+            result = quality_state.record_review_unverified(state, review_path, VALID_DIGEST)
+
+            self.assertEqual(0, result["rounds"]["plan"])
+            self.assertEqual({
+                "artifact": "plan", "round": 1, "attempts": 1, "exhausted": False,
+                "artifact_digest": VALID_DIGEST,
+                "unverified_claims": [review["evidence"][0]["claim"]],
+                "discarded_reviews": [str(review_path)],
+            }, result["review_unverified_retry"])
+
+    def test_unverified_retry_is_digest_bound_and_record_review_clears_it(self):
+        with tempfile.TemporaryDirectory() as directory:
+            unverified = valid_review(verdict="REVISE")
+            unverified["evidence"][0]["verified"] = False
+            unverified["required_next_action"] = "Supply evidence."
+            unverified_path = write_json(directory, "unverified.json", unverified)
+            state = state_at("PLAN_REVIEW")
+            quality_state.record_review_unverified(state, unverified_path, VALID_DIGEST)
+            normal_path = write_json(directory, "normal.json", valid_review())
+
+            with self.assertRaises(StateError):
+                quality_state.record_review(state, normal_path, "b" * 64)
+            result = quality_state.record_review(state, normal_path, VALID_DIGEST)
+            self.assertIsNone(result["review_unverified_retry"])
+
+    def test_rejects_blockers_or_fully_verified_evidence(self):
+        cases = []
+        blocked = unverified_review()
+        blocked["blockers"] = ["PLAN-001"]
+        blocked["findings"] = [high_finding("PLAN-001")]
+        cases.append(("blockers", blocked))
+        verified = unverified_review()
+        verified["evidence"][0]["verified"] = True
+        cases.append(("all verified", verified))
+
+        with tempfile.TemporaryDirectory() as directory:
+            for label, review in cases:
+                with self.subTest(condition=label):
+                    path = write_json(directory, f"{label}.json", review)
+                    with self.assertRaisesRegex(
+                        StateError, "review is not an unverified REVISE",
+                    ):
+                        quality_state.record_review_unverified(
+                            state_at("PLAN_REVIEW"), path, VALID_DIGEST,
+                        )
+
+    def test_rejects_pass_and_blocked_verdicts(self):
+        cases = []
+        passed = unverified_review()
+        passed["verdict"] = "PASS"
+        passed["evidence"][0]["verified"] = True
+        passed["required_next_action"] = None
+        cases.append(("PASS", passed))
+        blocked = unverified_review()
+        blocked["verdict"] = "BLOCKED"
+        cases.append(("BLOCKED", blocked))
+
+        with tempfile.TemporaryDirectory() as directory:
+            for verdict, review in cases:
+                with self.subTest(verdict=verdict):
+                    path = write_json(directory, f"{verdict}.json", review)
+                    with self.assertRaisesRegex(
+                        StateError, "review is not an unverified REVISE",
+                    ):
+                        quality_state.record_review_unverified(
+                            state_at("PLAN_REVIEW"), path, VALID_DIGEST,
+                        )
+
+    def test_rejects_wrong_review_stage(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = write_json(directory, "review.json", unverified_review())
+
+            with self.assertRaisesRegex(StateError, "requires stage PLAN_REVIEW"):
+                quality_state.record_review_unverified(
+                    state_at("IMPLEMENTING"), path, VALID_DIGEST,
+                )
+
+    def test_rejects_non_next_round_before_round_limit(self):
+        with tempfile.TemporaryDirectory() as directory:
+            wrong_round = unverified_review(round_number=2)
+            wrong_path = write_json(directory, "wrong-round.json", wrong_round)
+            with self.assertRaisesRegex(StateError, "review round must be 1"):
+                quality_state.record_review_unverified(
+                    state_at("PLAN_REVIEW"), wrong_path, VALID_DIGEST,
+                )
+
+            beyond_limit = unverified_review("spec", round_number=9)
+            beyond_path = write_json(directory, "beyond-limit.json", beyond_limit)
+            with self.assertRaisesRegex(StateError, "review round must be 1"):
+                quality_state.record_review_unverified(
+                    state_at("SPEC_REVIEW"), beyond_path, VALID_DIGEST,
+                )
+
+    def test_schema_invalid_review_leaves_state_unchanged(self):
+        with tempfile.TemporaryDirectory() as directory:
+            review = unverified_review()
+            del review["evidence"][0]["claim"]
+            path = write_json(directory, "invalid.json", review)
+            state = state_at("PLAN_REVIEW")
+            before = deepcopy(state)
+
+            with self.assertRaisesRegex(StateError, "missing required field: claim"):
+                quality_state.record_review_unverified(state, path, VALID_DIGEST)
+
+            self.assertEqual(before, state)
+
+    def test_registered_spec_digest_mismatch_leaves_state_unchanged(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = Path(directory)
+            spec = directory / "spec.md"
+            spec.write_text("original spec\n", encoding="utf-8")
+            path = write_json(directory, "review.json", unverified_review("spec"))
+            state = state_at("SPEC_REVIEW")
+            state["artifacts"]["spec"] = str(spec)
+            before = deepcopy(state)
+
+            with self.assertRaisesRegex(StateError, "spec artifact digest mismatch"):
+                quality_state.record_review_unverified(state, path, VALID_DIGEST)
+
+            self.assertEqual(before, state)
+
+    def test_round_limit_after_matching_round_raises_transition_error_unchanged(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state = state_at("PLAN_REVIEW")
+            state["rounds"]["plan"] = quality_state.ROUND_LIMITS["plan"]
+            path = write_json(
+                directory,
+                "limit.json",
+                unverified_review("plan", quality_state.ROUND_LIMITS["plan"] + 1),
+            )
+            before = deepcopy(state)
+
+            with self.assertRaisesRegex(
+                quality_state.TransitionError, "review round limit exhausted",
+            ):
+                quality_state.record_review_unverified(state, path, VALID_DIGEST)
+
+            self.assertEqual(before, state)
+
+    def test_second_unverified_retry_is_exhausted_without_consuming_round(self):
+        with tempfile.TemporaryDirectory() as directory:
+            first = unverified_review(claim="First condition was not verified.")
+            second = unverified_review(claim="Second condition was not verified.")
+            first_path = write_json(directory, "first.json", first)
+            second_path = write_json(directory, "second.json", second)
+            state = state_at("PLAN_REVIEW")
+            quality_state.record_review_unverified(state, first_path, VALID_DIGEST)
+
+            result = quality_state.record_review_unverified(state, second_path, VALID_DIGEST)
+
+            retry = result["review_unverified_retry"]
+            self.assertEqual(2, retry["attempts"])
+            self.assertTrue(retry["exhausted"])
+            self.assertEqual([str(first_path), str(second_path)], retry["discarded_reviews"])
+            self.assertEqual(
+                [first["evidence"][0]["claim"], second["evidence"][0]["claim"]],
+                retry["unverified_claims"],
+            )
+            self.assertEqual(0, result["rounds"]["plan"])
+
+    def test_third_unverified_retry_raises_persists_without_mutation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            first_path = write_json(directory, "first.json", unverified_review())
+            second_path = write_json(directory, "second.json", unverified_review())
+            third_path = write_json(directory, "third.json", unverified_review())
+            state = state_at("PLAN_REVIEW")
+            quality_state.record_review_unverified(state, first_path, VALID_DIGEST)
+            quality_state.record_review_unverified(state, second_path, VALID_DIGEST)
+            before = deepcopy(state)
+
+            with self.assertRaisesRegex(
+                quality_state.TransitionError, "REVIEWER_UNVERIFIED_PERSISTS",
+            ):
+                quality_state.record_review_unverified(state, third_path, VALID_DIGEST)
+
+            self.assertEqual(before, state)
+
+    def test_exhausted_unverified_retry_can_register_report_then_block(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = Path(directory)
+            first_path = write_json(directory, "first.json", unverified_review("spec"))
+            second_path = write_json(directory, "second.json", unverified_review("spec"))
+            third_path = write_json(directory, "third.json", unverified_review("spec"))
+            report_path = directory / "report.md"
+            report_path.write_text("blocked review report\n", encoding="utf-8")
+            state = state_at("SPEC_REVIEW")
+            quality_state.record_review_unverified(state, first_path, VALID_DIGEST)
+            quality_state.record_review_unverified(state, second_path, VALID_DIGEST)
+            with self.assertRaisesRegex(
+                quality_state.TransitionError, "REVIEWER_UNVERIFIED_PERSISTS",
+            ):
+                quality_state.record_review_unverified(state, third_path, VALID_DIGEST)
+
+            self.assertEqual("SPEC_REVIEW", state["stage"])
+            self.assertNotIn(state["stage"], quality_state.TERMINAL_STATES)
+            quality_state.set_artifact(state, "report", report_path)
+            quality_state.transition(
+                state, "BLOCKED", "REVIEWER_UNVERIFIED_PERSISTS:spec",
+            )
+            self.assertEqual("BLOCKED", state["stage"])
+
+    def test_retry_digest_binding_precedes_registered_spec_digest_mismatch(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = Path(directory)
+            spec = directory / "spec.md"
+            spec.write_text("original spec\n", encoding="utf-8")
+            digest = quality_state._file_digest(spec)
+            unverified_path = write_json(
+                directory, "unverified.json", unverified_review("spec"),
+            )
+            normal_path = write_json(directory, "normal.json", valid_review("spec"))
+            state = state_at("SPEC_REVIEW")
+            state["artifacts"]["spec"] = str(spec)
+            quality_state.record_review_unverified(state, unverified_path, digest)
+
+            with self.assertRaisesRegex(
+                StateError, "unverified review retry artifact digest mismatch",
+            ):
+                quality_state.record_review(state, normal_path, "b" * 64)
+            self.assertEqual(0, state["rounds"]["spec"])
+
+            second_path = write_json(
+                directory, "second-unverified.json", unverified_review("spec"),
+            )
+            with self.assertRaisesRegex(StateError, "spec artifact digest mismatch"):
+                quality_state.record_review_unverified(state, second_path, "b" * 64)
+
+    def test_retry_digest_binding_rejects_recomputed_revised_spec_digest(self):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = Path(directory)
+            spec = directory / "spec.md"
+            spec.write_text("original spec\n", encoding="utf-8")
+            initial_digest = quality_state._file_digest(spec)
+            unverified_path = write_json(
+                directory, "unverified.json", unverified_review("spec"),
+            )
+            normal_path = write_json(directory, "normal.json", valid_review("spec"))
+            state = state_at("SPEC_REVIEW")
+            state["artifacts"]["spec"] = str(spec)
+            quality_state.record_review_unverified(state, unverified_path, initial_digest)
+            spec.write_text("revised spec\n", encoding="utf-8")
+            revised_digest = quality_state._file_digest(spec)
+
+            with self.assertRaisesRegex(
+                StateError, "unverified review retry artifact digest mismatch",
+            ):
+                quality_state.record_review(state, normal_path, revised_digest)
+
+    def test_pass_with_unverified_evidence_does_not_record_a_round(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = write_json(directory, "pass.json", valid_review())
+            review = json.loads(path.read_text(encoding="utf-8"))
+            review["evidence"][0]["verified"] = False
+            write_json(directory, "pass.json", review)
+            state = state_at("PLAN_REVIEW")
+
+            with self.assertRaisesRegex(
+                StateError, "PASS reviews must not contain unverified evidence",
+            ):
+                quality_state.record_review(state, path, VALID_DIGEST)
+
+            self.assertEqual(0, state["rounds"]["plan"])
+
+    def test_round_two_unverified_review_assembles_prior_from_state(self):
+        with tempfile.TemporaryDirectory() as directory:
+            round_one = valid_review("spec", 1, "REVISE", ["SPEC-A"])
+            round_one["required_next_action"] = "Resolve SPEC-A."
+            first_path = write_json(directory, "round-one.json", round_one)
+            unverified_path = write_json(
+                directory, "round-two.json", unverified_review("spec", 2),
+            )
+            state = state_at("SPEC_REVIEW")
+            quality_state.record_review(state, first_path, VALID_DIGEST)
+
+            result = quality_state.record_review_unverified(
+                state, unverified_path, VALID_DIGEST,
+            )
+
+            self.assertEqual(1, result["rounds"]["spec"])
+            self.assertEqual(["SPEC-A"], result["open_finding_ids"]["spec"])
+
+    def test_parser_rejects_prior_for_record_review_unverified(self):
+        parser = quality_state._build_parser()
+
+        with self.assertRaisesRegex(StateError, "unrecognized arguments: --prior"):
+            parser.parse_args([
+                "record-review-unverified", "--state", "state.json",
+                "--review", "review.json", "--artifact-digest", VALID_DIGEST,
+                "--prior", "prior.json",
+            ])
+
+    def test_stale_unverified_retry_is_replaced_by_the_next_unverified_round(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state = state_at("SPEC_REVIEW")
+            state["rounds"]["spec"] = 1
+            state["review_unverified_retry"] = {
+                "artifact": "spec", "round": 1, "attempts": 2, "exhausted": True,
+                "artifact_digest": "a" * 64, "unverified_claims": ["stale"],
+                "discarded_reviews": ["stale.json"],
+            }
+            path = write_json(
+                directory, "round-two.json", unverified_review("spec", 2),
+            )
+
+            result = quality_state.record_review_unverified(state, path, "b" * 64)
+
+            self.assertEqual(1, result["review_unverified_retry"]["attempts"])
+            self.assertFalse(result["review_unverified_retry"]["exhausted"])
+            self.assertEqual("b" * 64, result["review_unverified_retry"]["artifact_digest"])
+            self.assertEqual(
+                ["The reviewed artifact is traceable to its acceptance criteria."],
+                result["review_unverified_retry"]["unverified_claims"],
+            )
+            self.assertEqual(
+                [str(path)], result["review_unverified_retry"]["discarded_reviews"],
+            )
+
+    def test_stale_unverified_retry_does_not_bind_normal_next_round_and_is_cleared(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state = state_at("SPEC_REVIEW")
+            state["rounds"]["spec"] = 1
+            state["review_unverified_retry"] = {
+                "artifact": "spec", "round": 1, "attempts": 2, "exhausted": True,
+                "artifact_digest": "a" * 64, "unverified_claims": ["stale"],
+                "discarded_reviews": ["stale.json"],
+            }
+            path = write_json(directory, "round-two.json", valid_review("spec", 2))
+
+            result = quality_state.record_review(state, path, "b" * 64)
+
+            self.assertEqual(2, result["rounds"]["spec"])
+            self.assertIsNone(result["review_unverified_retry"])
 
 
 class RoundLimitTests(unittest.TestCase):

--- a/dot_claude/skills/quality-goal/tests/test_validate_review.py
+++ b/dot_claude/skills/quality-goal/tests/test_validate_review.py
@@ -38,6 +38,7 @@ def valid_review(artifact="plan", score=87, verdict="PASS"):
             {
                 "claim": "The reviewed artifact is traceable to its acceptance criteria.",
                 "location": "plan.md#Traceability",
+                "verified": True,
             }
         ],
         "required_next_action": None,
@@ -110,7 +111,7 @@ class ValidateReviewTests(unittest.TestCase):
         review = valid_review()
         review["unexpected"] = True
 
-        self.assertTrue(validate_review(review, "plan"))
+        self.assertIn("unknown top-level field: 'unexpected'", validate_review(review, "plan"))
 
     def test_unknown_finding_level_key_is_rejected(self):
         finding = high_finding("PLAN-001")
@@ -118,17 +119,24 @@ class ValidateReviewTests(unittest.TestCase):
         review = valid_review()
         review["findings"] = [finding]
 
-        self.assertTrue(validate_review(review, "plan"))
+        self.assertIn("findings[0] has unknown field: 'unexpected'", validate_review(review, "plan"))
 
     def test_wrong_artifact_is_rejected_against_expected_artifact(self):
         review = valid_review(artifact="spec")
 
-        self.assertTrue(validate_review(review, expected_artifact="plan"))
+        self.assertIn(
+            "artifact 'spec' does not match expected artifact 'plan'",
+            validate_review(review, expected_artifact="plan"),
+        )
 
     def test_score_must_be_an_integer_between_zero_and_one_hundred(self):
-        for score in (101, -1, 87.5):
+        for score, expected_error in (
+            (101, "score must be between 0 and 100"),
+            (-1, "score must be between 0 and 100"),
+            (87.5, "score must be an integer"),
+        ):
             with self.subTest(score=score):
-                self.assertTrue(validate_review(valid_review(score=score), "plan"))
+                self.assertIn(expected_error, validate_review(valid_review(score=score), "plan"))
 
     def test_duplicate_finding_ids_are_rejected(self):
         review = valid_review()
@@ -137,13 +145,16 @@ class ValidateReviewTests(unittest.TestCase):
             high_finding("PLAN-001"),
         ]
 
-        self.assertTrue(validate_review(review, "plan"))
+        self.assertIn("duplicate finding ID: 'PLAN-001'", validate_review(review, "plan"))
 
     def test_blocker_id_must_resolve_to_a_finding(self):
         review = valid_review(verdict="REVISE")
         review["blockers"] = ["PLAN-001"]
 
-        self.assertTrue(validate_review(review, "plan"))
+        self.assertIn(
+            "blockers[0] does not resolve to a finding: 'PLAN-001'",
+            validate_review(review, "plan"),
+        )
 
     def test_medium_finding_cannot_be_listed_as_a_blocker(self):
         finding = high_finding("PLAN-001")
@@ -152,13 +163,16 @@ class ValidateReviewTests(unittest.TestCase):
         review["findings"] = [finding]
         review["blockers"] = ["PLAN-001"]
 
-        self.assertTrue(validate_review(review, "plan"))
+        self.assertIn(
+            "blocker 'PLAN-001' must resolve to a Critical or High finding",
+            validate_review(review, "plan"),
+        )
 
     def test_pass_with_required_next_action_is_rejected(self):
         review = valid_review()
         review["required_next_action"] = "Revise the traceability table."
 
-        self.assertTrue(validate_review(review, "plan"))
+        self.assertIn("PASS reviews must have no required_next_action", validate_review(review, "plan"))
 
     def test_pass_verdict_with_blockers_is_valid_but_fails_the_gate(self):
         review = valid_review(verdict="PASS")
@@ -179,7 +193,10 @@ class ValidateReviewTests(unittest.TestCase):
         review["blockers"] = ["PLAN-NEW"]
         prior = {"open_finding_ids": ["PLAN-OLD"]}
 
-        self.assertTrue(validate_review(review, "plan", prior))
+        self.assertIn(
+            "new blocker 'PLAN-NEW' at blockers[0] requires non-empty new_blocker_evidence",
+            validate_review(review, "plan", prior),
+        )
 
         review["findings"][0]["new_blocker_evidence"] = (
             "The revised plan introduced a new unmapped acceptance criterion."
@@ -190,13 +207,13 @@ class ValidateReviewTests(unittest.TestCase):
         review = valid_review()
         review.pop("evidence")
 
-        self.assertTrue(validate_review(review, "plan"))
+        self.assertIn("missing required field: evidence", validate_review(review, "plan"))
 
     def test_blockers_must_contain_strings(self):
         review = valid_review(verdict="REVISE")
         review["blockers"] = [123]
 
-        self.assertTrue(validate_review(review, "plan"))
+        self.assertIn("blockers[0] must be a string", validate_review(review, "plan"))
 
     def test_duplicate_blocker_ids_are_rejected(self):
         review = valid_review(verdict="REVISE")
@@ -232,6 +249,96 @@ class ValidateReviewTests(unittest.TestCase):
         review["round"] = 2
 
         self.assertEqual([], validate_review(review, "plan", {"open_finding_ids": []}))
+
+
+class PriorPayloadTests(unittest.TestCase):
+    def prior(self):
+        return {
+            "open_finding_ids": ["PLAN-001"],
+            "open_findings": [{
+                "id": "PLAN-001", "severity": "High", "description": "description",
+                "evidence_location": "plan.md:1", "required_resolution": "fix it",
+                "resolution_claim": None, "resolution_evidence": None,
+            }],
+            "resolved_finding_ids": ["PLAN-000"],
+        }
+
+    def test_structured_prior_accepts_an_open_finding_superset(self):
+        prior = self.prior()
+        prior["open_findings"].append({
+            "id": "PLAN-002", "severity": "Low", "description": "advisory",
+            "evidence_location": "plan.md:2", "required_resolution": "consider it",
+            "resolution_claim": "noted", "resolution_evidence": "plan.md:3",
+        })
+        review = valid_review(verdict="REVISE")
+        review["round"] = 2
+        self.assertEqual(validate_review(review, prior=prior), [])
+
+    def test_structured_prior_rejects_malformed_and_inconsistent_fields(self):
+        cases = []
+        for field in ("id", "severity", "description", "evidence_location", "required_resolution", "resolution_claim", "resolution_evidence"):
+            prior = self.prior()
+            del prior["open_findings"][0][field]
+            cases.append((f"missing {field}", prior, f"missing required field: {field}"))
+        prior = self.prior(); prior["open_findings"][0]["extra"] = True; cases.append(("unknown", prior, "has unknown field: 'extra'"))
+        prior = self.prior(); prior["open_findings"].append(dict(prior["open_findings"][0])); cases.append(("duplicate", prior, "duplicate prior open finding ID"))
+        prior = self.prior(); prior["open_finding_ids"] = ["PLAN-404"]; cases.append(("coverage", prior, "entry missing from open_findings"))
+        prior = self.prior(); prior["resolved_finding_ids"] = ["PLAN-001"]; cases.append(("overlap", prior, "overlaps open finding"))
+        prior = self.prior(); prior["resolved_finding_ids"] = ["PLAN-000", "PLAN-000"]; cases.append(("duplicate resolved", prior, "duplicate prior.resolved_finding_ids entry"))
+        prior = self.prior(); prior["resolved_finding_ids"] = [1]; cases.append(("nonstring resolved", prior, "prior.resolved_finding_ids[0] must be a string"))
+        prior = self.prior(); prior["open_finding"] = []; cases.append(("unknown prior", prior, "prior has unknown field: 'open_finding'"))
+        for label, prior, expected_error in cases:
+            with self.subTest(label=label):
+                review = valid_review(verdict="REVISE")
+                review["round"] = 2
+                self.assertTrue(
+                    any(expected_error in error for error in validate_review(review, prior=prior)),
+                    expected_error,
+                )
+
+    def test_structured_prior_rejects_invalid_open_finding_severity(self):
+        prior = self.prior()
+        prior["open_findings"][0]["severity"] = "Trivial"
+        review = valid_review(verdict="REVISE")
+        review["round"] = 2
+
+        self.assertTrue(any(
+            "severity must be one of" in error
+            for error in validate_review(review, prior=prior)
+        ))
+
+    def test_structured_prior_rejects_empty_and_whitespace_string_fields(self):
+        for field in (
+            "id", "severity", "description", "evidence_location", "required_resolution",
+        ):
+            for value in ("", "   "):
+                with self.subTest(field=field, value=repr(value)):
+                    prior = self.prior()
+                    prior["open_findings"][0][field] = value
+                    review = valid_review(verdict="REVISE")
+                    review["round"] = 2
+                    self.assertTrue(any(
+                        f"prior.open_findings[0].{field} must be a non-empty string" in error
+                        for error in validate_review(review, prior=prior)
+                    ))
+
+    def test_structured_prior_allows_null_and_rejects_integer_resolution_fields(self):
+        for field in ("resolution_claim", "resolution_evidence"):
+            with self.subTest(field=field, value="null"):
+                prior = self.prior()
+                prior["open_findings"][0][field] = None
+                review = valid_review(verdict="REVISE")
+                review["round"] = 2
+                self.assertEqual([], validate_review(review, prior=prior))
+            with self.subTest(field=field, value="integer"):
+                prior = self.prior()
+                prior["open_findings"][0][field] = 1
+                review = valid_review(verdict="REVISE")
+                review["round"] = 2
+                self.assertTrue(any(
+                    f"prior.open_findings[0].{field} must be a string or null" in error
+                    for error in validate_review(review, prior=prior)
+                ))
 
 
 class EvaluateGateTests(unittest.TestCase):
@@ -338,6 +445,46 @@ class EvaluateGateTests(unittest.TestCase):
         self.assertIn("critical_or_high_finding", decision["reasons"])
 
 
+class EvidenceVerificationTests(unittest.TestCase):
+    def test_verified_is_required_boolean_and_blocks_pass_when_false(self):
+        missing = valid_review()
+        del missing["evidence"][0]["verified"]
+        self.assertTrue(any(
+            "evidence[0] missing required field: verified" in error
+            for error in validate_review(missing)
+        ))
+        string_value = valid_review()
+        string_value["evidence"][0]["verified"] = "false"
+        self.assertTrue(any(
+            "evidence[0].verified must be a boolean" in error
+            for error in validate_review(string_value)
+        ))
+        integer_value = valid_review()
+        integer_value["evidence"][0]["verified"] = 0
+        self.assertTrue(any(
+            "evidence[0].verified must be a boolean" in error
+            for error in validate_review(integer_value)
+        ))
+        false_pass = valid_review()
+        false_pass["evidence"][0]["verified"] = False
+        self.assertTrue(any(
+            "PASS reviews must not contain unverified evidence" in error
+            for error in validate_review(false_pass)
+        ))
+        revise = valid_review(verdict="REVISE")
+        revise["evidence"][0]["verified"] = False
+        self.assertEqual(validate_review(revise), [])
+
+    def test_verified_evidence_still_requires_a_non_empty_claim(self):
+        review = valid_review()
+        review["evidence"][0]["claim"] = ""
+
+        self.assertTrue(any(
+            "evidence[0].claim must be a non-empty string" in error
+            for error in validate_review(review)
+        ))
+
+
 class SchemaDriftTests(unittest.TestCase):
     def test_schema_required_fields_and_enums_match_python_constants(self):
         import json
@@ -367,6 +514,7 @@ class SchemaDriftTests(unittest.TestCase):
         self.assertIs(schema["additionalProperties"], False)
         self.assertIs(finding_schema["additionalProperties"], False)
         self.assertIs(evidence_schema["additionalProperties"], False)
+        self.assertEqual("boolean", evidence_schema["properties"]["verified"]["type"])
         self.assertIs(schema["properties"]["blockers"]["uniqueItems"], True)
         self.assertIs(schema["properties"]["evidence"]["uniqueItems"], True)
         self.assertEqual(0, schema["properties"]["score"]["minimum"])


### PR DESCRIPTION
## 요약

`quality-goal` 스킬 리뷰 루프의 결함 3건을 함께 고친다. 세 결함은 모두 **"리뷰어가 무엇을 검증했는지 시스템이 알 수 없다"**는 하나의 공백에서 파생한다. 게이트 규칙과 상태 머신 계약이 바뀌므로 SemVer MAJOR — **v3.0.0 → v4.0.0**.

Closes #44
Closes #37
Closes #38

## 무엇을 고쳤나

### #44 — 라운드 2+ 리뷰 계약이 finding ID만 전달한다

`SKILL.md`가 라운드 2 이상에서 "prior open finding IDs"만 보내도록 규정해, 리뷰어가 이전 finding의 해소 여부를 판정할 수 없었다. 더 나쁜 것은 상태의 `open_finding_ids`가 **blocker만 보존**해(`quality_state.py:649`) Medium·Low finding은 전달 수단 자체가 없었다는 점이다.

- `validate_review.py`의 prior 입력에 `open_findings`(7필드)와 `resolved_finding_ids`를 선택 필드로 추가. `open_finding_ids`를 커버하기만 하면 **상위집합을 허용**해 비-blocker finding도 전달할 수 있다
- prior **최상위 unknown 키를 검증 오류**로 만든다 — 지금은 오타 하나가 구조화 prior 검증을 조용히 전부 무력화한다
- `SKILL.md`·`quality-reviewer.md` 계약을 그에 맞춰 확장

### #37 — 미검증 사유 REVISE가 리뷰 라운드를 소모한다

실체가 결함이 아니라 "X를 검증하지 못했다"뿐인 well-formed REVISE가 라운드를 소모해, **리뷰어 역량 실패가 코드·설계 실패로 귀속**됐다.

- `record-review-unverified` 서브커맨드와 `review_unverified_retry` 상태 키 신설. 트리거는 `REVISE` ∧ `blockers == []` ∧ `verified:false` evidence 존재
- **폐기 리뷰 2건 상한** — 무료 재수행은 정확히 1회. 두 번째는 `exhausted: true`로 기록되고 세 번째는 `TransitionError`로 거부된다
- **스스로 터미널 전이하지 않는다.** #43의 결함(전이 후 보고서 등록 불가)을 새 경로에 복제하지 않기 위해서다
- 재수행 digest를 상태에 바인딩해 재수행 중 아티팩트 개정을 결정적으로 차단

### #38 — no-PASS-when-unverified가 지시문 준수에만 의존한다

`evaluate_gate`가 `evidence` 배열을 전혀 읽지 않고, 스키마에 미검증을 표시할 구조화된 필드가 없었다.

- `review.schema.json`의 evidence 항목에 `verified`(boolean) **필수** 추가
- `EVIDENCE_STRING_FIELDS`를 분리해 문자열 검사가 boolean에 걸리지 않게 함
- PASS이면서 미검증 evidence가 있으면 **검증 오류**. 게이트가 아니라 검증 단계에 두어 리뷰어의 계약 위반이 라운드를 소모하지 않게 했다

## 검증

| 항목 | 결과 |
|---|---|
| 결정적 테스트 | **201 → 229개 통과** (exit 0) |
| 변이 검증 | 신규 규칙 **13건 전수**, 13/13 대응 테스트가 검출 |
| 불변 확인 | `references/` 5개, `ROUND_LIMITS`, `verification-pass.json`, `record_review`의 자동 전이 블록 9줄 모두 **바이트 동일** |
| 범위 | `git diff --name-only ...` allow-list 위반 0건 |
| 타입체크·린트·빌드 | `not configured` (저장소에 해당 인프라 부재) |

## 범위 밖

- **#43**(`record-review`의 자동 터미널 전이)은 고치지 않았다. 같은 파일을 만지지만 해당 블록 9줄은 base와 바이트 동일함을 확인했다
- `ROUND_LIMITS`와 `references/` 루브릭은 불변. plan 한도 상향은 #60의 몫이다
- **배포하지 않았다.** 배포본은 `v3.0.0`으로 남아 있다. 다른 세션이 실행 중일 수 있어 배포 시점은 사용자가 결정한다

## 산출물

`docs/development/2026-09-03-quality-goal-review-loop/` — Spec, Plan, Report. 보고서에는 리뷰 5라운드 이력, 블로커 2건의 해소와 검증 증거, 실행한 명령 전수와 종료 코드, 변이 검증 결과, 잔여 advisory 5건, 승인 후 기록된 Plan 이탈 1건, 그리고 **이번 실행에서 실제로 발현한 #37·#44·#38의 실측**이 담겨 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)