### PR TITLE
fix(collector): 분할 전 검색 관측과 재개 감사 기록을 보존한다

### DIFF
--- a/dot_codex/skills/collecting-recent-closed-prs/references/collection-contract.md
+++ b/dot_codex/skills/collecting-recent-closed-prs/references/collection-contract.md
@@ -95,6 +95,21 @@ evidence and explain that handoff is incomplete. Never fabricate state history
 to satisfy validation. Candidate validation and GitHub writes require their
 own workflow and authorization.
 
+Each repository's `partitions` retains final leaf outcomes. The additive
+`split_observations` list separately retains executed unsafe parent searches:
+exact query and interval, returned/total counts, incomplete flag, observation
+time, split reasons, and the two proposed child intervals. Child intervals do
+not assert that either child request ran. Parent observations are checkpointed
+before any child request and append on an actual repeated search during resume;
+they neither supply hits nor make resolved leaf coverage partial.
+
+`split_observation_history: complete-since-run-start` describes newly recorded
+runs. Retrying an older repository checkpoint without this field records
+`legacy-unavailable`; it does not backfill missing parent facts. Reused complete
+legacy checkpoints remain unchanged, including their absent audit fields.
+Absence is not proof that no splitting occurred. Existing legacy gaps remain
+unknown even after newer observations are appended.
+
 Core evidence that cannot support a valid observation is retained under the
 repository manifest's `partial_records`, outside the analyzer corpus. Failed
 or reclassified candidates are not counted as exclusions caused by the cap.

--- a/dot_codex/skills/collecting-recent-closed-prs/references/github-rest-contract.md
+++ b/dot_codex/skills/collecting-recent-closed-prs/references/github-rest-contract.md
@@ -29,6 +29,10 @@ Split at a whole-second midpoint when total_count is at least 1000 or
 incomplete_results is true. A still-unsafe one-second leaf is partial. Only
 safe, fully paginated leaves supply selectable hits. Count drift, contradictory
 pages, failures, and exhausted budgets remain explicit partition evidence.
+Before descending, checkpoint the parent's exact query, interval, response
+counts/incomplete flag, capture time, split causes, and proposed child intervals
+in the repository's append-only `split_observations`. This audit is separate
+from final leaf outcomes and does not claim proposed children were requested.
 Deduplicate by PR node ID, order by closed_at/number descending, and apply the
 cap per repository. Keep ordered overflow for outcome-race backfill.
 

--- a/dot_codex/skills/collecting-recent-closed-prs/scripts/collect_recent_closed_prs.py
+++ b/dot_codex/skills/collecting-recent-closed-prs/scripts/collect_recent_closed_prs.py
@@ -460,6 +460,7 @@ def collect_repository_hits(
     *,
     safe_leaves: Optional[list[dict[str, object]]] = None,
     on_safe_leaf: Optional[Callable[[dict[str, object]], None]] = None,
+    on_split_observation: Optional[Callable[[dict[str, object]], None]] = None,
 ) -> RepositorySearchResult:
     """Collect one repository's ordered search candidates without hydration.
 
@@ -571,6 +572,20 @@ def collect_repository_hits(
                 )
                 return
             midpoint = start + timedelta(seconds=int((end - start).total_seconds()) // 2)
+            if on_split_observation is not None:
+                on_split_observation({
+                    "repository": repository,
+                    "interval": [_utc_string(start), _utc_string(end)],
+                    "query": query,
+                    "total_count": total_count,
+                    "returned_count": len(first_items),
+                    "incomplete_results": incomplete_results,
+                    "observed_at": _run_timestamp(None),
+                    "split_reasons": (["search-result-limit"] if total_count >= 1000 else [])
+                                     + (["incomplete-results"] if incomplete_results else []),
+                    "children": [[_utc_string(start), _utc_string(midpoint)],
+                                 [_utc_string(midpoint), _utc_string(end)]],
+                })
             collect_partition(start, midpoint)
             collect_partition(midpoint, end)
             return
@@ -2419,6 +2434,8 @@ def collect(
         checkpoint_repo = {
             "repository": repository, "collection_status": "partial",
             "safe_leaves": deepcopy(previous.get("safe_leaves", [])) if previous else [],
+            "split_observations": deepcopy(previous.get("split_observations", [])) if previous else [],
+            "split_observation_history": previous.get("split_observation_history", "legacy-unavailable") if previous else "complete-since-run-start",
             "completed_records": [], "selected_count": 0, "warnings": [],
         }
         reusable_records = {
@@ -2432,9 +2449,16 @@ def collect(
             checkpoint_repo["safe_leaves"].append(deepcopy(leaf))
             save_checkpoint()
 
+        def checkpoint_split(observation: dict[str, object]) -> None:
+            # Parents are observations, not selectable/completed leaves. Persist
+            # before requesting a child so an interrupt cannot erase the cause.
+            checkpoint_repo["split_observations"].append(deepcopy(observation))
+            save_checkpoint()
+
         try:
             search = collect_repository_hits(client, repository, interval, outcome, max_per_repository,
-                                             safe_leaves=checkpoint_repo["safe_leaves"], on_safe_leaf=checkpoint_leaf)
+                                             safe_leaves=checkpoint_repo["safe_leaves"], on_safe_leaf=checkpoint_leaf,
+                                             on_split_observation=checkpoint_split)
         except KeyboardInterrupt:
             search = _empty_repository_search_result(repository, "partial", "partial", "collection interrupted during search")
         except (ApiFailure, BudgetExhausted, ValueError, TypeError) as error:

--- a/dot_codex/skills/collecting-recent-closed-prs/tests/test_collect_recent_closed_prs.py
+++ b/dot_codex/skills/collecting-recent-closed-prs/tests/test_collect_recent_closed_prs.py
@@ -2153,6 +2153,82 @@ class Task7OrchestrationTests(unittest.TestCase):
         self.assertEqual(repository["partial_records"][0]["state_history"], [])
         self.assertEqual(run.corpus["records"], [])
 
+    def test_saved_manifest_retains_split_parent_observations(self):
+        collector = self.collector
+        class Client:
+            api_version = "2026-03-10"
+            budget = collector.RequestBudget(100)
+            def get_json(self, endpoint, params=None):
+                if endpoint.startswith("/repos/"):
+                    return collector.ApiResponse(200, {}, {"node_id": "R_repo", "full_name": "owner/repo"})
+                root = "00:00:00Z..2026-09-01T23:59:59Z" in params["q"]
+                return collector.ApiResponse(200, {}, {"total_count": 1000 if root else 0, "incomplete_results": root, "items": []})
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = Path(directory) / "manifest.json"
+            run = collector.collect(Client(), ["owner/repo"], self.interval, manifest_output=manifest)
+            saved = json.loads(manifest.read_text())["records"][-1]
+        self.assertEqual(run.exit_code, 0, "a resolved split is not a collection gap")
+        repository = saved["repositories"][0]
+        observations = repository.get("split_observations", [])
+        self.assertEqual(len(observations), 1, "executed split parent must survive in saved manifest")
+        parent = observations[0]
+        self.assertEqual(parent["query"], collector.build_closed_query("owner/repo", self.interval, "all"))
+        self.assertEqual(parent["interval"], [self.interval.start_at, self.interval.end_at])
+        self.assertEqual(parent["total_count"], 1000)
+        self.assertIs(parent["incomplete_results"], True)
+        self.assertEqual(parent["split_reasons"], ["search-result-limit", "incomplete-results"])
+        self.assertEqual(parent["children"], [p["interval"] for p in repository["partitions"]])
+        self.assertEqual(parent["returned_count"], 0)
+        self.assertTrue(parent["observed_at"])
+        self.assertEqual(repository["split_observation_history"], "complete-since-run-start")
+        legacy = deepcopy(run.manifest)
+        legacy_repository = legacy["records"][-1]["repositories"][0]
+        del legacy_repository["split_observations"]
+        del legacy_repository["split_observation_history"]
+        reused = collector.collect(Client(), ["owner/repo"], self.interval, existing_corpus=run.corpus, existing_manifest=legacy, run_id=run.record["run_id"])
+        self.assertNotIn("split_observations", reused.record["repositories"][0], "complete legacy checkpoint must not gain invented parent observations")
+
+    def test_split_observation_checkpoint_survives_interrupt_before_first_leaf(self):
+        collector = self.collector
+        class Client:
+            api_version = "2026-03-10"
+            budget = collector.RequestBudget(100)
+            interrupted = False
+            def get_json(self, endpoint, params=None):
+                if endpoint.startswith("/repos/"):
+                    return collector.ApiResponse(200, {}, {"node_id": "R_repo", "full_name": "owner/repo"})
+                root = "00:00:00Z..2026-09-01T23:59:59Z" in params["q"]
+                if not root and not self.interrupted:
+                    self.interrupted = True
+                    raise KeyboardInterrupt()
+                return collector.ApiResponse(200, {}, {"total_count": 1000 if root else 0, "incomplete_results": False, "items": []})
+        with tempfile.TemporaryDirectory() as directory:
+            output, manifest = Path(directory) / "corpus.json", Path(directory) / "manifest.json"
+            client = Client()
+            collector.collect(client, ["owner/repo"], self.interval, output=output, manifest_output=manifest)
+            saved = json.loads(manifest.read_text())
+            before = saved["records"][-1]["repositories"][0].get("split_observations", [])
+            self.assertEqual(len(before), 1, "parent evidence must precede the first child request")
+            resumed = collector.collect(client, ["owner/repo"], self.interval, existing_corpus=json.loads(output.read_text()), existing_manifest=saved, run_id=saved["records"][-1]["run_id"], output=output, manifest_output=manifest)
+            after = json.loads(manifest.read_text())["records"][-1]["repositories"][0]["split_observations"]
+            self.assertEqual(resumed.exit_code, 0)
+            self.assertEqual(after[:len(before)], before)
+            self.assertEqual(len(after), 2, "a genuinely repeated parent request adds an observation")
+            self.assertEqual(saved["records"][-1]["repositories"][0]["split_observations"], before)
+            class FailedPreflightClient(Client):
+                def global_preflight(self):
+                    raise collector.ApiFailure("fixture authentication failure", status=401)
+            failed = collector.collect(FailedPreflightClient(), ["owner/repo"], self.interval, existing_corpus=resumed.corpus, existing_manifest=resumed.manifest, run_id=resumed.record["run_id"])
+            self.assertEqual(failed.exit_code, 4)
+            self.assertEqual(failed.record["repositories"][0]["split_observations"], after)
+            legacy = deepcopy(saved)
+            del legacy["records"][-1]["repositories"][0]["split_observations"]
+            del legacy["records"][-1]["repositories"][0]["split_observation_history"]
+            legacy_retry = collector.collect(client, ["owner/repo"], self.interval, existing_corpus=json.loads(output.read_text()), existing_manifest=legacy, run_id=legacy["records"][-1]["run_id"])
+            legacy_repository = legacy_retry.record["repositories"][0]
+            self.assertEqual(legacy_repository["split_observation_history"], "legacy-unavailable")
+            self.assertEqual(len(legacy_repository["split_observations"]), 1, "only the new request may supply a legacy retry observation")
+
     def test_safe_leaf_survives_interruption_and_is_not_requested_on_resume(self):
         collector = self.collector
         queries = []


### PR DESCRIPTION
## 요약

승인된 collector 설계의 모든 검색 구간 감사 요건을 보완합니다. 분할 전 부모 검색이 manifest에서 사라지는 결함을 수정합니다.

- 부모 query/interval/counts/incomplete/시각/분할 원인/예정 자식 구간을 append-only split_observations에 기록
- 자식 요청 전 체크포인트 저장, 재개 시 기존 관측 보존
- leaf 선택·완료 판정과 분리, legacy 누락 관측은 만들어내지 않음
- corpus 병합 로직과 six-file revision 계산은 변경하지 않음

## 검증

- 신규 회귀 테스트 2개 RED 확인 후 수정
- 전체 110개 테스트 통과, git diff --check 통과
- 독립 코드 리뷰: Critical/Important/Minor 지적 없음, merge 가능
- 수정본 B fixture 재실행: exit3/partial 유지, 기존에 누락된 부모 관측 3개 저장
- Codex quick_validate.py: 지정된 /opt/homebrew/bin/python3 환경에서 통과

이전 스킬 PR #77의 후속 수정입니다. 연구 근거는 lee-kyu-hwan/eslint-learning-lab#3에 보존되어 있습니다.
배포는 #80의 공유 collector 작업과 통합 범위를 확인한 뒤 수행합니다. 이 PR 자체는 upstream 기여 후보 생성이나 GitHub 쓰기 기능을 추가하지 않습니다.
